### PR TITLE
Add a check for ALPENHORN_NODE file when mounting the node (fix #7)

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -757,6 +757,13 @@ def mount(name, path, user, address, hostname):
         click.echo("Node \"%s\" is already mounted." % name)
         return
 
+    if path is not None:
+        node.root = path
+
+    if not util.alpenhorn_node_check(node):
+        click.echo('Node "{}" does not match ALPENHORN_NODE'.format(node.name))
+        exit(1)
+
     # Set the default hostname if required
     if hostname is None:
         hostname = util.get_short_hostname()
@@ -767,9 +774,6 @@ def mount(name, path, user, address, hostname):
     node.address = address
     node.mounted = True
     node.host = hostname
-
-    if path is not None:
-        node.root = path
 
     node.save()
 

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -98,40 +98,22 @@ def update_node(node):
 def update_node_mounted(node):
     """Check if a node is actually mounted in the filesystem"""
 
-    fname = 'ALPENHORN_NODE'
-    fullpath = os.path.join(node.root, fname)
-
-    # Check if the node shows up as mounted in database
-    if node.mounted is True:
-        # Check if a file fname exists in the root of the node
-        if os.path.exists(fullpath):
-            log.debug("Checking if file \"%s\" exists on node \"%s\".", fname, node.name)
-
-            # Open fname
-            with open(fullpath, 'r') as f:
-                first_line = f.readline()
-                # Check if the actual node name is in the textfile
-                if node.name == first_line.rstrip():
-                    # Great! Everything is as expected. Exit this routine.
-                    log.debug("Node %s matches with node name %s in %s file",
-                              node.name, first_line, fname)
-                    return True
-                else:
-                    log.error("Node %s does not match string %s in %s file",
-                              node.name, first_line, fname)
-
-        # If file does not exist in the root directory of the node, then mark
-        # node as unmounted
+    if node.mounted:
+        if alpenhorn_node_check(node):
+            return True
         else:
-            log.error("Node \"%s\" is not mounted as expected from db (missing %s file).",
-                      node.name, fname)
+            log.error('Node "%s" does not have the expected ALPENHORN_NODE file',
+                        node.name)
+    else:
+        log.error('Node "%s" is not mounted', node.name)
 
-    # If we are here the node it not correctly mounted so we should unmount it...
+    # Mark the node as unmouted in the database
     node.mounted = False
     node.save(only=node.dirty_fields)  # save only fields that have been updated
-    log.info("Correcting. Node %s is now set to unmounted", node.name)
+    log.info('Correcting the database: node "%s" is now set to unmounted.', node.name)
 
     return False
+
 
 def update_node_free_space(node):
     """Calculate the free space on the node and update the database with it."""

--- a/alpenhorn/util.py
+++ b/alpenhorn/util.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
 
+import os.path
 import re
 import shlex
 import logging
@@ -101,3 +102,19 @@ def md5sum_file(filename, hr=True, cmd_line=False):
 def get_short_hostname():
     """Returns the short hostname (up to the first '.')"""
     return socket.gethostname().split(".")[0]
+
+
+def alpenhorn_node_check(node):
+    """Returns True if ALPENHORN_NODE contains node name"""
+
+    if node.mounted:
+        file_path = os.path.join(node.root, 'ALPENHORN_NODE')
+        if os.path.isfile(file_path):
+            with open(file_path, 'r') as f:
+                first_line = f.readline()
+                # Check if the actual node name is in the textfile
+                if node.name == first_line.rstrip():
+                    # Great! Everything is as expected.
+                    return True
+
+    return False


### PR DESCRIPTION
This was already used in the Alpenhorn service to detect the case when a remote
mount went away. We now do the same check in the client command, so that it
prevents mistakenly mounting a storage node under another node's mountpoint.