### PR TITLE
Improve user-friendliness of the `clean` command

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -438,14 +438,18 @@ def clean(node_name, days, cancel, force, now, target, acq):
     Files will never be removed until they are available on at least two
     archival nodes.
 
-    If --target is specified we will only remove files already available in the
-    TARGET_GROUP. This is useful for cleaning out intermediate locations such as
-    transport disks.
-
     Normally, files are marked to be removed only if the disk space on the node
     is running low. With the --now flag, they will be made available for
     immediate removal. Either way, they will *never* be actually removed until
     there are sufficient archival copies.
+
+    Using the --cancel option undoes previous cleaning operations by marking
+    files that are still on the node and that were marked as available for
+    removal as "must keep".
+
+    If --target is specified, the command will only affect files already
+    available in the TARGET_GROUP. This is useful for cleaning out intermediate
+    locations such as transport disks.
 
     Using the --days flag will only clean correlator and housekeeping
     files which have a timestamp associated with them. It will not

--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -453,21 +453,25 @@ def clean(node_name, days, cancel, force, now, target, acq):
     considered for removal.
     """
 
+    if cancel and now:
+        print('Options --cancel and --now are mutually exclusive.')
+        exit(1)
+
     _init_config_db()
 
     try:
         this_node = st.StorageNode.get(st.StorageNode.name == node_name)
     except pw.DoesNotExist:
-        print("Specified node does not exist.")
-        return
+        print('Storage node "%s" does not exist.' % node_name)
+        exit(1)
 
     # Check to see if we are on an archive node
     if this_node.storage_type == 'A':
-        if force or click.confirm('DANGER: run clean on archive node?'):
-            print("%s is an archive node. Forcing clean." % node_name)
+        if force or click.confirm('DANGER: run clean on archive node "%s"?' % node_name):
+            print('"%s" is an archive node. Forcing clean.' % node_name)
         else:
-            print("Cannot clean archive node %s without forcing." % node_name)
-            return
+            print('Cannot clean archive node "%s" without forcing.' % node_name)
+            exit(1)
 
     # Select FileCopys on this node.
     files = ar.ArchiveFileCopy.select(ar.ArchiveFileCopy.id).where(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -270,8 +270,8 @@ def test_clean(fixtures):
     tmpdir.chdir()
     result = runner.invoke(cli.clean, args=['-f', 'x'])
     assert result.exit_code == 0
-    assert re.match(r'.*\nCleaning up 1 files \(1\.0 GB\) from x\.\n.*' +
-                    r'Marked 1 files for cleaning\n',
+    assert re.match(r'.*\nMark 1 files \(1\.0 GB\) from "x" available for removal\.\n.*' +
+                    r'Marked 1 files available for removal.\n',
                     result.output, re.DOTALL)
 
     ## by default, the cleaned copy should be marked as 'maybe wanted'
@@ -286,8 +286,8 @@ def test_clean(fixtures):
     file_copy.save()
     result = runner.invoke(cli.clean, args=['-f', '--now', 'x'])
     assert result.exit_code == 0
-    assert re.match(r'.*\nCleaning up 1 files \(1\.0 GB\) from x\.\n.*' +
-                    r'Marked 1 files for cleaning\n',
+    assert re.match(r'.*\nMark 1 files \(1\.0 GB\) from "x" available for removal\.\n.*' +
+                    r'Marked 1 files available for removal.\n',
                     result.output, re.DOTALL)
 
     file_copy = (ar.ArchiveFileCopy

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -296,6 +296,19 @@ def test_clean(fixtures):
                  .where(ac.ArchiveFile.name == 'fred')).get()
     assert file_copy.wants_file == 'N'
 
+    ## if we clean with the '--cancel' option, all unwanted copies should again be marked wanted
+    result = runner.invoke(cli.clean, args=['-f', '--cancel', 'x'])
+    assert result.exit_code == 0
+    assert re.match(r'.*\nMark 1 files \(1\.0 GB\) from "x" for keeping\.\n.*' +
+                    r'Marked 1 files for keeping.\n',
+                    result.output, re.DOTALL)
+
+    file_copy = (ar.ArchiveFileCopy
+                 .select()
+                 .join(ac.ArchiveFile)
+                 .where(ac.ArchiveFile.name == 'fred')).get()
+    assert file_copy.wants_file == 'Y'
+
 
 def test_active(fixtures):
     """Test the output of the 'active' command"""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -309,6 +309,22 @@ def test_clean(fixtures):
                  .where(ac.ArchiveFile.name == 'fred')).get()
     assert file_copy.wants_file == 'Y'
 
+    ## '--cancel' and '--now' are mutually exclusive options
+    result = runner.invoke(cli.clean, args=['--now', '--cancel', 'x'])
+    assert result.exit_code == 1
+    assert 'Options --cancel and --now are mutually exclusive.' in result.output
+
+    # using a non-existent node should be reported as an error
+    result = runner.invoke(cli.clean, args=['--force', '--cancel', 'y'])
+    assert result.exit_code == 1
+    assert 'Storage node "y" does not exist.' in result.output
+
+    # cleaning an archive node without the force flag or interactive
+    # confirmation should be an error
+    result = runner.invoke(cli.clean, args=['z'])
+    assert result.exit_code == 1
+    assert 'Cannot clean archive node "z" without forcing.' in result.output
+
 
 def test_active(fixtures):
     """Test the output of the 'active' command"""


### PR DESCRIPTION
- improves the help text and progress messages to make it clearer what's being cleaned means
- have a way to undo a "clean" request
- signal user errors with non-zero exit code
