### PR TITLE
#28: use docker-py v3 API

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest >= 2.10
 pyfakefs >= 3.1
 mock; python_version < '3.0'
+docker >= 3.0

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -342,7 +342,7 @@ def _verify_files(worker):
     )
 
     # Convert the output back to an exit status
-    assert not int(output)
+    assert not output.exit_code
 
 
 # ====== Test the auto_import behaviour ======


### PR DESCRIPTION
Since v3, `Container.exec_run` returns a tuple of (exit_code, output)`.

We could also check `docker.__version__` after importing, and raise an exception if it's not `=~ 3.0`.