### PR TITLE
Fix #61: allow already mounted node filesystem in `mount_transport`

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -709,8 +709,11 @@ def mount_transport(ctx, node, user, address):
 
     mnt_point = "/mnt/%s" % node
 
-    print("Mounting disc at %s" % mnt_point)
-    os.system("mount %s" % mnt_point)
+    if os.path.ismount(mnt_point):
+        print('{} is already mounted in the filesystem. Proceeding to activate it.'.format(node))
+    else:
+        print("Mounting disc at %s" % mnt_point)
+        os.system("mount %s" % mnt_point)
 
     ctx.invoke(mount, name=node, path=mnt_point, user=user, address=address)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -318,8 +318,9 @@ def test_format_transport(system_mock, getuid_mock, glob_mock, popen_mock, mkdir
     assert node.storage_type == 'T'
 
 
+@patch('os.path.ismount')
 @patch('os.system')
-def test_mount_transport(mock, fixtures):
+def test_mount_transport(mock, mock_ismount, fixtures):
     """Test the 'mount_transport' command"""
     runner = CliRunner()
 
@@ -328,11 +329,20 @@ def test_mount_transport(mock, fixtures):
     assert 'Mount a transport disk into the system and then make it available' in help_result.output
     assert 'Options:\n  --user TEXT     username to access this node' in help_result.output
 
+    mock_ismount.return_value = False
     result = runner.invoke(cli.mount_transport, args=['z'])
     assert result.exit_code == 0
     assert mock.mock_calls == [call('mount /mnt/z')]
     assert re.match(r'Mounting disc at /mnt/z',
                     result.output, re.DOTALL)
+
+    mock_ismount.return_value = True
+    result = runner.invoke(cli.mount_transport, args=['x'])
+    assert result.exit_code == 0
+    assert mock.mock_calls == [call('mount /mnt/z')]
+    assert re.match(r'x is already mounted in the filesystem. Proceeding to activate it.',
+                    result.output, re.DOTALL)
+
 
 @patch('os.system')
 def test_unmount_transport(mock, fixtures):


### PR DESCRIPTION
It's not really an error if the node is already mounted, as it means that
Alpenhorn can just proceed to activating it.