### PR TITLE
Fix #113: Only check ALPENHORN_NODE in `util.alpenhorn_node_check`

### DIFF
--- a/alpenhorn/util.py
+++ b/alpenhorn/util.py
@@ -105,16 +105,25 @@ def get_short_hostname():
 
 
 def alpenhorn_node_check(node):
-    """Returns True if ALPENHORN_NODE contains node name"""
+    """Check for valid ALPENHORN_NODE file contents
 
-    if node.active:
-        file_path = os.path.join(node.root, 'ALPENHORN_NODE')
-        if os.path.isfile(file_path):
-            with open(file_path, 'r') as f:
-                first_line = f.readline()
-                # Check if the actual node name is in the textfile
-                if node.name == first_line.rstrip():
-                    # Great! Everything is as expected.
-                    return True
+    Return
+    ------
+
+    True if ALPENHORN_NODE is present in `node.root` directory and contains the
+    contains node name as its first line, False otherwise.
+
+    .. Note:: The caller needs to ensure the StorageNode has the appropriate
+    `active` status.
+    """
+
+    file_path = os.path.join(node.root, 'ALPENHORN_NODE')
+    if os.path.isfile(file_path):
+        with open(file_path, 'r') as f:
+            first_line = f.readline()
+            # Check if the actual node name is in the textfile
+            if node.name == first_line.rstrip():
+                # Great! Everything is as expected.
+                return True
 
     return False

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -463,8 +463,7 @@ def test_unmount_transport(mock, fixtures):
                     result.output, re.DOTALL)
 
 
-@patch('alpenhorn.util.alpenhorn_node_check')
-def test_activate(mock_node_check, fixtures):
+def test_activate(fixtures):
     """Test the 'activate' command"""
     runner = CliRunner()
 
@@ -493,7 +492,6 @@ def test_activate(mock_node_check, fixtures):
     node.save()
 
     # test for error when check for ALPENHORN_NODE fails
-    mock_node_check.return_value = False
     result = runner.invoke(cli.activate, args=['x'])
     assert result.exit_code == 1
     assert 'Node "x" does not match ALPENHORN_NODE' in result.output
@@ -501,9 +499,10 @@ def test_activate(mock_node_check, fixtures):
 
     # test for success when check for ALPENHORN_NODE passes and the node is
     # mounted
-    mock_node_check.return_value = True
+    x_root = fixtures['root'].join('x')
+    x_root.join('ALPENHORN_NODE').write('x')
     result = runner.invoke(cli.activate,
-                           args=['--path=/bla',
+                           args=['--path=' + str(x_root),
                                  '--user=bozo',
                                  '--address=foobar.example.com',
                                  'x'])
@@ -515,7 +514,7 @@ def test_activate(mock_node_check, fixtures):
 
     node = st.StorageNode.get(name='x')
     assert node.active
-    assert node.root == '/bla'
+    assert node.root == x_root
     assert node.username == 'bozo'
     assert node.address == 'foobar.example.com'
     assert node.host == output[0].split('"')[1] == util.get_short_hostname()


### PR DESCRIPTION
Otherwise, running `alpenhorn activate` will fail because `alpenhorn_node_check`
failed if the node was not active. (A catch-22.)

This does mean that the callers of `alpenhorn_node_check` need to ensure the
StorageNode.active is in the correct state, but they currently all do.