### PR TITLE
Require PeeWee v2 (#27)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-peewee >= 2.7.0
+peewee ~= 2.7
 Click >= 6.0
 globre
 watchdog


### PR DESCRIPTION
We have incompatibilities with API changes introduced in PeeWee v3, so until
this is resolved, we should require v2.7 and up to but excluding v3.