### PR TITLE
Fix #31: confirmation message printed by `create_node`

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -1023,8 +1023,13 @@ def create_node(node_name, root, hostname, group, address, mounted, auto_import,
                               min_avail_gb=min_avail_gb, min_delete_age_days=min_delete_age_days,
                               notes=notes)
 
-        print("Added node \"%s\" belonging to group \"%s\" in the directory \
-              \"%s\" at host \"%s\" to database." % (node_name, root, group, hostname))
+        print('Added node "%(node)s" belonging to group "%(group)s" in the directory '
+              '"%(root)s" at host "%(host)s" to database.' % dict(
+                  node=node_name,
+                  root=root,
+                  group=group,
+                  host=hostname
+              ))
 
 # A few utility routines for dealing with filesystems
 MAX_E2LABEL_LEN = 16

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -588,6 +588,8 @@ def test_create_node(fixtures):
     tmpdir.chdir()
 
     result = runner.invoke(cli.create_node, args=['y', 'root', 'hostname', 'bar'])
+    assert result.exit_code == 0
+    assert result.output == 'Added node "y" belonging to group "bar" in the directory "root" at host "hostname" to database.\n'
 
     node = st.StorageNode.get(name='y')
 


### PR DESCRIPTION
See #31