### PR TITLE
Increase the limit for file name to 255 characters

### DIFF
--- a/alpenhorn/acquisition.py
+++ b/alpenhorn/acquisition.py
@@ -300,7 +300,7 @@ class ArchiveFile(base_model):
     """
     acq = pw.ForeignKeyField(ArchiveAcq, related_name='files')
     type = pw.ForeignKeyField(FileType, related_name='files')
-    name = pw.CharField(max_length=64)
+    name = pw.CharField(max_length=255)
     size_b = pw.BigIntegerField(null=True)
     md5sum = pw.CharField(null=True, max_length=32)
 


### PR DESCRIPTION
Since we allow nested directories inside acquisitions, file names can easily get
longer than the current 64-character limit. Raising this to 255 is at least in
line with filename limit on common Linux filesystems, although even that is not
quite enough for any possibility, as the maximum *path* length in current Linux
is usually 4,096 bytes.