### PR TITLE
Finer-grained ArchiveFileCopyRequest tracking and accounting

### DIFF
--- a/alpenhorn/archive.py
+++ b/alpenhorn/archive.py
@@ -60,7 +60,11 @@ class ArchiveFileCopyRequest(base_model):
     cancelled : bool
         Set to true if the copy is no longer wanted.
     timestamp : datetime
-        The time the most recent request was made.
+        The time the request was made.
+    transfer_started : datetime
+        The time the transfer was started.
+    transfer_completed : datetime
+        The time the transfer was completed.
     """
     file = pw.ForeignKeyField(ArchiveFile, backref='requests')
     group_to = pw.ForeignKeyField(StorageGroup, backref='requests_to')
@@ -69,6 +73,10 @@ class ArchiveFileCopyRequest(base_model):
     completed = pw.BooleanField()
     cancelled = pw.BooleanField(default=False)
     timestamp = pw.DateTimeField()
+    transfer_started = pw.DateTimeField(null=True)
+    transfer_completed = pw.DateTimeField(null=True)
 
     class Meta:
-        primary_key = pw.CompositeKey('file', 'group_to', 'node_from')
+        indexes = (
+            (('file', 'group_to', 'node_from'), False),        # non-unique index
+        )

--- a/alpenhorn/archive.py
+++ b/alpenhorn/archive.py
@@ -59,8 +59,6 @@ class ArchiveFileCopyRequest(base_model):
         Set to true when the copy has succeeded.
     cancelled : bool
         Set to true if the copy is no longer wanted.
-    n_requests : integer
-        The number of previous requests that have been made for this copy.
     timestamp : datetime
         The time the most recent request was made.
     """
@@ -70,7 +68,6 @@ class ArchiveFileCopyRequest(base_model):
     nice = pw.IntegerField()
     completed = pw.BooleanField()
     cancelled = pw.BooleanField(default=False)
-    n_requests = pw.IntegerField()
     timestamp = pw.DateTimeField()
 
     class Meta:

--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -221,8 +221,7 @@ def sync(node_name, group_name, acq, force, nice, target, transport, show_acq, s
 
         # Perform an update of all the existing copy requests
         if len(files_in) > 0:
-            update = ar.ArchiveFileCopyRequest.update(nice=nice, completed=False, cancelled=False, timestamp=dtnow,
-                                                      n_requests=ar.ArchiveFileCopyRequest.n_requests + 1)
+            update = ar.ArchiveFileCopyRequest.update(nice=nice, completed=False, cancelled=False, timestamp=dtnow)
 
             update = update.where(ar.ArchiveFileCopyRequest.file << files_in,
                                   ar.ArchiveFileCopyRequest.group_to == to_group,
@@ -235,7 +234,7 @@ def sync(node_name, group_name, acq, force, nice, target, transport, show_acq, s
             # Construct a list of all the rows to insert
             insert = [{'file': fid, 'node_from': from_node, 'nice': 0,
                        'group_to': to_group, 'completed': False,
-                       'n_requests': 1, 'timestamp': dtnow} for fid in files_out]
+                       'timestamp': dtnow} for fid in files_out]
 
             # Do a bulk insert of these new rows
             ar.ArchiveFileCopyRequest.insert_many(insert).execute()

--- a/tests/fixtures/archive.yml
+++ b/tests/fixtures/archive.yml
@@ -12,5 +12,4 @@ copy_requests:
     group_to: bar
     nice: 3
     completed: False
-    n_requests: 0
     timestamp: '2017-03-03T15:02:43'

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -215,6 +215,8 @@ def test_update_node_requests(tmpdir, fixtures):
     update.update_node_requests(z)
     req = ar.ArchiveFileCopyRequest.get(file=jim, group_to=z.group, node_from=x)
     assert req.completed
+    assert req.transfer_started
+    assert req.transfer_completed > req.transfer_started
 
     assert root_z.join('x', 'jim').check()
     assert root_z.join('x', 'jim').read() == fixtures['root'].join('x', 'jim').read()


### PR DESCRIPTION
This implements schema changes proposed in #57 and #63, namely:

Instead having ArchiveFileCopyRequest have a single instance for each `(file, node_from, group_to)` combination, and updating them in place as a new copy operation is requested after being completed or cancelled once, this changetracks the copying at a request level by:

1. adding new columns for start and end time of the transfer

2. once a copy request is completed or cancelled, requesting the copying of a file again will create a new instance of a copy request for the same `(file, node_from, group_to)`.

With this semantics of copy requests, the `n_requests` column becomes redundant and is removed.