### PR TITLE
Show a better error message on bad arguments in `sync` (fix #47)

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -86,11 +86,13 @@ def sync(node_name, group_name, acq, force, nice, target, transport, show_acq, s
     try:
         from_node = st.StorageNode.get(name=node_name)
     except pw.DoesNotExist:
-        raise Exception("Node \"%s\" does not exist in the DB." % node_name)
+        click.echo("Node \"%s\" does not exist in the DB." % node_name)
+        exit(1)
     try:
         to_group = st.StorageGroup.get(name=group_name)
     except pw.DoesNotExist:
-        raise Exception("Group \"%s\" does not exist in the DB." % group_name)
+        click.echo("Group \"%s\" does not exist in the DB." % group_name)
+        exit(1)
 
     # Construct list of file copies that are available on the source node, and
     # not available on any nodes at the destination. This query is quite complex
@@ -120,7 +122,8 @@ def sync(node_name, group_name, acq, force, nice, target, transport, show_acq, s
         try:
             target_group = st.StorageGroup.get(name=target)
         except pw.DoesNotExist:
-            raise RuntimeError("Target group \"%s\" does not exist in the DB." % target)
+            click.echo("Target group \"%s\" does not exist in the DB." % target)
+            exit(1)
 
         # First get the nodes at the destination...
         nodes_at_target = st.StorageNode.select().where(st.StorageNode.group == target_group)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,6 +77,18 @@ def test_sync(fixtures):
     assert 'Copy all files from NODE to GROUP that are not already present.' in help_result.output
     assert 'Options:\n  --acq ACQ              Sync only this acquisition.' in help_result.output
 
+    result = runner.invoke(cli.sync, args=['--target', 'doesnotexist', 'x', 'bar'])
+    assert result.exit_code == 1
+    assert result.output == 'Target group "doesnotexist" does not exist in the DB.\n'
+
+    result = runner.invoke(cli.sync, args=['doesnotexist', 'bar'])
+    assert result.exit_code == 1
+    assert result.output == 'Node "doesnotexist" does not exist in the DB.\n'
+
+    result = runner.invoke(cli.sync, args=['x', 'doesnotexist'])
+    assert result.exit_code == 1
+    assert result.output == 'Group "doesnotexist" does not exist in the DB.\n'
+
     result = runner.invoke(cli.sync, args=['x', 'bar'])
     assert result.exit_code == 0
     assert result.output == 'No files to copy from node x.\n'
@@ -113,9 +125,6 @@ def test_sync(fixtures):
 
     ## if we run sync again, the copy request will simply get the 'n_requests' count incremented by 1
     result = runner.invoke(cli.sync, args=['--force', '--show_acq', '--show_files', 'x', 'bar'])
-
-    print(result.output)
-    print(result.exception)
 
     assert result.exit_code == 0
     assert re.match(r'x \[1 files\]\n' +


### PR DESCRIPTION
Instead of raising an exception with a pile of traceback, it's friendlier to the
user and conveys just as much detail to print out an error message and exit with
status code 1.