### PR TITLE
Add missing method argument `node_root` to AcqInfoBase.set_info

### DIFF
--- a/alpenhorn/acquisition.py
+++ b/alpenhorn/acquisition.py
@@ -371,7 +371,7 @@ class AcqInfoBase(base_model, ConfigClass):
         """
         return AcqType.get(name=cls._acq_type)
 
-    def set_info(self, acqpath):
+    def set_info(self, acqpath, node_root):
         """Set any metadata from the acquisition directory.
 
         Abstract method, must be implemented in a derived AcqInfo table.
@@ -380,6 +380,8 @@ class AcqInfoBase(base_model, ConfigClass):
         ----------
         acqpath : string
             Path to the acquisition directory.
+        node_root : string
+            Path to the root directory for data in the node we are currently on.
         """
         raise NotImplementedError()
 


### PR DESCRIPTION
The calling code invokes `AcqInfo.set_info()` with both `acqpath` and
`node_root`, but the abstract method in AcqInfoBase is missing the 'node_root'.