### PR TITLE
Functional tests using Docker

### DIFF
--- a/tests/docker/Dockerfile.alpenhorn
+++ b/tests/docker/Dockerfile.alpenhorn
@@ -1,7 +1,9 @@
-# Use an official Python runtime as a base image
+## Generate an image that automatically starts alpenhornd and sshd (for
+## transfers)
+
+# Use the base base image
 FROM jrs65/python-mysql
 
-## The maintainer name and email
 MAINTAINER Richard Shaw <richard@phas.ubc.ca>
 
 # Install any needed packages specified in requirements.txt
@@ -10,11 +12,20 @@ COPY test-requirements.txt /build_req/
 RUN pip install -r /build_req/requirements.txt
 RUN pip install -r /build_req/test-requirements.txt
 
+# Install alpenhorn
+ADD . /build
+RUN pip install /build
+
 # Copy the configuration file, and create the log directory
 COPY tests/docker/alpenhorn.conf /etc/alpenhorn/alpenhorn.conf
 RUN mkdir /var/log/alpenhorn
 
-ADD . /build
-RUN pip install /build
+# Set up ssh key based login for root
+RUN ssh-keygen -t rsa -N '' -f /root/.ssh/id_rsa
+RUN cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN echo 'Host *\n\
+    StrictHostKeyChecking no\n' > /root/.ssh/config
 
-CMD alpenhornd
+# Run alpenhorn and ssh
+CMD service ssh start && \
+    alpenhornd

--- a/tests/docker/Dockerfile.alpenhorn
+++ b/tests/docker/Dockerfile.alpenhorn
@@ -1,0 +1,20 @@
+# Use an official Python runtime as a base image
+FROM jrs65/python-mysql
+
+## The maintainer name and email
+MAINTAINER Richard Shaw <richard@phas.ubc.ca>
+
+# Install any needed packages specified in requirements.txt
+COPY requirements.txt /build_req/
+COPY test-requirements.txt /build_req/
+RUN pip install -r /build_req/requirements.txt
+RUN pip install -r /build_req/test-requirements.txt
+
+# Copy the configuration file, and create the log directory
+COPY tests/docker/alpenhorn.conf /etc/alpenhorn/alpenhorn.conf
+RUN mkdir /var/log/alpenhorn
+
+ADD . /build
+RUN pip install /build
+
+CMD alpenhornd

--- a/tests/docker/Dockerfile.alpenhorn
+++ b/tests/docker/Dockerfile.alpenhorn
@@ -16,9 +16,13 @@ RUN pip install -r /build_req/test-requirements.txt
 ADD . /build
 RUN pip install /build
 
-# Copy the configuration file, and create the log directory
+# Copy the configuration file and create the log directory
 COPY tests/docker/alpenhorn.conf /etc/alpenhorn/alpenhorn.conf
 RUN mkdir /var/log/alpenhorn
+
+# Install the custom acq and file types
+COPY tests/docker/custom_test_types.py /root/python/custom_test_types.py
+ENV PYTHONPATH /root/python/
 
 # Set up ssh key based login for root
 RUN ssh-keygen -t rsa -N '' -f /root/.ssh/id_rsa

--- a/tests/docker/Dockerfile.base
+++ b/tests/docker/Dockerfile.base
@@ -1,0 +1,19 @@
+# Use an official Python runtime as a base image
+FROM python:3.6.1
+
+## The maintainer name and email
+MAINTAINER Richard Shaw <richard@phas.ubc.ca>
+
+# Install any needed packages specified in requirements.txt
+RUN apt-get update
+RUN apt-get install -y ssh
+RUN apt-get install -y rsync
+RUN apt-get install -y netcat
+RUN apt-get install -y mysql-client
+RUN pip install mysqlclient
+
+# Make port 80 available to the world outside this container
+EXPOSE 22
+
+# Run app.py when the container launches
+CMD ["python"]

--- a/tests/docker/Dockerfile.base
+++ b/tests/docker/Dockerfile.base
@@ -12,7 +12,7 @@ RUN apt-get install -y netcat
 RUN apt-get install -y mysql-client
 RUN pip install mysqlclient
 
-# Make port 80 available to the world outside this container
+# Make port 22 available to the world outside this container
 EXPOSE 22
 
 # Run app.py when the container launches

--- a/tests/docker/alpenhorn.conf
+++ b/tests/docker/alpenhorn.conf
@@ -1,0 +1,18 @@
+database:
+    url: mysql://root@db/alpenhorn_db
+
+extensions:
+    - alpenhorn.generic
+
+# Set any configuration for acquisition type extensions
+acq_types:
+    generic:
+        patterns:
+            - "*"
+
+# Set any configuration for file type extensions
+file_types:
+    generic:
+        patterns:
+            - "*.h5"
+            - "*.log"

--- a/tests/docker/alpenhorn.conf
+++ b/tests/docker/alpenhorn.conf
@@ -2,17 +2,4 @@ database:
     url: mysql://root@db/alpenhorn_db
 
 extensions:
-    - alpenhorn.generic
-
-# Set any configuration for acquisition type extensions
-acq_types:
-    generic:
-        patterns:
-            - "*"
-
-# Set any configuration for file type extensions
-file_types:
-    generic:
-        patterns:
-            - "*.h5"
-            - "*.log"
+    - custom_test_types

--- a/tests/docker/custom_test_types.py
+++ b/tests/docker/custom_test_types.py
@@ -1,0 +1,48 @@
+"""Custom acquisition and file handlers for the docker integration tests."""
+
+from alpenhorn import generic as ge
+
+
+# Create handlers for the acquisition and file types
+class ZabInfo(ge.GenericAcqInfo):
+    _acq_type = 'zab'
+    _file_types = ['zxc', 'log']
+    patterns = ['**zab']
+
+    def set_config(configdict):
+        pass
+
+
+class QuuxInfo(ge.GenericAcqInfo):
+    _acq_type = 'quux'
+    _file_types = ['zxc', 'log']
+    patterns = ['*quux', 'x']
+
+    def set_config(configdict):
+        pass
+
+
+class ZxcInfo(ge.GenericFileInfo):
+    _file_type = 'zxc'
+    patterns = ['**.zxc', 'jim*', 'sheila']
+
+    def set_config(configdict):
+        pass
+
+
+class LogInfo(ge.GenericFileInfo):
+    _file_type = 'log'
+    patterns = ['*.log']
+
+    def set_config(configdict):
+        pass
+
+
+def register_extension():
+
+    ext_dict = {
+        'acq_types': [ZabInfo, QuuxInfo],
+        'file_types': [ZxcInfo, LogInfo]
+    }
+
+    return ext_dict

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -25,7 +25,7 @@ from alpenhorn import storage as st
 try:
     import docker
     client = docker.from_env()
-except ImportError:
+except ImportError, AttributeError:
     pass
 
 

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -1,0 +1,124 @@
+
+
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import pytest
+import docker
+
+client = docker.from_env()
+
+
+@pytest.fixture(scope='module')
+def images():
+    """Build the images for the tests."""
+
+    print('Building docker images...')
+
+    # Build base image
+    client.images.build(
+        path='../../', tag='jrs65/python-mysql', rm=True, forcerm=True,
+        dockerfile='tests/docker/Dockerfile.base'
+    )
+
+    # Build alpenhorn image
+    client.images.build(
+        path='../../', tag='alpenhorn', rm=True, forcerm=True,
+        dockerfile='tests/docker/Dockerfile.alpenhorn'
+    )
+
+
+@pytest.fixture(scope='module')
+def network():
+    """Set up the network."""
+    # Note to connect to this network you need to pass network_mode=networks to
+    # .run(). See https://github.com/docker/docker-py/issues/1433
+
+    print('Setting up the network...')
+
+    network = client.networks.create("alpenhorn-net", driver="bridge")
+
+    yield network.name
+
+    network.remove()
+
+
+@pytest.fixture(scope='module')
+def db(network, images):
+    """Set up the database and create the tables for alpenhorn."""
+
+    print ('Creating the database...')
+
+    # Create the database container
+    db = client.containers.run(
+        'mysql:latest', name='db', detach=True,
+        network_mode=network, ports={'3306/tcp': 63306},
+        environment={'MYSQL_ALLOW_EMPTY_PASSWORD': 'yes'}
+    )
+
+    # Wait until the MySQL instance is properly up
+    client.containers.run(
+        'alpenhorn', remove=True, detach=False, network_mode=network,
+        command="bash -c 'while ! mysqladmin ping -h db --silent; do sleep 3; done'"
+    )
+
+    # Create the database
+    client.containers.run(
+        'alpenhorn', remove=True, detach=False, network_mode=network,
+        command="mysql -h db -e 'CREATE DATABASE alpenhorn_db'"
+    )
+
+    print('Creating the tables...')
+
+    # Initialise alpenhorn
+    client.containers.run(
+        'alpenhorn', remove=True, detach=False, network_mode=network,
+        command="alpenhorn init"
+    )
+
+    yield db
+
+    print('Cleaning up db container...')
+    _stop_or_kill(db)
+    db.remove()
+
+
+@pytest.fixture(scope='module')
+def workers(db, network, images):
+    """Create a group of alpenhorn entries."""
+
+    node_names = ['node_a', 'node_b', 'node_c']
+
+    def create_worker(name):
+        print('Creating alpenhorn container %s' % name)
+        return client.containers.run('alpenhorn', name=name, detach=True,
+                                     network_mode=network)
+
+    nodes = {name: create_worker(name) for name in node_names}
+
+    yield nodes
+
+    for container in nodes.values():
+        print('Stopping and removing alpenhorn container %s' % container.name)
+        _stop_or_kill(container, timeout=1)
+        container.remove()
+
+
+def _stop_or_kill(container, timeout=10):
+    # Work around for:
+    # https://github.com/docker/docker-py/issues/1374
+    import requests.exceptions
+
+    try:
+        container.stop(timeout=timeout)
+    except requests.exceptions.ReadTimeout:
+        container.kill()
+
+
+
+def test_stuff(workers):
+
+    import time
+
+    time.sleep(10)

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -14,17 +14,21 @@ client = docker.from_env()
 def images():
     """Build the images for the tests."""
 
-    print('Building docker images...')
+    import os.path
+
+    context = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
+
+    print('Building docker images from location %s...' % context)
 
     # Build base image
     client.images.build(
-        path='../../', tag='jrs65/python-mysql', rm=True, forcerm=True,
+        path=context, tag='jrs65/python-mysql', rm=True, forcerm=True,
         dockerfile='tests/docker/Dockerfile.base'
     )
 
     # Build alpenhorn image
     client.images.build(
-        path='../../', tag='alpenhorn', rm=True, forcerm=True,
+        path=context, tag='alpenhorn', rm=True, forcerm=True,
         dockerfile='tests/docker/Dockerfile.alpenhorn'
     )
 
@@ -117,6 +121,7 @@ def workers(db, network, images, tmpdir_factory):
         # Create a temporary directory on the host to store the data, which will
         # get mounted into the container
         data_dir = tmpdir_factory.mktemp(hostname)
+        print('Node directory (on host): %s' % str(data_dir))
 
         container = client.containers.run(
             'alpenhorn', name=hostname, detach=True, network_mode=network,

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -25,7 +25,7 @@ from alpenhorn import storage as st
 try:
     import docker
     client = docker.from_env()
-except ImportError, AttributeError:
+except (ImportError, AttributeError):
     pass
 
 

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -21,10 +21,12 @@ from alpenhorn import archive as ar
 from alpenhorn import storage as st
 
 
-# Skip all these tests if docker-py is not installed
-docker = pytest.importorskip('docker')
-
-client = docker.from_env()
+# Try and import docker.
+try:
+    import docker
+    client = docker.from_env()
+except ImportError:
+    pass
 
 
 # ====== Fixtures for controlling Docker ======

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -9,6 +9,11 @@ import os
 from os.path import join, dirname, exists
 
 import pytest
+pytestmark = pytest.mark.skipif(
+    'RUN_DOCKER_TESTS' not in os.environ,
+    reason=('Docker tests must be enabled by setting the RUN_DOCKER_TEST environment variable')
+)
+
 import yaml
 
 from alpenhorn import acquisition as ac


### PR DESCRIPTION
This pull requests adds in the ability to test the behaviour of alpenhorn running across multiple systems. It uses docker to setup a test system of several instances of alpenhornd running against a separate MySQL system.

These tests are pretty lightweight for what they are, but compared to the unit tests they will take a lot more time.

To run the tests, simply install Docker (this was easy enough on my laptop using Docker for Mac), install the docker python SDK `pip install docker`, and set the environment variable `RUN_DOCKER_TESTS`.