### PR TITLE
Fix #109: `alpenhorn status` failing with MySQL backend

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -274,8 +274,8 @@ def status(all):
     for node in nodes.tuples():
         node_name, file_count, file_size, node_host, node_root = node
         pct_count = (100.0 * file_count / total_count) if total_count else None
-        pct_size = (100.0 * file_size / total_size) if total_count and file_size else None
-        file_size_tb = (file_size / 2**40.0) if file_count else None
+        pct_size = (100.0 * float(file_size / total_size)) if total_count and file_size else None
+        file_size_tb = (float(file_size) / 2**40.0) if file_count else None
         node_path = '%s:%s' % (node_host, node_root)
         data.append([node_name, file_count, file_size_tb, pct_count, pct_size, node_path])
 

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import
 import time
 import os
 from os.path import join, dirname, exists
+import re
 
 import pytest
 
@@ -362,6 +363,21 @@ def test_import(workers, test_files):
     _verify_db(test_files, copies_on_node=node)
 
     _verify_files(workers[0])
+
+
+def test_status(workers, network):
+    """Check for #109, `alpenhorn status` failing with MySQL storage"""
+
+    status = client.containers.run(
+        'alpenhorn', remove=True, detach=False, network_mode=network,
+        command="alpenhorn status"
+    )
+    assert re.search(r'^node_0\s+9\s+0.0\s+100\.0\s+100\.0\s+container-0:/data$',
+                     status, re.MULTILINE)
+    assert re.search(r'^node_1\s+0\s+0.0\s+container-1:/data$',
+                     status, re.MULTILINE)
+    assert re.search(r'^node_2\s+0\s+0.0\s+container-2:/data$',
+                     status, re.MULTILINE)
 
 
 # ====== Test that the sync between nodes works ======


### PR DESCRIPTION
ArchiveFile.size_b is defined as peewee.BigIntegerField, which at least in
latest Peewee and Python 2.7 is returned as a `decimal.Decimal` value, so
calculations with floats can't be done without an explicit cast.