### PR TITLE
Fix #34: Fix UnboundLocalError when `mount`-ing a non-existent node

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -748,6 +748,7 @@ def mount(name, path, user, address, hostname):
         node = st.StorageNode.get(name=name)
     except pw.DoesNotExist:
         click.echo("Storage node \"%s\" does not exist. I quit." % name)
+        exit(1)
 
     if node.mounted:
         click.echo("Node \"%s\" is already mounted." % name)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -359,6 +359,13 @@ def test_mount(fixtures):
     assert 'Interactive routine for mounting a storage node located at ROOT.' in help_result.output
     assert 'Options:\n  --path TEXT      Root path for this node' in help_result.output
 
+    # test mounting a non-existent node
+    result = runner.invoke(cli.mount, args=['nonexistent'])
+    assert result.exit_code == 1
+    output = result.output.splitlines()
+    assert len(output) == 1
+    assert 'Storage node "nonexistent" does not exist. I quit.' in output[0]
+
     result = runner.invoke(cli.mount, args=['x'])
     assert result.exit_code == 0
     output = result.output.splitlines()


### PR DESCRIPTION
We detected the error case, but were missing the early exit statement, so the
processing continued assuming the variable was properly initialized.