### PR TITLE
Refactor test fixtures to work in Pytest v4

### DIFF
--- a/tests/test_acquisition_model.py
+++ b/tests/test_acquisition_model.py
@@ -19,12 +19,10 @@ from alpenhorn.acquisition import *
 
 tests_path = path.abspath(path.dirname(__file__))
 
-@pytest.fixture
-def fixtures(clear_db=True):
-    """Initializes an in-memory Sqlite database with data in tests/fixtures"""
-    if (clear_db):
-        db._connect()
-    db.database_proxy.create_tables([ArchiveAcq, AcqType, FileType, ArchiveFile], safe=not clear_db)
+
+def load_fixtures():
+    """Loads data from tests/fixtures into the connected database"""
+    db.database_proxy.create_tables([ArchiveAcq, AcqType, FileType, ArchiveFile])
 
     # Check we're starting from a clean slate
     assert ArchiveAcq.select().count() == 0
@@ -54,11 +52,17 @@ def fixtures(clear_db=True):
     ArchiveFile.insert_many(fixtures['files']).execute()
     files = dict(ArchiveFile.select(ArchiveFile.name, ArchiveFile.id).tuples())
 
-    yield {'types': types, 'file_types': file_types, 'files': files}
+    return {'types': types, 'file_types': file_types, 'files': files}
 
-    # cleanup
-    if clear_db:
-        db.database_proxy.close()
+
+@pytest.fixture
+def fixtures():
+    """Initializes an in-memory Sqlite database with data in tests/fixtures"""
+    db._connect()
+
+    yield load_fixtures()
+
+    db.database_proxy.close()
 
 
 def test_schema(fixtures):

--- a/tests/test_archive_model.py
+++ b/tests/test_archive_model.py
@@ -26,14 +26,10 @@ import test_acquisition_model as ta
 tests_path = path.abspath(path.dirname(__file__))
 
 
-@pytest.fixture
-def fixtures():
-    """Initializes an in-memory Sqlite database with data in tests/fixtures"""
-
-    db._connect()
-
-    fs = next(ts.fixtures(False))
-    fa = next(ta.fixtures(False))
+def load_fixtures():
+    """Loads data from tests/fixtures into the connected database"""
+    fs = ts.load_fixtures()
+    fa = ta.load_fixtures()
 
     db.database_proxy.create_tables([ArchiveFileCopy, ArchiveFileCopyRequest ])
 
@@ -66,12 +62,19 @@ def fixtures():
                                                        ArchiveFileCopyRequest.node_from,
                                                        ArchiveFileCopyRequest.group_to).tuples())
 
-    yield {
+    return {
         'file_copies': file_copies,
         'copy_requests': copy_requests
     }
 
-    # cleanup
+
+@pytest.fixture
+def fixtures():
+    """Initializes an in-memory Sqlite database with data in tests/fixtures"""
+    db._connect()
+
+    yield load_fixtures()
+
     db.database_proxy.close()
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,7 +32,12 @@ import test_import as ti
 
 @pytest.fixture
 def fixtures(tmpdir):
-    return ti.fixtures(tmpdir)
+    """Initializes an in-memory Sqlite database with data in tests/fixtures"""
+    db._connect()
+
+    yield ti.load_fixtures(tmpdir)
+
+    db.database_proxy.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -53,9 +53,9 @@ class LogInfo(ge.GenericFileInfo):
     patterns = ['*.log']
 
 
-@pytest.fixture
-def fixtures(tmpdir):
-    fs = next(ta.fixtures())
+def load_fixtures(tmpdir):
+    """Loads data from tests/fixtures into the connected database"""
+    fs = ta.load_fixtures()
 
     p = tmpdir.join("ROOT")
 
@@ -89,6 +89,16 @@ def fixtures(tmpdir):
     make_files(p.basename, fixtures, tmpdir)
 
     return {'root': p, 'files': fixtures}
+
+
+@pytest.fixture
+def fixtures(tmpdir):
+    """Initializes an in-memory Sqlite database with data in tests/fixtures"""
+    db._connect()
+
+    yield load_fixtures(tmpdir)
+
+    db.database_proxy.close()
 
 
 def test_schema(fixtures):


### PR DESCRIPTION
Pytest deprecated direct calling of fixtures in release 4. Instead, the
[recommended pattern][1] is to refactor the "callable" part of the fixture into a
regular function, and call that from any fixture that needs it.

[1]: https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly