### PR TITLE
Configuration loading support

### DIFF
--- a/alpenhorn/config.py
+++ b/alpenhorn/config.py
@@ -1,5 +1,15 @@
 """For configuring alpenhorn from the config file.
 
+Configuration file search order:
+
+- `/etc/alpenhorn/alpenhorn.conf`
+- `/etc/xdg/alpenhorn/alpenhorn.conf`
+- `~/.config/alpenhorn/alpenhorn.conf`
+- `ALPENHORN_CONFIG_FILE` environment variable
+
+This is in order of increasing precendence, with options in later files
+overriding those in earlier entries.
+
 Example config:
 
 .. codeblock:: yaml
@@ -28,8 +38,53 @@ Example config:
 """
 
 
+configdict = None
+
+_default_config = {}
+
+
 def load_config():
-    raise NotImplementedError()
+    """Find and load the configuration from a file.
+    """
+
+    global configdict
+
+    import os
+    import yaml
+
+    # Initialise and merge in any default configuration
+    configdict = {}
+    configdict.update(_default_config)
+
+    # Construct the configuration file path
+    config_files = [
+        '/etc/alpenhorn/alpenhorn.conf',
+        '/etc/xdg/alpenhorn/alpenhorn.conf',
+        '~/.config/alpenhorn/alpenhorn.conf',
+    ]
+
+    if 'ALPENHORN_CONFIG_FILE' in os.environ:
+        config_files.append(os.environ['ALPENHORN_CONFIG_FILE'])
+
+    any_exist = False
+
+    for cfile in config_files:
+
+        # Expand the configuration file path
+        cfile = os.path.abspath(os.path.expanduser(os.path.expandvars(cfile)))
+
+        if not os.path.exists(cfile):
+            continue
+
+        any_exist = True
+
+        with open(cfile, 'r') as fh:
+            conf = yaml.safe_load(fh)
+
+        configdict.update(conf)
+
+    if not any_exist:
+        raise RuntimeError("No configuration files available.")
 
 
 class ConfigClass(object):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest >= 2.10
+pyfakefs >= 3.1
 PyYAML
 mock

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+
+from alpenhorn import config
+
+
+def test_no_config():
+    # Check that alpenhorn fails if it has no appropriate configuration
+
+    with pytest.raises(RuntimeError) as excinfo:
+        config.load_config()
+
+    assert 'No configuration' in str(excinfo.value)
+
+
+def test_config_env(fs, monkeypatch):
+    # Test that we can load config from an environment variable
+    fs.CreateFile('/test/from/env/test.yaml', contents='hello: test\n')
+
+    monkeypatch.setenv('ALPENHORN_CONFIG_FILE', '/test/from/env/test.yaml')
+    config.load_config()
+    assert config.configdict == dict(config._default_config.items() + [('hello', 'test')])
+
+
+def test_precendence(fs, monkeypatch):
+    # Test the precedence of configuration imported from files is correct
+
+    fs.CreateFile('/etc/alpenhorn/alpenhorn.conf', contents='hello: test\n')
+    config.load_config()
+    assert config.configdict == dict(config._default_config.items() + [('hello', 'test')])
+
+    fs.CreateFile('/etc/xdg/alpenhorn/alpenhorn.conf', contents='hello: test2\n')
+    config.load_config()
+    assert config.configdict == dict(config._default_config.items() + [('hello', 'test2')])
+
+    fs.CreateFile(os.path.expanduser('~/.config/alpenhorn/alpenhorn.conf'), contents='hello: test3\nmeh: embiggens')
+    config.load_config()
+    assert config.configdict == dict(config._default_config.items() + [('hello', 'test3'), ('meh', 'embiggens')])
+
+    fs.CreateFile('/test/from/env/test.yaml', contents='hello: test4\n')
+    monkeypatch.setenv('ALPENHORN_CONFIG_FILE', '/test/from/env/test.yaml')
+    config.load_config()
+    assert config.configdict == dict(config._default_config.items() + [('hello', 'test4'), ('meh', 'embiggens')])


### PR DESCRIPTION
I've added support for loading configuration files. The paths it checks are basically the ones recommended in the XDG standards, but that means they are a little linux specific (especially the /etc/xdg/ one). But I think that's alright.