### PR TITLE
Add true size field to ArchiveFileCopy (closes #58)

### DIFF
--- a/alpenhorn/archive.py
+++ b/alpenhorn/archive.py
@@ -30,11 +30,15 @@ class ArchiveFileCopy(base_model):
         - 'M': maybe, can delete if we need space
         - 'N': no, attempt to delete
         In all cases we try to keep at least two copies of the file around.
+    size_b : integer
+        Allocated size of file in bytes (calculated as a multiple of 512-byte
+        blocks).
     """
     file = pw.ForeignKeyField(ArchiveFile, backref='copies')
     node = pw.ForeignKeyField(StorageNode, backref='copies')
     has_file = EnumField(['N', 'Y', 'M', 'X'], default='N')
     wants_file = EnumField(['Y', 'M', 'N'], default='Y')
+    size_b = pw.BigIntegerField()
 
     class Meta:
         indexes = (

--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -154,8 +154,10 @@ def _import_file(node, file_path):
     # does not exist, or (2) if there has previously been a copy here ensure it
     # is checksummed to ensure the archives integrity.
     if not file_.copies.where(ar.ArchiveFileCopy.node == node).count():
-        copy = ar.ArchiveFileCopy.create(file=file_, node=node, has_file='Y',
-                                         wants_file='Y')
+        copy_size_b = os.stat(abspath).st_blocks * 512
+        copy = ar.ArchiveFileCopy.create(file=file_, node=node,
+                                         has_file='Y', wants_file='Y',
+                                         size_b=copy_size_b)
         log.info("Registered file copy \"%s/%s\" to DB.", acq_name, file_name)
     else:
         # Mark any previous copies as not being present...

--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -975,14 +975,17 @@ def import_files(node_name, verbose, acq, dry):
                     registered_files.append(file_path)
                 else:
                     archive_file = ac.ArchiveFile.select().where(ac.ArchiveFile.name == f_name, ac.ArchiveFile.acq == acq).get()
+                    abs_path = os.path.join(node.root, file_path)
 
-                    if (os.path.getsize(os.path.join(node.root, file_path)) != archive_file.size_b):
+                    if (os.path.getsize(abs_path) != archive_file.size_b):
                         corrupt_files.append(file_path)
                         continue
 
                     added_files.append(file_path)
                     if not dry:
-                        ar.ArchiveFileCopy.create(file=archive_file, node=node, has_file='Y', wants_file='Y')
+                        copy_size_b = os.stat(abs_path).st_blocks * 512
+                        ar.ArchiveFileCopy.create(file=archive_file, node=node, has_file='Y', wants_file='Y',
+                                                  size_b=copy_size_b)
 
     # now find the minimum unknown acqs paths that we can report
     not_acqs_roots = []

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -149,6 +149,8 @@ def update_node_integrity(node):
             if util.md5sum_file(fullpath) == fcopy.file.md5sum:
                 log.info("File is A-OK!")
                 fcopy.has_file = 'Y'
+                copy_size_b = os.stat(fullpath).st_blocks * 512
+                fcopy.size_b = copy_size_b
             else:
                 log.error("File is corrupted!")
                 fcopy.has_file = 'X'
@@ -442,6 +444,7 @@ def update_node_requests(node):
         # Check integrity.
         if md5sum == req.file.md5sum:
             size_mb = req.file.size_b / 2**20.0
+            copy_size_b = os.stat(to_file).st_blocks * 512
             trans_time = end_time - start_time
             rate = size_mb / trans_time
             log.info("Pull complete (md5sum correct). Transferred %.1f MB in %i "
@@ -459,6 +462,7 @@ def update_node_requests(node):
                                   .get()
                         fcopy.has_file = 'Y'
                         fcopy.wants_file = 'Y'
+                        fcopy.size_b = copy_size_b
                         fcopy.save()
                         done = True
                     except pw.OperationalError:
@@ -467,8 +471,9 @@ def update_node_requests(node):
                         time.sleep(5)
                         db.config_connect()
             except pw.DoesNotExist:
-                ar.ArchiveFileCopy.insert(file=req.file, node=node, has_file='Y',
-                                          wants_file='Y').execute()
+                ar.ArchiveFileCopy.insert(file=req.file, node=node,
+                                          has_file='Y', wants_file='Y',
+                                          size_b=copy_size_b).execute()
 
             # Mark any FileCopyRequest for this file as completed
             ar.ArchiveFileCopyRequest.update(completed=True,

--- a/tests/test_archive_model.py
+++ b/tests/test_archive_model.py
@@ -45,6 +45,7 @@ def load_fixtures():
     for copy in fixtures['file_copies']:
         copy['file'] = fa['files'][copy['file']]
         copy['node'] = fs['nodes'][copy['node']]
+        copy['size_b'] = 512
 
     # bulk load the file copies
     ArchiveFileCopy.insert_many(fixtures['file_copies']).execute()

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -108,7 +108,7 @@ def test_update_node_integrity(fixtures):
     jim_file.md5sum = fixtures['files']['x']['jim']['md5']
     jim_file.save(only=jim_file.dirty_fields)
 
-    jim = ar.ArchiveFileCopy(file=jim_file, node=node, has_file='M')
+    jim = ar.ArchiveFileCopy(file=jim_file, node=node, has_file='M', size_b=512)
     jim.save()
 
     # create a local copy of 'fred', but with a corrupt contents
@@ -169,8 +169,8 @@ def test_update_node_delete(fixtures):
         c.save(only=c.dirty_fields)
 
         # add copies of the file on the archival nodes
-        ar.ArchiveFileCopy.create(file=c.file, node=node2, has_file='Y').save()
-        ar.ArchiveFileCopy.create(file=c.file, node=node3, has_file='Y').save()
+        ar.ArchiveFileCopy.create(file=c.file, node=node2, has_file='Y', size_b=512).save()
+        ar.ArchiveFileCopy.create(file=c.file, node=node3, has_file='Y', size_b=512).save()
 
     # update_node_delete should mark these files not present or wanted on the
     # node, and delete them from the filesystem
@@ -199,7 +199,7 @@ def test_update_node_requests(tmpdir, fixtures):
     jim.size_b = 0
     jim.md5sum = fixtures['files']['x']['jim']['md5']
     jim.save(only=jim.dirty_fields)
-    ar.ArchiveFileCopy(file=jim, node=x, has_file='Y').save()
+    ar.ArchiveFileCopy(file=jim, node=x, has_file='Y', size_b=512).save()
 
     # make the 'z' node available locally
     root_z = tmpdir.join("ROOT_z")


### PR DESCRIPTION
This reflects the "true" size of the file, as used by the filesystem. (E.g.,
accounting for holes in sparse files or Lustre filesystem compression.)