### PR TITLE
Better handling of illegal value of `--storage_type` in `create_node` (fixes #46)

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -987,7 +987,7 @@ def create_group(group_name, notes):
 @click.option('--storage_type', help='What is the type of storage? Options:\
                 A - archive for the data, T - for transiting data \
                 F - for data in the field (i.e acquisition machines)',
-              type=str, default='A')
+              type=click.Choice(['A', 'T', 'F']), default='A')
 @click.option('--max_total_gb', help='The maximum amout of storage we should \
               use.', metavar='FLOAT', type=float, default=-1.)
 @click.option('--min_avail_gb', help='What is the minimum amount of free space \

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -632,3 +632,7 @@ def test_create_node(fixtures):
     result = runner.invoke(cli.create_node, args=['x', 'root', 'hostname', 'bar'])
     assert result.exit_code == 1
     assert result.output == 'Node name "x" already exists! Try a different name!\n'
+
+    result = runner.invoke(cli.create_node, args=['--storage_type=Z', 'z', 'root', 'hostname', 'bar'])
+    assert result.exit_code == 2  # Click usage error
+    assert 'Invalid value for "--storage_type": invalid choice: Z. (choose from A, T, F)' in result.output


### PR DESCRIPTION
We can use click.Choice to get a more descriptive error message for the user,
and proper error exit.