### PR TITLE
Configure pytest to ignore deprecation warning for compiler package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [aliases]
 test=pytest
+
+[tool:pytest]
+filterwarnings =
+    ignore:.*compiler package is deprecated:DeprecationWarning


### PR DESCRIPTION
Using Pyfakefs in fixtures triggers, perhaps indirectly, the import of the
'compiler' package. That, in turn, prints out a deprecation warning because it
is removed in Python 3. This kind of warning is by default filtered out by the
Python interpreter; however, Pytest v3.8 introduced displaying deprecation
warnings [[1]], so that this annoying message now shows up in every test run that
includes tests/test_config.py.

Luckily, Pytest also provides a mechanism to filter out specific warnings, so
that ignoring the warnings about importing 'compiler' can be added to setup.cfg.

[1]: https://docs.pytest.org/en/latest/warnings.html#deprecationwarning-and-pendingdeprecationwarning