### PR TITLE
Allow nested acquisition directory and file structure (fixes #4)

### DIFF
--- a/alpenhorn/acquisition.py
+++ b/alpenhorn/acquisition.py
@@ -105,14 +105,17 @@ class AcqType(base_model):
             The node we are importing from. Needed so we can inspect the actual
             acquisition.
         """
+        # TODO: document return type
 
-        # Iterate over all known acquisition types to try and find one that matches
-        # the directory being processed
-        for acq_type in cls.select():
-
-            if acq_type.is_type(acqname, node):
-                return acq_type
-
+        # Iterate over all known acquisition types to try and find one that
+        # matches the directory being processed. If nothing is found, repeat
+        # the process with the parent directory of acqname, until we run out of
+        # directory segments
+        while acqname != '':
+            for acq_type in cls.select():
+                if acq_type.is_type(acqname, node):
+                    return acq_type, acqname
+            acqname = path.dirname(acqname)
         return None
 
     @property

--- a/alpenhorn/acquisition.py
+++ b/alpenhorn/acquisition.py
@@ -104,11 +104,23 @@ class AcqType(base_model):
         node : StorageNode
             The node we are importing from. Needed so we can inspect the actual
             acquisition.
+
+        Returns
+        -------
+        (AcqType, str) or None
+            A tuple of acquisition type and name or None if one could not be found
+
+        Notes
+        -----
+
+        The returned acquisition name is either equal to the parameter
+        `acqname` or the closest ancestor directory which had a matching
+        `AcqType`.
+
         """
-        # TODO: document return type
 
         # Iterate over all known acquisition types to try and find one that
-        # matches the directory being processed. If nothing is found, repeat
+        # can handle the acqname path. If nothing is found, repeat
         # the process with the parent directory of acqname, until we run out of
         # directory segments
         while acqname != '':

--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -281,32 +281,27 @@ class RegisterFile(FileSystemEventHandler):
         super(RegisterFile, self).__init__()
 
     def on_created(self, event):
-        # Figure out the parts; it should be ROOT/ACQ_NAME/FILE_NAME
-        subpath = event.src_path.replace(self.root + "/", "").split("/")
-        if len(subpath) == 2:
-            import_file(self.node, self.root, subpath[0], subpath[1])
+        subpath = event.src_path.replace(self.root + "/", "")
+        import_file(self.node, self.root, subpath)
         return
 
     def on_modified(self, event):
-        # Figure out the parts; it should be ROOT/ACQ_NAME/FILE_NAME
-        subpath = event.src_path.replace(self.root + "/", "").split("/")
-        if len(subpath) == 2:
-            import_file(self.node, self.root, subpath[0], subpath[1])
+        subpath = event.src_path.replace(self.root + "/", "")
+        import_file(self.node, self.root, subpath)
         return
 
     def on_moved(self, event):
-        # Figure out the parts; it should be ROOT/ACQ_NAME/FILE_NAME
-        subpath = event.dest_path.replace(self.root + "/", "").split("/")
-        if len(subpath) == 2:
-            import_file(self.node, self.root, subpath[0], subpath[1])
+        subpath = event.dest_path.replace(self.root + "/", "")
+        import_file(self.node, self.root, subpath)
         return
 
     def on_deleted(self, event):
         # For lockfiles: ensure that the file that was locked is added: it is
         # possible that the watchdog notices that a file has been closed before the
         # lockfile is deleted.
-        subpath = event.src_path.replace(self.root + "/", "").split("/")
-        if len(subpath) == 2:
-            if subpath[1][0] == "." and subpath[1][-5:] == ".lock":
-                subpath[1] = subpath[1][1:-5]
-                import_file(self.node, self.root, subpath[0], subpath[1])
+        subpath = event.src_path.replace(self.root + "/", "")
+        basename = os.path.basename(subpath)
+        dirname = os.path.dirname(subpath)
+        if basename[0] == "." and basename[-5:] == ".lock":
+            basename = basename[1:-5]
+            import_file(self.node, self.root, os.path.join(dirname, basename))

--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -29,7 +29,7 @@ def import_file(node, root, file_path):
             log.error("MySQL connexion dropped. Will attempt to reconnect in "
                       "five seconds.")
             time.sleep(5)
-            # TODO: reconnection
+            # TODO: handle reconnection
             db.database_proxy.connect()
 
 
@@ -57,7 +57,6 @@ def _import_file(node, root, file_path):
         return
 
     # Check if we can handle this acquisition, and skip if we can't
-    # TODO: detect on the full file_path or just dir_name?
     acq_type_name = ac.AcqType.detect(file_path, node)
     if acq_type_name is None:
         log.info("Skipping non-acquisition path %s." % file_path)
@@ -77,9 +76,6 @@ def _import_file(node, root, file_path):
         log.debug("Acquisition \"%s\" already in DB. Skipping." % acq_name)
     except pw.DoesNotExist:
         acq = add_acq(acq_type, acq_name, node)
-        if acq is None:
-            # TODO: raise error? is a check even necessary?
-            return
         log.info("Acquisition \"%s\" added to DB." % acq_name)
 
     # What kind of file do we have?
@@ -117,6 +113,7 @@ def _import_file(node, root, file_path):
                           "five seconds.")
                 time.sleep(5)
 
+                # TODO: re-implement
                 # di.connect_database(True)
         log.info("File \"%s/%s\" added to DB." % (acq_name, file_name))
 
@@ -186,12 +183,8 @@ def add_acq(acq_type, name, node, comment=""):
         raise AlreadyExists("Acquisition \"%s\" already exists in DB." %
                             name)
 
-    # TODO: should we still check?
-    # if acq_type is None:
-    #     log.debug("No handler available to process \"%s\"" % name)
-    #     return
-
     # At the moment we need an instrument, so just create one.
+    # TODO: this should probably go away
     try:
         inst_rec = ac.ArchiveInst.get(name='inst')
     except pw.DoesNotExist:

--- a/tests/fixtures/files.yml
+++ b/tests/fixtures/files.yml
@@ -19,3 +19,45 @@ x:
   jim:
     contents: ''
     md5: d41d8cd98f00b204e9800998ecf8427e
+
+alp_root:
+  '2017':
+    '03':
+      '21':
+        acq_xy1_45678901T000000Z_inst_zab:
+          summary.txt:
+            contents: ''
+            md5: d41d8cd98f00b204e9800998ecf8427e
+          acq_data:
+            x_123_1_data:
+              raw:
+                acq_123_1.zxc:
+                  contents: "I'm a ZXC FRB."
+                  md5: cc85416c60621811dc93e591f4e787be
+              proc:
+                acq_123_1_proc.zxc:
+                  contents: "Still processing, come back later!"
+                  md5: 66f708a80f5eeb47076aa7e0035ae064
+                .acq_123_proc.zxc.lock:
+                  contents: ''
+                  md5: d41d8cd98f00b204e9800998ecf8427e
+            x_123_2_data:
+              raw:
+                acq_123_2.zxc:
+                  contents: "I'm a ZXC FRB."
+                  md5: cc85416c60621811dc93e591f4e787be
+              proc:
+                acq_123_2_proc.zxc:
+                  contents: "Still processing, come back later!"
+                  md5: 66f708a80f5eeb47076aa7e0035ae064
+                .acq_123_2_proc.zxc.lock:
+                  contents: ''
+                  md5: d41d8cd98f00b204e9800998ecf8427e
+          housekeeping_data:
+            hk_123.zxc:
+              contents: "Still processing, come back later!"
+              md5: 66f708a80f5eeb47076aa7e0035ae064
+            .hk_123.zxc.lock:
+              contents: ''
+              md5: d41d8cd98f00b204e9800998ecf8427e
+


### PR DESCRIPTION
* Importing a file asks each of the registered acquisition types if the dirname belongs to it. If none can handle it, the rightmost segment of the directory is removed and the process started again.
* First match wins, and the rest of the path to the file becomes the file name.
* The file name is tried on each of the acquisition's file types, and in case of no matches the file is skipped -- we don't try to repeat the loop on the subset of the file name's path segments as we do with acquisitions.
* The `auto_import.import_file` now has one fewer argument, since has to decide where the file's path gets broken into the acquisition vs the file name.

**Please note:** a number of TODOs are my questions over some implementation details. Let me know what you think.