### PR TITLE
Fix #118: `verify` called `alpenhorn_node_check` with wrong argument

### DIFF
--- a/alpenhorn/client.py
+++ b/alpenhorn/client.py
@@ -321,8 +321,12 @@ def verify(node_name, md5, fixdb, acq):
         click.echo('Storage node "{}" does not exist.'.format(node_name))
         exit(1)
 
-    if not util.alpenhorn_node_check(node_name):
-        click.echo('Node "{}" does not match ALPENHORN_NODE'.format(node_name))
+    if not this_node.active:
+        click.echo('Node "{}" is not active.'.format(node_name))
+        exit(1)
+    if not util.alpenhorn_node_check(this_node):
+        click.echo('Node "{}" does not match ALPENHORN_NODE: {}'
+                   .format(node_name, this_node.root))
         exit(1)
 
     # Use a complicated query with a tuples construct to fetch everything we


### PR DESCRIPTION
`util.alpenhorn_node_check`'s argument is a `StorageNode`, not its name as
`client.verify` was passing. Also, it's now up to the caller to check that the
node is active, which was missing in `verify`.

Finally, the test for the `verify` method mocked `alpenhorn_node_check`, so this
bug was masked in testing. I removed the mock and now test all code paths
realistically.