### PR TITLE
Add missing `util` import (#71)

### DIFF
--- a/alpenhorn/service.py
+++ b/alpenhorn/service.py
@@ -10,7 +10,7 @@ import logging
 import click
 
 from . import (extensions, db, config, logger,
-               auto_import, storage, update)
+               auto_import, storage, update, util)
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Commit 9ce8954d34136a2bf7641b6e8a7c37f5c91ae7cd neglected to import
`alpenhorn.util` in `alpenhorn.service`. This adds it.