### PR TITLE
Alpenhorn service and extension support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 
 python:
-#    - "2.7"
+    - "2.7"
     - "3.5"
-    #- "3.6"
+    - "3.6"
 
 install:
     - pip install .

--- a/alpenhorn/__init__.py
+++ b/alpenhorn/__init__.py
@@ -2,4 +2,4 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 # Specify version in Semantic style (with PEP 440 pre-release specification)
-__version__ = '2.0.0.a1'
+__version__ = '2.0.0a1'

--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -21,6 +21,7 @@ log = logger.get_log()
 
 log.setLevel(logger.logging.DEBUG)
 
+
 def import_file(node, root, file_path):
     done = False
     while not done:
@@ -206,6 +207,7 @@ def add_acq(acq_type, name, node, comment=""):
         acq_type.acq_info.new(acq, node)
 
     return acq
+
 
 # Helper routines for adding files
 # ================================

--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -3,23 +3,23 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-import sys
 import os
 import datetime
 
 import click
 import peewee as pw
 
-import alpenhorn.db as db
 import alpenhorn.archive as ar
 import alpenhorn.storage as st
 import alpenhorn.acquisition as ac
+import alpenhorn.auto_import as ai
 
 # Setup the logging
 from . import logger
 log = logger.get_log()
 
 log.setLevel(logger.logging.DEBUG)
+
 
 @click.group()
 def cli():
@@ -200,12 +200,13 @@ def sync(node_name, group_name, acq, force, nice, target, transport, show_acq, s
         if len(files_out) > 0:
 
             # Construct a list of all the rows to insert
-            insert = [{ 'file': fid, 'node_from': from_node, 'nice': 0,
-                        'group_to': to_group, 'completed': False,
-                        'n_requests': 1, 'timestamp': dtnow} for fid in files_out]
+            insert = [{'file': fid, 'node_from': from_node, 'nice': 0,
+                       'group_to': to_group, 'completed': False,
+                       'n_requests': 1, 'timestamp': dtnow} for fid in files_out]
 
             # Do a bulk insert of these new rows
             ar.ArchiveFileCopyRequest.insert_many(insert).execute()
+
 
 @cli.command()
 @click.option('--all', help='Show the status of all nodes, not just mounted ones.', is_flag=True)
@@ -216,14 +217,15 @@ def status(all):
     import tabulate
 
     # Data to fetch from the database (node name, total files, total size)
-    query_info = (st.StorageNode.name, pw.fn.Count(ar.ArchiveFileCopy.id).alias('count'),
+    query_info = (
+        st.StorageNode.name, pw.fn.Count(ar.ArchiveFileCopy.id).alias('count'),
         pw.fn.Sum(ac.ArchiveFile.size_b).alias('total_size'), st.StorageNode.host, st.StorageNode.root
     )
 
     # Per node totals
     nodes = st.StorageNode.select(*query_info)\
-    .join(ar.ArchiveFileCopy).where(ar.ArchiveFileCopy.has_file=='Y')\
-    .join(ac.ArchiveFile).group_by(st.StorageNode).order_by(st.StorageNode.name)
+        .join(ar.ArchiveFileCopy).where(ar.ArchiveFileCopy.has_file == 'Y')\
+        .join(ac.ArchiveFile).group_by(st.StorageNode).order_by(st.StorageNode.name)
 
     log.info("Nodes: %s (all=%s)" % (nodes.count(), all))
     if not all:
@@ -249,7 +251,7 @@ def status(all):
 @click.option('--md5', help='perform full check against md5sum', is_flag=True)
 @click.option('--fixdb', help='fix up the database to be consistent with reality', is_flag=True)
 @click.option('--acq', metavar='ACQ', multiple=True,
-    help='Limit verification to specified acquisitions. Use repeated --acq flags to specify multiple acquisitions.')
+              help='Limit verification to specified acquisitions. Use repeated --acq flags to specify multiple acquisitions.')
 def verify(node_name, md5, fixdb, acq):
     """Verify the archive on NODE against the database.
     """
@@ -262,13 +264,13 @@ def verify(node_name, md5, fixdb, acq):
         click.echo("Specified node does not exist.")
         return
 
-    ## Use a complicated query with a tuples construct to fetch everything we
-    ## need in a single query. This massively speeds up the whole process versus
-    ## fetching all the FileCopy's then querying for Files and Acqs.
+    # Use a complicated query with a tuples construct to fetch everything we
+    # need in a single query. This massively speeds up the whole process versus
+    # fetching all the FileCopy's then querying for Files and Acqs.
     lfiles = ac.ArchiveFile\
                .select(ac.ArchiveFile.name, ac.ArchiveAcq.name,
-                          ac.ArchiveFile.size_b, ac.ArchiveFile.md5sum,
-                          ar.ArchiveFileCopy.id)\
+                       ac.ArchiveFile.size_b, ac.ArchiveFile.md5sum,
+                       ar.ArchiveFileCopy.id)\
                .join(ac.ArchiveAcq)\
                .switch(ac.ArchiveFile)\
                .join(ar.ArchiveFileCopy)\
@@ -302,7 +304,7 @@ def verify(node_name, md5, fixdb, acq):
                 continue
 
             if md5:
-                file_md5 = di.md5sum_file(filepath)
+                file_md5 = ai.md5sum_file(filepath)
                 corrupt = (file_md5 != md5sum)
             else:
                 corrupt = (os.path.getsize(filepath) != filesize)
@@ -311,7 +313,6 @@ def verify(node_name, md5, fixdb, acq):
                 corrupt_files.append(filepath)
                 corrupt_ids.append(fc_id)
                 continue
-
 
     if len(missing_files) > 0:
         click.echo()
@@ -432,7 +433,6 @@ def clean(node_name, days, force, now, target, acq):
         # Only match files that are also available at the target
         files = files.where(ar.ArchiveFileCopy.file << files_at_target)
 
-
     # If --days has been set we need to restrict to files older than the given
     # time. This only works for a few particular file types
     if days is not None and days > 0:
@@ -518,9 +518,8 @@ def mounted(host):
     if host is None:
         host = socket.gethostname().split(".")[0]
     zero = True
-    for node in st.StorageNode \
-                  .select() \
-                  .where(st.StorageNode.host == host, st.StorageNode.mounted == True):
+    for node in (st.StorageNode.select()
+                 .where(st.StorageNode.host == host, st.StorageNode.mounted)):
         n_file = ar.ArchiveFileCopy \
                    .select() \
                    .where(ar.ArchiveFileCopy.node == node) \
@@ -588,7 +587,7 @@ def format_transport(serial_num):
     e2label = get_e2label(dev_part)
     name = "CH-%s" % serial_num
     if e2label and e2label != name:
-        print("Disc label %s does not conform to labelling standard, " \
+        print("Disc label %s does not conform to labelling standard, "
               "which is CH-<serialnum>.")
         exit
     elif not e2label:
@@ -618,14 +617,14 @@ def format_transport(serial_num):
             if l[:len(dev_part)] == dev or l[:len(dev_part_abs)] == dev_part_abs:
                 mounted = True
             else:
-                print("%s is a mount point, but %s is already mounted there." \
+                print("%s is a mount point, but %s is already mounted there."
                       (root, l.split()[0]))
     fp.close()
 
     try:
         node = st.StorageNode.get(name=name)
     except pw.DoesNotExist:
-        print("This disc has not been registered yet as a storage node. " \
+        print("This disc has not been registered yet as a storage node. "
               "Registering now.")
         try:
             group = st.StorageGroup.get(name="transport")
@@ -681,7 +680,8 @@ def unmount_transport(ctx, node):
 @click.option("--path", help="Root path for this node", type=str, default=None)
 @click.option("--user", help="username to access this node.", type=str, default=None)
 @click.option("--address", help="address for remote access to this node.", type=str, default=None)
-@click.option("--hostname", help="hostname running the alpenhornd instance for this node (set to this hostname by default).", type=str, default=None)
+@click.option("--hostname", type=str, default=None,
+              help="hostname running the alpenhornd instance for this node (set to this hostname by default).")
 def mount(name, path, user, address, hostname):
     """Interactive routine for mounting a storage node located at ROOT."""
 
@@ -737,15 +737,15 @@ def unmount(root_or_name):
             root_or_name = root_or_name[:len(root_or_name) - 1]
 
         if not os.path.exists(root_or_name):
-            click.echo("That is neither a node name, nor a path on this host. " \
-                  "I quit.")
+            click.echo("That is neither a node name, nor a path on this host. "
+                       "I quit.")
             exit()
         try:
             node = st.StorageNode.get(root=root_or_name,
                                       host=socket.gethostname())
         except pw.DoesNotExist:
-            click.echo("That is neither a node name nor a root name that is " \
-                  "known. I quit.")
+            click.echo("That is neither a node name nor a root name that is "
+                       "known. I quit.")
             exit()
 
     if not node.mounted:
@@ -810,7 +810,7 @@ def import_files(node_name, verbose, acq, dry):
             else:
                 not_acqs.append(d)
     else:
-        acqs = [ acq ]
+        acqs = [acq]
 
     with click.progressbar(acqs, label='Scanning acquisitions') as acq_iter:
 

--- a/alpenhorn/config.py
+++ b/alpenhorn/config.py
@@ -14,21 +14,27 @@ Example config:
 
 .. codeblock:: yaml
 
-    db: peewee_url
+    # Configure the data base connection with a peewee db_url
+    database:
+        url:    peewee_url
 
+    # Logging configuration
     logging:
         file:   alpenhorn.log
         level:  debug
 
+    # Specify extensions as a list of fully qualified references to python packages or modules
     extensions:
         - alpenhorn.generic
         - alpenhorn_chime
 
+    # Set any configuration for acquisition type extensions
     acq_types:
         generic:
             patterns:
                 - ".*/.*"
 
+    # Set any configuration for file type extensions
     file_types:
         generic:
             patterns:
@@ -40,6 +46,9 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+# Setup the logging
+from . import logger
+log = logger.get_log()
 
 configdict = None
 
@@ -74,14 +83,16 @@ def load_config():
     for cfile in config_files:
 
         # Expand the configuration file path
-        cfile = os.path.abspath(os.path.expanduser(os.path.expandvars(cfile)))
+        absfile = os.path.abspath(os.path.expanduser(os.path.expandvars(cfile)))
 
-        if not os.path.exists(cfile):
+        if not os.path.exists(absfile):
             continue
 
         any_exist = True
 
-        with open(cfile, 'r') as fh:
+        log.info('Loading config file %s', cfile)
+
+        with open(absfile, 'r') as fh:
             conf = yaml.safe_load(fh)
 
         configdict.update(conf)
@@ -97,7 +108,7 @@ class ConfigClass(object):
     """
 
     @classmethod
-    def set_config(self, configdict):
+    def set_config(cls, configdict):
         """Configure the class from the supplied `configdict`.
         """
         pass

--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -118,11 +118,11 @@ def _connect(url=None, db=None):
 
 
 class EnumField(pw.Field):
-    """Implements an ENUM field for the peewee.
+    """Implements an ENUM field for peewee.
 
     Only MySQL and PostgreSQL support `ENUM` types natively in the database. For
-    Sqlite, the `ENUM` is implemented as an appropriately sized `VARCHAR` and
-    the validation is done at the Python level.
+    Sqlite (and others), the `ENUM` is implemented as an appropriately sized
+    `VARCHAR` and the validation is done at the Python level.
 
     .. warning::
         For the *native* ``ENUM`` to work you *must* register it with peewee like::

--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -120,9 +120,10 @@ EnumField = None
 
 
 class EnumFieldDB(pw.Field):
-    """Implements an enum field for the ORM.
+    """Implements an enum field for the peewee at the database level.
 
-    Why doesn't peewee support enums? That's dumb. We should make one."""
+    Only MySQL and PostgreSQL support `ENUM` types in the database.
+    """
     db_field = 'enum'
 
     def __init__(self, enum_list, *args, **kwargs):
@@ -144,7 +145,8 @@ class EnumFieldDB(pw.Field):
 
 
 class EnumFieldPython(pw.CharField):
-    """An EnumField implementation for Sqlite that enforces the type at the Python level.
+    """An EnumField implementation for Sqlite that enforces the type at the
+    Python level.
 
     Parameters
     ----------
@@ -152,18 +154,18 @@ class EnumFieldPython(pw.CharField):
         A list of the string values for the ENUM.
     """
 
-    def __init__(self, enum_values, *args, **kwargs):
+    def __init__(self, enum_list, *args, **kwargs):
 
-        self.enum_values = list(enum_values)
+        self.enum_list = list(enum_list)
 
         # Get the maximum length of any string in the set of enum values, and
         # use this to initialise the length of the underlying CharField
-        maxlen = max([len(val) for val in self.enum_values])
+        maxlen = max([len(val) for val in self.enum_list])
         super(EnumFieldPython, self).__init__(max_length=maxlen, *args, **kwargs)
 
         def db_value(self, value):
-            if value not in self.enum_values:
-                raise TypeError("Value %s not in ENUM(%s)" % str(enum_values))
+            if value not in self.enum_list:
+                raise TypeError("Value %s not in ENUM(%s)" % str(self.enum_list))
             return super(EnumFieldPython, self).db_field(value)
 
 

--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -52,17 +52,74 @@ class RobustProxy(pw.Proxy):
 database_proxy = RobustProxy()
 
 
-def connect(url=None):
-    # TODO: use connectdb?
-    db = db_url.connect(url or 'sqlite:///:memory:')
-    db.register_fields({'enum': 'enum'})
+def config_connect():
+    """Initiate the database connection from alpenhorns config.
+
+    If an `'url'` entry is present in the `'database'` section of the
+    configuration, use this, otherwise try and start the connection using an
+    extension.
+    """
+
+    from . import config, extensions
+
+    # Connect to the database
+    if 'database' in config.configdict and \
+       'url' in config.configdict['database']:
+        _connect(url=config.configdict['database']['url'])
+    else:
+        db_ext = extensions.database_extension()
+
+        if db_ext is not None:
+            _connect(db=db_ext)
+        else:
+            raise RuntimeError('No way to connect to the database')
+
+
+def _connect(url=None, db=None):
+    """Set up the database connection from an explicit peewee url, or
+    `peewee.Database`.
+
+    If neither argument is specified create and in-memory Sqlite database. If
+    both are given, initialisation by `url` is chosen. This routine also adds an
+    `EnumField` type to peewee. For databases that support it, this is a native
+    implemenation in the database, for those that don't (Sqlite), this is simply
+    a `VARCHAR` type with the validation done in Python.
+
+    Generally the database connection should be initiated using the
+    `config_connect` routine.
+
+    Parameters
+    ----------
+    url : str, optional
+        Database url using the scheme from `playhouse.db_url`.
+    db : `peewee.Database`, optional
+        Peewee database instance to connect alpenhorn to.
+    """
+
+    global EnumField
+
+    if url is None and db is None:
+        url = 'sqlite:///:memory:'
+
+    if url is not None:
+        db = db_url.connect(url)
+
+    if isinstance(db, pw.SqliteDatabase):
+        EnumField = EnumFieldPython
+    else:
+        db.register_fields({'enum': 'enum'})
+        EnumField = EnumFieldDB
+
     database_proxy.initialize(db)
 
 
 # Helper classes for the peewee ORM
 # =================================
 
-class EnumField(pw.Field):
+EnumField = None
+
+
+class EnumFieldDB(pw.Field):
     """Implements an enum field for the ORM.
 
     Why doesn't peewee support enums? That's dumb. We should make one."""
@@ -84,6 +141,33 @@ class EnumField(pw.Field):
 
     def coerce(self, val):
         return str(val or '')
+
+
+class EnumFieldPython(pw.CharField):
+    """An EnumField implementation for Sqlite that enforces the type at the Python level.
+
+    Parameters
+    ----------
+    enum_values : list
+        A list of the string values for the ENUM.
+    """
+
+    def __init__(self, enum_values, *args, **kwargs):
+
+        self.enum_values = list(enum_values)
+
+        # Get the maximum length of any string in the set of enum values, and
+        # use this to initialise the length of the underlying CharField
+        maxlen = max([len(val) for val in self.enum_values])
+        super(EnumFieldPython, self).__init__(max_length=maxlen, *args, **kwargs)
+
+        def db_value(self, value):
+            if value not in self.enum_values:
+                raise TypeError("Value %s not in ENUM(%s)" % str(enum_values))
+            return super(EnumFieldPython, self).db_field(value)
+
+
+EnumField = EnumFieldPython
 
 
 class base_model(pw.Model):

--- a/alpenhorn/extensions.py
+++ b/alpenhorn/extensions.py
@@ -1,0 +1,141 @@
+"""Extension loading and registation.
+
+Extensions are simply python packages or modules providing extra functionality
+to alpenhorn. They should be specified in the `'extension'` section of the
+alpenhorn configuration as fully qualified python name. They must have a
+`'register_extension'` function that returns a `dict` specifying the extra
+functionality they provide. There are currently three supported keys:
+
+`database`
+    A callable that returns a `peewee.Database` instance.
+`acq_types`
+    The acquisition type extensions, given as a list of `AcqInfoBase` subclasses.
+`file_types`
+    The file type extensions, given as a list of `FileInfoBase` subclasses.
+
+If multiple extensions provide acquisition or file types with the same name (as
+seen by the `._acq_type` or `._file_type` properties), only the last one is
+used. Similarly, only the last `database` specification matters.
+"""
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import importlib
+
+from . import config
+
+# Setup the logging
+from . import logger, acquisition
+log = logger.get_log()
+
+
+# Internal variable for holding the extension references
+_ext = None
+
+
+def load_extensions():
+    """Load any extension modules specified in the configuration.
+
+    Inspects the `'extensions'` section in the configuration for full resolved
+    Python module names, and then registers any extension types and database
+    connections.
+    """
+
+    global _ext
+
+    _ext = []
+
+    if 'extensions' not in config.configdict:
+        log.info('No extensions to load.')
+        return
+
+    extension_list = list(config.configdict['extensions'])
+
+    for name in extension_list:
+
+        log.info("Loading extension %s", name)
+
+        try:
+            ext_module = importlib.import_module(name)
+        except ImportError:
+            raise ImportError('Extension module %s not found', name)
+
+        try:
+            extension_dict = ext_module.register_extension()
+        except AttributeError:
+            raise RuntimeError('Module %s is not a valid alpenhorn extension (no register_extension hook).', name)
+
+        extension_dict['module'] = ext_module
+
+        _ext.append(extension_dict)
+
+
+def connect_database_extension():
+    """Find and connect a database found in an extension.
+
+    Returns
+    -------
+    db : `peewee.Database`
+        A connected `peewee.Database` instance or `None` if there was no
+        database extension specified.
+    """
+
+    dbconnect = None
+
+    for ext_dict in _ext:
+
+        if 'database' in ext_dict:
+            dbconnect = ext_dict['database']
+
+    if dbconnect is not None:
+        return dbconnect()
+    else:
+        return None
+
+
+def register_type_extensions():
+    """Register any types found in extension modules.
+
+    Later entries will override earlier ones. This *must* be called after the
+    database has been connected.
+    """
+
+    for ext_dict in _ext:
+
+        if 'acq_types' in ext_dict:
+            _register_acq_extensions(ext_dict['acq_types'])
+
+        if 'file_types' in ext_dict:
+            _register_file_extensions(ext_dict['file_types'])
+
+
+def _register_acq_extensions(acq_types):
+
+    for acq_type in acq_types:
+        name = acq_type._acq_type
+        log.info("Registering new acquisition type %s", name)
+        acquisition.AcqType.register_type(acq_type)
+
+        try:
+            conf = config.configdict['acq_types'][name]
+        except KeyError:
+            conf = {}
+
+        acq_type.set_config(conf)
+
+
+def _register_file_extensions(file_types):
+
+    for file_type in file_types:
+        name = file_type._file_type
+        log.info("Registering new file type %s", name)
+        acquisition.FileType.register_type(file_type)
+
+        try:
+            conf = config.configdict['file_types'][name]
+        except KeyError:
+            conf = {}
+
+        file_type.set_config(conf)

--- a/alpenhorn/generic.py
+++ b/alpenhorn/generic.py
@@ -107,6 +107,16 @@ class GenericFileInfo(ac.FileInfoBase):
         pass
 
 
+def register_extension():
+
+    ext_dict = {
+        'acq_types': [GenericAcqInfo],
+        'file_types': [GenericFileInfo]
+    }
+
+    return ext_dict
+
+
 def _check_match(name, patterns, glob):
     # Get the match function to use depending on whether globbing is enabled.
     if glob:

--- a/alpenhorn/storage.py
+++ b/alpenhorn/storage.py
@@ -75,5 +75,3 @@ class StorageNode(base_model):
     avail_gb_last_checked = pw.DateTimeField(null=True)
     min_delete_age_days = pw.FloatField(default=30)
     notes = pw.TextField(null=True)
-
-

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
     scripts=[],
     entry_points={
         'console_scripts': [
-
+            'alpenhorn = alpenhorn.client:cli',
+            'alpenhornd = alpenhorn.service:cli'
         ]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,21 @@ import alpenhorn
 
 here = path.abspath(path.dirname(__file__))
 
+
+def strip_envmark(requires):
+    # Strip out environment markers options
+    return [req.split(';')[0].rstrip() for req in requires]
+
+
 # Get the long description from the README file
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 with open(path.join(here, 'requirements.txt')) as f:
-    requirements = f.readlines()
+    requirements = strip_envmark(f.readlines())
 
 with open(path.join(here, 'test-requirements.txt')) as f:
-    test_requirements = f.readlines()
+    test_requirements = strip_envmark(f.readlines())
 
 setup_requirements = [
     'pytest-runner',

--- a/tests/test_acquisition_model.py
+++ b/tests/test_acquisition_model.py
@@ -25,7 +25,7 @@ tests_path = path.abspath(path.dirname(__file__))
 def fixtures(clear_db=True):
     """Initializes an in-memory Sqlite database with data in tests/fixtures"""
     if (clear_db):
-        db.connect()
+        db._connect()
     db.database_proxy.create_tables([ArchiveAcq, ArchiveInst, AcqType, FileType, ArchiveFile], safe=not clear_db)
 
     # Check we're starting from a clean slate

--- a/tests/test_archive_model.py
+++ b/tests/test_archive_model.py
@@ -69,8 +69,8 @@ def fixtures():
 
     # fixup foreign keys for the file copies
     for copy in fixtures['file_copies']:
-        copy['file']= fa['files'][copy['file']]
-        copy['node']= fs['nodes'][copy['node']]
+        copy['file'] = fa['files'][copy['file']]
+        copy['node'] = fs['nodes'][copy['node']]
 
     # bulk load the file copies
     ArchiveFileCopy.insert_many(fixtures['file_copies']).execute()
@@ -78,9 +78,9 @@ def fixtures():
 
     # fixup foreign keys for the copy requests
     for req in fixtures['copy_requests']:
-        req['file']= fa['files'][req['file']]
-        req['node_from']= fs['nodes'][req['node_from']]
-        req['group_to']= fs['groups'][req['group_to']]
+        req['file'] = fa['files'][req['file']]
+        req['node_from'] = fs['nodes'][req['node_from']]
+        req['group_to'] = fs['groups'][req['group_to']]
 
     # bulk load the file copies
     ArchiveFileCopyRequest.insert_many(fixtures['copy_requests']).execute()

--- a/tests/test_archive_model.py
+++ b/tests/test_archive_model.py
@@ -24,26 +24,6 @@ import alpenhorn.acquisition as acquisition
 import test_storage_model as ts
 import test_acquisition_model as ta
 
-class SqliteEnumField(pw.CharField):
-    """Implements an enum field for the ORM.
-
-    Why doesn't peewee support enums? That's dumb. We should make one."""
-
-    def __init__(self, choices, *args, **kwargs):
-        super(SqliteEnumField, self).__init__(*args, **kwargs)
-        self.choices = choices
-
-    def coerce(self, val):
-        if val is None:
-            return str(self.default)
-        if val not in self.choices:
-            raise ValueError("Invalid enum value '%s'" % val)
-        return str(val)
-
-
-# Use Sqlite-compatible EnumField
-SqliteEnumField(['N', 'Y', 'M', 'X'], default='N').add_to_class(ArchiveFileCopy, 'has_file')
-SqliteEnumField(['Y', 'M', 'N'], default='Y').add_to_class(ArchiveFileCopy, 'wants_file')
 
 tests_path = path.abspath(path.dirname(__file__))
 

--- a/tests/test_archive_model.py
+++ b/tests/test_archive_model.py
@@ -52,7 +52,7 @@ tests_path = path.abspath(path.dirname(__file__))
 def fixtures():
     """Initializes an in-memory Sqlite database with data in tests/fixtures"""
 
-    db.connect()
+    db._connect()
 
     fs = next(ts.fixtures(False))
     fa = next(ta.fixtures(False))

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,91 @@
+import os
+
+import pytest
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+# TODO: use Pytest's directory used for tmpdir/basedir, not '/tmp'
+os.environ['ALPENHORN_LOG_FILE'] = '/tmp' + '/alpenhornd.log'
+
+
+from alpenhorn import extensions, acquisition, generic
+
+
+@pytest.fixture
+def fixtures():
+
+    from alpenhorn import db
+
+    db.connect()
+
+    db.database_proxy.create_tables([
+        acquisition.AcqType, acquisition.FileType, acquisition.ArchiveAcq,
+        acquisition.ArchiveFile, generic.GenericAcqInfo,
+        generic.GenericFileInfo
+    ])
+
+    yield
+
+    # cleanup
+    db.database_proxy.close()
+
+
+def test_invalid_extension():
+    # Test that invalid extension paths, or modules that are not extensions
+    # throw the approproate exceptions
+
+    with patch('alpenhorn.config.configdict', {'extensions': ['unknown_module']}):
+        with pytest.raises(ImportError):
+            extensions.load_extensions()
+
+    with patch('alpenhorn.config.configdict', {'extensions': ['alpenhorn.acquisition']}):
+        with pytest.raises(RuntimeError):
+            extensions.load_extensions()
+
+
+def test_generic_extension(fixtures):
+    # Test that extension registration works correctly for the generic extension
+
+    conf = {
+        'extensions': ['alpenhorn.generic'],
+        'acq_types': {
+            'generic': {
+                'patterns': '*.zxc',
+                'file_types': ['generic']
+            }
+        },
+        'file_types': {
+            'generic': {
+                'patterns': '*.zxc'
+            }
+        }
+    }
+
+    # Load the extensions. This should cause the acq/file info types to be registered
+    with patch('alpenhorn.config.configdict', conf):
+        extensions.load_extensions()
+
+        extensions.register_type_extensions()
+
+    # Check that we have registered every known type
+    acquisition.AcqType.check_registration()
+    acquisition.FileType.check_registration()
+
+    # Check that the correct entries have appeared
+    assert 'generic' in acquisition.AcqType._registered_acq_types
+    assert 'generic' in acquisition.FileType._registered_file_types
+    assert generic.GenericAcqInfo is acquisition.AcqType._registered_acq_types['generic']
+    assert generic.GenericFileInfo is acquisition.FileType._registered_file_types['generic']
+
+    # Do a few look ups mapping betweeb the AcqType entry and the AcqInfo tables
+    # back and forth
+    assert acquisition.AcqType.get(name='generic').acq_info is generic.GenericAcqInfo
+    assert generic.GenericAcqInfo.get_acq_type().acq_info is generic.GenericAcqInfo
+
+    # Check that the file_types registration works out
+    reg_file_types = generic.GenericAcqInfo.get_acq_type().file_types
+    assert reg_file_types.count() == 1
+    assert reg_file_types.get().file_info is generic.GenericFileInfo

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -19,7 +19,7 @@ def fixtures():
 
     from alpenhorn import db
 
-    db.connect()
+    db._connect()
 
     db.database_proxy.create_tables([
         acquisition.AcqType, acquisition.FileType, acquisition.ArchiveAcq,

--- a/tests/test_storage_model.py
+++ b/tests/test_storage_model.py
@@ -44,7 +44,7 @@ def fixtures(clear_db=True):
     """Initializes an in-memory Sqlite database with data in tests/fixtures"""
 
     if clear_db:
-        db.connect()
+        db._connect()
 
     db.database_proxy.create_tables([StorageGroup, StorageNode], safe=not clear_db)
 

--- a/tests/test_storage_model.py
+++ b/tests/test_storage_model.py
@@ -16,26 +16,6 @@ import alpenhorn.db as db
 from alpenhorn.storage import *
 
 
-class SqliteEnumField(pw.CharField):
-    """Implements an enum field for the ORM.
-
-    Why doesn't peewee support enums? That's dumb. We should make one."""
-
-    def __init__(self, choices, *args, **kwargs):
-        super(SqliteEnumField, self).__init__(*args, **kwargs)
-        self.choices = choices
-
-    def coerce(self, val):
-        if val is None:
-            return str(self.default)
-        if val not in self.choices:
-            raise ValueError("Invalid enum value '%s'" % val)
-        return str(val)
-
-
-# Use Sqlite-compatible EnumField
-SqliteEnumField(['A', 'T', 'F'], default='A').add_to_class(StorageNode, 'storage_type')
-
 tests_path = path.abspath(path.dirname(__file__))
 
 
@@ -81,7 +61,7 @@ def test_model(fixtures):
     groups = set(StorageGroup.select(StorageGroup.name).tuples())
     assert groups == { ( 'foo', ), ( 'bar', ), ('transport', ) }
     assert StorageGroup.get(StorageGroup.name == 'bar').notes == 'Some bar!'
-    
+
     nodes = list(StorageNode.select().dicts())
     assert nodes == [
         {


### PR DESCRIPTION
This is a moderately large set of changes that implement support for
loading extensions into alpenhorn from the given configuration, and
has the first steps to getting `alpenhornd` running.

In addition to the headline changes it has a number of smaller additions:
  - A new, working, implementation of ENUM for all database types.
  - Removed SqliteEnum hacks from tests as Sqlite should be supported
    natively now.
  - Rewrote database connection code to work with the config.
  - Added an `init` command to `alpenhorn` for creating the required tables.
  - Added Python versions back to Travis testing.
  - Added script entry points back into `setup.py`
  - Removed some exception classes mistakenly brought in from the layout db.
  - Added a custom database connection class that is a hybrid of Proxy and
    RetryOperationalError.