### PR TITLE
Add an option for client 'import_files' to perform auto-import

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -8,6 +8,7 @@ import sys
 import os
 import datetime
 import logging
+import re
 
 import click
 import peewee as pw
@@ -20,6 +21,8 @@ import alpenhorn.auto_import as ai
 
 
 log = logging.getLogger(__name__)
+
+RE_LOCK_FILE = re.compile('^\..*\.lock$')
 
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
@@ -937,11 +940,11 @@ def import_files(node_name, verbose, acq, create, dry):
                 _, acq_name = acq_type_name
                 if d == acq_name:
                     # the directory is the acquisition
-                    acq_files[acq_name] += fs
+                    acq_files[acq_name] += [f for f in fs if not RE_LOCK_FILE.match(f) and not os.path.isfile(os.path.join(d, '.{}.lock'.format(f)))]
                 if d.startswith(acq_name + "/"):
                     # the directory is inside an acquisition
                     acq_dirname = os.path.relpath(d, acq_name)
-                    acq_files[acq_name] += [(acq_dirname + '/' + f) for f in fs]
+                    acq_files[acq_name] += [(acq_dirname + '/' + f) for f in fs if not RE_LOCK_FILE.match(f) and not os.path.isfile(os.path.join(d, '.{}.lock'.format(f)))]
             else:
                 not_acqs.append(d)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -646,6 +646,69 @@ def test_import_files(fixtures):
     ]
 
 
+def test_import_files_create(fixtures):
+    """Test the 'import_files' command with the `--create` flag"""
+    runner = CliRunner()
+
+    tmpdir = fixtures['root']
+    tmpdir.chdir()
+
+    ## check the starting database state
+    assert (ac.ArchiveAcq.select()
+            .where(ac.ArchiveAcq.name == '12345678T000000Z_inst_zab')
+            .count()) == 0
+
+    result = runner.invoke(cli.import_files, args=['--create', '-vv', 'x'])
+    assert result.exit_code == 0
+    assert re.match(r'.*\n==== Summary ====\n\n' +
+                    r'Registered 2 new acquisitions\n' +
+                    r'Added 9 files\n\n' +
+                    r'0 corrupt files\.\n' +
+                    r'0 files already registered\.\n' +
+                    r'6 files not known\n' +
+                    r'0 directories were not acquisitions\.\n\n' +
+                    r'New acquisitions:\n' +
+                    r'12345678T000000Z_inst_zab\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab\n\n' +
+                    r'Added files:\n' +
+                    r'12345678T000000Z_inst_zab/ch_master.log\n' +
+                    r'12345678T000000Z_inst_zab/foo.zxc\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/acq_123_1_proc.zxc\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/raw/acq_123_1.zxc\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/proc/acq_123_2_proc.zxc\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/raw/acq_123_2.zxc\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/housekeeping_data/hk_123.zxc\n' +
+                    r'x/foo.log\n' +
+                    r'x/jim\n\n' +
+                    r'Corrupt:\n' +
+                    r'\n' +
+                    r'Unknown files:\n' +
+                    r'12345678T000000Z_inst_zab/.foo.zxc.lock\n' +
+                    r'12345678T000000Z_inst_zab/hello.txt\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/.acq_123_proc.zxc.lock\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/proc/.acq_123_2_proc.zxc.lock\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/housekeeping_data/.hk_123.zxc.lock\n' +
+                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/summary.txt\n' +
+                    r'\n' +
+                    r'Unknown acquisitions:\n\n$',
+                    result.output, re.DOTALL)
+
+    ## check the database state
+    assert (ac.ArchiveAcq.select()
+            .where(ac.ArchiveAcq.name == '12345678T000000Z_inst_zab')
+            .count()) == 1
+
+    foo_logs = list(ar.ArchiveFileCopy
+                    .select(ac.ArchiveFile.name,
+                            ar.ArchiveFileCopy.has_file,
+                            ar.ArchiveFileCopy.wants_file)
+                    .join(ac.ArchiveFile)
+                    .where(ac.ArchiveFile.name == 'foo.log')
+                    .dicts())
+    assert foo_logs == [
+        {'name': 'foo.log', 'has_file': 'Y', 'wants_file': 'Y'}
+    ]
+
 def test_nested_import_files(fixtures):
     """Test the 'import_files' command"""
     runner = CliRunner()
@@ -791,6 +854,50 @@ def test_import_files_within_acq_dir(fixtures):
     import textwrap
     assert textwrap.dedent(expected_output) in result.output
 
+    assert acq_file.copies.join(st.StorageNode).where(st.StorageNode.name == 'x').count() == 1
+
+
+def test_import_files_within_acq_dir_create(fixtures):
+    """Test the 'import_files' command from within a directory, combined with the --create flag"""
+    tmpdir = fixtures['root']
+    runner = CliRunner()
+
+    # switch inside the acquisition
+    tmpdir.join('alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data').chdir()
+
+    result = runner.invoke(cli.import_files, args=['--create', '-vv', 'x'])
+    assert result.exit_code == 0
+    expected_output = """
+        ==== Summary ====
+
+        Registered 1 new acquisitions
+        Added 2 files
+
+        0 corrupt files.
+        0 files already registered.
+        1 files not known
+        0 directories were not acquisitions.
+
+        New acquisitions:
+        alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab
+
+        Added files:
+        alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/acq_123_1_proc.zxc
+        alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/raw/acq_123_1.zxc
+
+        Corrupt:
+
+        Unknown files:
+        alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/.acq_123_proc.zxc.lock
+
+        """
+    import textwrap
+    assert textwrap.dedent(expected_output) in result.output
+
+    acq = ac.ArchiveAcq.select().where(ac.ArchiveAcq.name == 'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab').get()
+    acq_file = ac.ArchiveFile.select().where(ac.ArchiveFile.acq == acq, ac.ArchiveFile.name == 'acq_data/x_123_1_data/raw/acq_123_1.zxc').get()
+    assert acq_file.size_b == len(fixtures['files']['alp_root']['2017']['03']['21']['acq_xy1_45678901T000000Z_inst_zab']['acq_data']['x_123_1_data']['raw']['acq_123_1.zxc']['contents'])
+    assert acq_file.md5sum == fixtures['files']['alp_root']['2017']['03']['21']['acq_xy1_45678901T000000Z_inst_zab']['acq_data']['x_123_1_data']['raw']['acq_123_1.zxc']['md5']
     assert acq_file.copies.join(st.StorageNode).where(st.StorageNode.name == 'x').count() == 1
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -561,7 +561,7 @@ def test_import_files(fixtures):
     help_result = runner.invoke(cli.import_files, ['--help'])
     assert help_result.exit_code == 0
     assert 'Scan the current directory for known acquisition files' in help_result.output
-    assert 'Options:\n  -v, --verbose\n  --acq TEXT     Limit import to specified acquisition directories.' in help_result.output
+    assert 'Options:\n  -v, --verbose\n  --acq TEXT      Limit import to specified acquisition directories.' in help_result.output
 
     tmpdir = fixtures['root']
     tmpdir.chdir()
@@ -646,8 +646,8 @@ def test_import_files(fixtures):
     ]
 
 
-def test_import_files_create(fixtures):
-    """Test the 'import_files' command with the `--create` flag"""
+def test_import_files_register_new(fixtures):
+    """Test the 'import_files' command with the `--register-new` flag"""
     runner = CliRunner()
 
     tmpdir = fixtures['root']
@@ -658,7 +658,7 @@ def test_import_files_create(fixtures):
             .where(ac.ArchiveAcq.name == '12345678T000000Z_inst_zab')
             .count()) == 0
 
-    result = runner.invoke(cli.import_files, args=['--create', '-vv', 'x'])
+    result = runner.invoke(cli.import_files, args=['--register-new', '-vv', 'x'])
     assert result.exit_code == 0
     assert re.match(r'.*\n==== Summary ====\n\n' +
                     r'Registered 2 new acquisitions\n' +
@@ -842,15 +842,15 @@ def test_import_files_within_acq_dir(fixtures):
     assert acq_file.copies.join(st.StorageNode).where(st.StorageNode.name == 'x').count() == 1
 
 
-def test_import_files_within_acq_dir_create(fixtures):
-    """Test the 'import_files' command from within a directory, combined with the --create flag"""
+def test_import_files_within_acq_dir_register_new(fixtures):
+    """Test the 'import_files' command from within a directory, combined with the --register-new flag"""
     tmpdir = fixtures['root']
     runner = CliRunner()
 
     # switch inside the acquisition
     tmpdir.join('alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data').chdir()
 
-    result = runner.invoke(cli.import_files, args=['--create', '-vv', 'x'])
+    result = runner.invoke(cli.import_files, args=['--register-new', '-vv', 'x'])
     assert result.exit_code == 0
     expected_output = """
         ==== Summary ====

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -662,32 +662,25 @@ def test_import_files_create(fixtures):
     assert result.exit_code == 0
     assert re.match(r'.*\n==== Summary ====\n\n' +
                     r'Registered 2 new acquisitions\n' +
-                    r'Added 9 files\n\n' +
+                    r'Added 6 files\n\n' +
                     r'0 corrupt files\.\n' +
                     r'0 files already registered\.\n' +
-                    r'6 files not known\n' +
+                    r'2 files not known\n' +
                     r'0 directories were not acquisitions\.\n\n' +
                     r'New acquisitions:\n' +
                     r'12345678T000000Z_inst_zab\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab\n\n' +
                     r'Added files:\n' +
                     r'12345678T000000Z_inst_zab/ch_master.log\n' +
-                    r'12345678T000000Z_inst_zab/foo.zxc\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/acq_123_1_proc.zxc\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/raw/acq_123_1.zxc\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/proc/acq_123_2_proc.zxc\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/raw/acq_123_2.zxc\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/housekeeping_data/hk_123.zxc\n' +
                     r'x/foo.log\n' +
                     r'x/jim\n\n' +
                     r'Corrupt:\n' +
                     r'\n' +
                     r'Unknown files:\n' +
-                    r'12345678T000000Z_inst_zab/.foo.zxc.lock\n' +
                     r'12345678T000000Z_inst_zab/hello.txt\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/.acq_123_proc.zxc.lock\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/proc/.acq_123_2_proc.zxc.lock\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/housekeeping_data/.hk_123.zxc.lock\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/summary.txt\n' +
                     r'\n' +
                     r'Unknown acquisitions:\n\n$',
@@ -729,26 +722,20 @@ def test_nested_import_files(fixtures):
         md5sum=fixtures['files']['alp_root']['2017']['03']['21']['acq_xy1_45678901T000000Z_inst_zab']['acq_data']['x_123_1_data']['raw']['acq_123_1.zxc']['md5'])
 
     result = runner.invoke(cli.import_files, args=['-vv', 'x'])
-
     assert result.exit_code == 0
     assert re.match(r'.*\n==== Summary ====\n\n' +
                     r'Added 1 files\n\n' +
                     r'1 corrupt files\.\n' +
                     r'0 files already registered\.\n' +
-                    r'9 files not known\n' +
+                    r'4 files not known\n' +
                     r'1 directories were not acquisitions\.\n\n' +
                     r'Added files:\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/raw/acq_123_1.zxc\n\n' +
                     r'Corrupt:\n' +
                     r'x/jim\n\n' +
                     r'Unknown files:\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/.acq_123_proc.zxc.lock\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/acq_123_1_proc.zxc\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/proc/.acq_123_2_proc.zxc.lock\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/proc/acq_123_2_proc.zxc\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_2_data/raw/acq_123_2.zxc\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/housekeeping_data/.hk_123.zxc.lock\n' +
-                    r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/housekeeping_data/hk_123.zxc\n' +
                     r'alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/summary.txt\n' +
                     r'x/foo\.log\n\n' +
                     r'Unknown acquisitions:\n' +
@@ -828,7 +815,6 @@ def test_import_files_within_acq_dir(fixtures):
     # switch inside the acquisition
     tmpdir.join('alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data').chdir()
 
-    node = st.StorageNode.get(name='x')
     result = runner.invoke(cli.import_files, args=['-vv', 'x'])
     assert result.exit_code == 0
     expected_output = """
@@ -838,7 +824,7 @@ def test_import_files_within_acq_dir(fixtures):
 
         0 corrupt files.
         0 files already registered.
-        2 files not known
+        1 files not known
         0 directories were not acquisitions.
 
         Added files:
@@ -847,7 +833,6 @@ def test_import_files_within_acq_dir(fixtures):
         Corrupt:
 
         Unknown files:
-        alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/.acq_123_proc.zxc.lock
         alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/acq_123_1_proc.zxc
 
         """
@@ -875,7 +860,7 @@ def test_import_files_within_acq_dir_create(fixtures):
 
         0 corrupt files.
         0 files already registered.
-        1 files not known
+        0 files not known
         0 directories were not acquisitions.
 
         New acquisitions:
@@ -888,7 +873,6 @@ def test_import_files_within_acq_dir_create(fixtures):
         Corrupt:
 
         Unknown files:
-        alp_root/2017/03/21/acq_xy1_45678901T000000Z_inst_zab/acq_data/x_123_1_data/proc/.acq_123_proc.zxc.lock
 
         """
     import textwrap


### PR DESCRIPTION
This allows us to import files on a field node without having to run the daemon, or if we want to be selective about which directories to import.