### PR TITLE
Fix #101: check for update timeout at the top of the processing loop

### DIFF
--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -290,6 +290,9 @@ def update_node_requests(node):
 
     for req in requests:
 
+        if time.time() - start_time > max_time_per_node_operation:
+            break  # Don't hog all the time.
+
         # Only continue if the node is actually active
         if not req.node_from.active:
             continue
@@ -507,6 +510,3 @@ def update_node_requests(node):
             ar.ArchiveFileCopy.update(has_file='M').where(
                 ar.ArchiveFileCopy.file == req.file,
                 ar.ArchiveFileCopy.node == req.node_from).execute()
-
-        if time.time() - start_time > max_time_per_node_operation:
-            break  # Don't hog all the time.


### PR DESCRIPTION
With the check at the bottom of the loop, there were cases where a `continue` on
persistent rsync errors causes the loop to keep running forever, since it never
gets to the timeout check.