### PR TITLE
Tidied up the logging code

### DIFF
--- a/alpenhorn/acquisition.py
+++ b/alpenhorn/acquisition.py
@@ -1,15 +1,16 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+
+import logging
 from os import path
 
 import peewee as pw
 from .db import base_model
 from .config import ConfigClass
 
-# Setup the logging
-from . import logger
-log = logger.get_log()
+
+log = logging.getLogger(__name__)
 
 
 class ArchiveInst(base_model):

--- a/alpenhorn/archive.py
+++ b/alpenhorn/archive.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
+
 import peewee as pw
+
 from .db import base_model, EnumField
 from alpenhorn.storage import *
 from alpenhorn.acquisition import *

--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -2,8 +2,10 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+
 import time
 import os
+import logging
 
 import peewee as pw
 
@@ -17,11 +19,8 @@ from . import acquisition as ac
 from . import util
 from . import config
 
-# Setup the logging
-from . import logger
-log = logger.get_log()
 
-log.setLevel(logger.logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 def import_file(node, root, file_path):

--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import sys
 import os
 import datetime
+import logging
 
 import click
 import peewee as pw
@@ -16,11 +17,8 @@ import alpenhorn.storage as st
 import alpenhorn.acquisition as ac
 import alpenhorn.auto_import as ai
 
-# Setup the logging
-from . import logger
-log = logger.get_log()
 
-log.setLevel(logger.logging.DEBUG)
+log = logging.getLogger(__name__)
 
 
 @click.group()

--- a/alpenhorn/config.py
+++ b/alpenhorn/config.py
@@ -61,6 +61,8 @@ from __future__ import division
 from __future__ import absolute_import
 
 import logging
+import os
+import yaml
 
 
 log = logging.getLogger(__name__)
@@ -87,9 +89,6 @@ def load_config():
     """
 
     global config
-
-    import os
-    import yaml
 
     # Initialise with the default configuration
     config = _default_config.copy()

--- a/alpenhorn/config.py
+++ b/alpenhorn/config.py
@@ -26,8 +26,13 @@ Example config:
 
     # Logging configuration
     logging:
-        file: alpenhorn.log
+
+        # Set the overall logging level
         level: debug
+
+        # Allow overriding the level on a module by module basis
+        module_levels:
+            alpenhorn.db: info
 
     # Configure the operation of the local service
     service:
@@ -55,9 +60,10 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-# Setup the logging
-from . import logger
-log = logger.get_log()
+import logging
+
+
+log = logging.getLogger(__name__)
 
 config = None
 
@@ -65,6 +71,13 @@ _default_config = {
     'service': {
         'update_interval': 60,
         'auto_import_interval': 30
+    },
+
+    'logging': {
+        'level': 'warning',
+        'module_levels': {
+            'alpenhorn': 'info'
+        }
     }
 }
 

--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -7,8 +7,8 @@ import peewee as pw
 import playhouse.db_url as db_url
 
 # All peewee-generated logs are logged to this namespace.
-logger = logging.getLogger("db")
-logger.addHandler(logging.NullHandler())
+logger = logging.getLogger(__name__)
+# logger.addHandler(logging.NullHandler())
 
 
 # Global variables and constants.

--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -8,7 +8,6 @@ import playhouse.db_url as db_url
 
 # All peewee-generated logs are logged to this namespace.
 logger = logging.getLogger(__name__)
-# logger.addHandler(logging.NullHandler())
 
 
 # Global variables and constants.

--- a/alpenhorn/extensions.py
+++ b/alpenhorn/extensions.py
@@ -24,12 +24,12 @@ from __future__ import division
 from __future__ import absolute_import
 
 import importlib
+import logging
 
-from . import config
+from . import config, acquisition
 
-# Setup the logging
-from . import logger, acquisition
-log = logger.get_log()
+
+log = logging.getLogger(__name__)
 
 
 # Internal variable for holding the extension references

--- a/alpenhorn/service.py
+++ b/alpenhorn/service.py
@@ -5,13 +5,15 @@ from __future__ import absolute_import
 
 import sys
 import socket
+import logging
 
 import click
 
-from alpenhorn import (logger, extensions, db, config,
-                       auto_import, storage, update)
+from . import (extensions, db, config, logger,
+               auto_import, storage, update)
 
-log = logger.get_log()
+
+log = logging.getLogger(__name__)
 
 
 # Register Hook to Log Exception
@@ -31,6 +33,9 @@ def cli():
 
     # Load the configuration for alpenhorn
     config.load_config()
+
+    # Set up logging
+    logger.start_logging()
 
     # Attempt to load any alpenhor extensions
     extensions.load_extensions()

--- a/alpenhorn/storage.py
+++ b/alpenhorn/storage.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import division
+
 import peewee as pw
 from .db import base_model, EnumField
 

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -8,6 +8,7 @@ import os
 import time
 import datetime
 import re
+import logging
 
 import peewee as pw
 from peewee import fn
@@ -17,9 +18,8 @@ from . import archive as ar
 from . import storage as st
 from . import util, config, db
 
-# Setup the logging
-from . import logger
-log = logger.get_log()
+
+log = logging.getLogger(__name__)
 
 # Parameters.
 max_time_per_node_operation = 300   # Don't let node operations hog time.

--- a/alpenhorn/util.py
+++ b/alpenhorn/util.py
@@ -5,9 +5,12 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
-import os
 import re
 import shlex
+import logging
+
+
+log = logging.getLogger(__name__)
 
 
 def run_command(cmd, **kwargs):
@@ -32,6 +35,8 @@ def run_command(cmd, **kwargs):
     """
 
     import subprocess
+
+    log.debug('Running command "%s"', cmd)
 
     # Split the cmd string appropriately and then run using Popen
     proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE,

--- a/tests/test_acquisition_model.py
+++ b/tests/test_acquisition_model.py
@@ -13,8 +13,6 @@ import yaml
 import os
 from os import path
 
-# TODO: use Pytest's directory used for tmpdir/basedir, not '/tmp'
-os.environ['ALPENHORN_LOG_FILE'] = '/tmp' + '/alpenhornd.log'
 
 import alpenhorn.db as db
 from alpenhorn.acquisition import *

--- a/tests/test_archive_model.py
+++ b/tests/test_archive_model.py
@@ -13,8 +13,6 @@ import yaml
 import os
 from os import path
 
-# TODO: use Pytest's directory used for tmpdir/basedir, not '/tmp'
-os.environ['ALPENHORN_LOG_FILE'] = '/tmp' + '/alpenhornd.log'
 
 import alpenhorn.db as db
 from alpenhorn.archive import *

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,9 +20,6 @@ try:
 except ImportError:
     from mock import patch, call
 
-# TODO: use Pytest's directory used for tmpdir/basedir, not '/tmp'
-os.environ['ALPENHORN_LOG_FILE'] = '/tmp' + '/alpenhornd.log'
-
 
 import alpenhorn.db as db
 import alpenhorn.client as cli

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -7,10 +7,6 @@ try:
 except ImportError:
     from mock import patch
 
-# TODO: use Pytest's directory used for tmpdir/basedir, not '/tmp'
-os.environ['ALPENHORN_LOG_FILE'] = '/tmp' + '/alpenhornd.log'
-
-
 from alpenhorn import extensions, acquisition, generic
 
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -12,9 +12,6 @@ import pytest
 import yaml
 import os
 
-# TODO: use Pytest's directory used for tmpdir/basedir, not '/tmp'
-os.environ['ALPENHORN_LOG_FILE'] = '/tmp' + '/alpenhornd.log'
-
 import alpenhorn.db as db
 import alpenhorn.archive as ar
 import alpenhorn.storage as st
@@ -34,22 +31,27 @@ class ZabInfo(ge.GenericAcqInfo):
     _file_types = ['zxc', 'log']
     patterns = ['**zab']
 
+
 class QuuxInfo(ge.GenericAcqInfo):
     _acq_type = 'quux'
     _file_types = ['zxc', 'log']
     patterns = ['*quux', 'x']
 
+
 class ZxcInfo(ge.GenericFileInfo):
     _file_type = 'zxc'
     patterns = ['**.zxc', 'jim*', 'sheila']
+
 
 class SpqrInfo(ge.GenericFileInfo):
     _file_type = 'spqr'
     patterns = ['*spqr*']
 
+
 class LogInfo(ge.GenericFileInfo):
     _file_type = 'log'
     patterns = ['*.log']
+
 
 @pytest.fixture
 def fixtures(tmpdir):


### PR DESCRIPTION
This pull request is a cleanup of the logging code, switching to getting a logger object at the module level direct from `logging`, and having `alpenhorn.logger` be only for configuring the logging output.

Most recommendations for python are to simply allow logging output to go to stdout and then let the system process it with its own tools (systemd, syslog etc). This is mostly fine, and is what should do by default, but on machines where alpenhorn doesn't run as a proper service (e.g. SciNet for CHIME), then we might need to specifically configure file locations. That ability has been removed in this PR, and so should be brought back later.