### PR TITLE
Add a 'acq' subcommand to the CLI for listing details of acquisitions

### DIFF
--- a/alpenhorn/client/__init__.py
+++ b/alpenhorn/client/__init__.py
@@ -15,6 +15,7 @@ import alpenhorn.storage as st
 import alpenhorn.acquisition as ac
 
 from .connect_db import config_connect
+from . import acq
 from . import group
 from . import node
 from . import transport
@@ -285,6 +286,7 @@ def status(all):
     print(tabulate.tabulate(data, headers=headers, floatfmt=".1f"))
 
 
+cli.add_command(acq.cli, "acq")
 cli.add_command(group.cli, "group")
 cli.add_command(node.cli, "node")
 cli.add_command(transport.cli, "transport")

--- a/alpenhorn/client/acq.py
+++ b/alpenhorn/client/acq.py
@@ -1,0 +1,99 @@
+"""Alpenhorn client interface for operations on `ArchiveAcq`s."""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import click
+from collections import defaultdict
+import os
+import peewee as pw
+import re
+import sys
+
+from alpenhorn import db
+
+import alpenhorn.acquisition as ac
+import alpenhorn.archive as ar
+import alpenhorn.storage as st
+import alpenhorn.util as util
+
+from .connect_db import config_connect
+
+RE_LOCK_FILE = re.compile(r'^\..*\.lock$')
+
+
+@click.group(context_settings={'help_option_names': ['-h', '--help']})
+def cli():
+    """Commands operating on archival data products. Use to list acquisitions, their contents, and locations of copies."""
+    pass
+
+
+@cli.command(name='list')
+@click.argument('node_name', required=False)
+def acq_list(node_name):
+    """List known acquisitions. With NODE specified, list acquisitions with files on NODE.
+    """
+    config_connect()
+
+    import tabulate
+
+    if node_name:
+        try:
+            node = st.StorageNode.get(name=node_name)
+        except pw.DoesNotExist:
+            print("No such storage node:", node_name)
+            sys.exit(1)
+
+        query = (
+            ar.ArchiveFileCopy.select(
+                ac.ArchiveAcq.name,
+                pw.fn.count(ar.ArchiveFileCopy.id))
+            .join(ac.ArchiveFile)
+            .join(ac.ArchiveAcq)
+            .where(ar.ArchiveFileCopy.node == node)
+            .group_by(ac.ArchiveAcq.id)
+        )
+    else:
+        query = (
+            ac.ArchiveAcq.select(
+                ac.ArchiveAcq.name,
+                pw.fn.COUNT(ac.ArchiveFile.id))
+            .join(ac.ArchiveFile, pw.JOIN.LEFT_OUTER)
+            .group_by(ac.ArchiveAcq.name)
+        )
+
+    data = query.tuples()
+
+    if data:
+        print(tabulate.tabulate(data, headers=['Name', 'Files']))
+    else:
+        print("No matching acquisitions")
+
+@cli.command()
+@click.argument('acquisition')
+def files(acquisition):
+    """List files that are in the ACQUISITION.
+    """
+    config_connect()
+
+    import tabulate
+
+    try:
+        acq = ac.ArchiveAcq.get(name=acquisition)
+    except pw.DoesNotExist:
+        print("No such acquisition:", acquisition)
+        sys.exit(1)
+
+    query = (
+        ac.ArchiveFile.select(
+            ac.ArchiveFile.name,
+            ac.ArchiveFile.size_b)
+        .where(ac.ArchiveFile.acq_id == acq.id)
+    )
+
+    data = query.tuples()
+
+    if data:
+        print(tabulate.tabulate(data, headers=['Name', 'Size']))
+    else:
+        print("No registered archive files.")

--- a/alpenhorn/client/acq.py
+++ b/alpenhorn/client/acq.py
@@ -110,10 +110,11 @@ def files(acquisition, node_name):
         query = (
             ac.ArchiveFile.select(
                 ac.ArchiveFile.name,
-                ac.ArchiveFile.size_b)
+                ac.ArchiveFile.size_b,
+                ac.ArchiveFile.md5sum)
             .where(ac.ArchiveFile.acq_id == acq.id)
         )
-        headers = ['Name', 'Size']
+        headers = ['Name', 'Size', 'MD5']
 
     data = query.tuples()
 

--- a/alpenhorn/client/acq.py
+++ b/alpenhorn/client/acq.py
@@ -97,3 +97,66 @@ def files(acquisition):
         print(tabulate.tabulate(data, headers=['Name', 'Size']))
     else:
         print("No registered archive files.")
+
+@cli.command()
+@click.argument('acquisition')
+@click.argument('source_node')
+@click.argument('destination_group')
+def syncable(acquisition, source_node, destination_group):
+    """List all files that are in the ACQUISITION.
+    """
+    config_connect()
+
+    import tabulate
+
+    try:
+        acq = ac.ArchiveAcq.get(name=acquisition)
+    except pw.DoesNotExist:
+        print("No such acquisition:", acquisition)
+
+    try:
+        src = st.StorageNode.get(name=source_node)
+    except pw.DoesNotExist:
+        print("No such storage node:", source_node)
+        sys.exit(1)
+
+    try:
+        dest = st.StorageGroup.get(name=destination_group)
+    except pw.DoesNotExist:
+        print("No such storage group:", destination_group)
+        sys.exit(1)
+
+    # First get the nodes at the destination...
+    nodes_at_dest = st.StorageNode.select().where(st.StorageNode.group == dest)
+
+    # Then use this to get a list of all files at the destination...
+    files_at_dest = ac.ArchiveFile.select().join(ar.ArchiveFileCopy).where(
+        ac.ArchiveFile.acq == acq,
+        ar.ArchiveFileCopy.node << nodes_at_dest,
+        ar.ArchiveFileCopy.has_file == 'Y',
+    )
+
+    # Then combine to get all file(copies) that are available at the source but
+    # not at the destination...
+    query = (
+        ac.ArchiveFile.select(
+            ac.ArchiveFile.name,
+            ac.ArchiveFile.size_b,
+        )
+        .where(ac.ArchiveFile.acq == acq)
+        .join(ar.ArchiveFileCopy)
+        .where(
+            ar.ArchiveFileCopy.node == src,
+            ar.ArchiveFileCopy.has_file == 'Y',
+            ~(ar.ArchiveFile.id << files_at_dest),
+        )
+    )
+
+    data = query.tuples()
+
+    if data:
+        print(tabulate.tabulate(data, headers=['Name', 'Size']))
+    else:
+        print("No files to copy from node '", source_node,
+              "' to group '", destination_group, "'.", sep="")
+

--- a/tests/test_client_acq.py
+++ b/tests/test_client_acq.py
@@ -63,6 +63,7 @@ def test_list(fixtures):
         r'x +3 *\n',
         result.output, re.DOTALL)
 
+    # Fail when given a non-existent storage node
     result = runner.invoke(cli.cli, ['acq', 'list', 'y'])
     assert result.exit_code == 1
     assert "No such storage node: y" in result.output
@@ -99,7 +100,22 @@ def test_files(fixtures):
         r'-+  -+\n'
         r'fred *\n'
         r'jim +0 *\n'
-        r'sheila *\n',
+        r'sheila *\n$',
+        result.output, re.DOTALL)
+
+    # Fail when given a non-existent storage node
+    result = runner.invoke(cli.cli, ['acq', 'files', 'x', 'y'])
+    assert result.exit_code == 1
+    assert "No such storage node: y" in result.output
+
+    # Check files from 'x' present on node 'x' (only 'fred' and 'sheila', with 'missing' and 'corrupted' has_file status)
+    result = runner.invoke(cli.cli, ['acq', 'files', 'x', 'x'])
+    assert result.exit_code == 0
+    assert re.match(
+        r'.*Name +Size +Has +Wants\n'
+        r'-+  -+  -+  -+\n'
+        r'fred +512 +N +Y *\n'
+        r'sheila +512 +X +M *\n$',
         result.output, re.DOTALL)
 
 

--- a/tests/test_client_acq.py
+++ b/tests/test_client_acq.py
@@ -96,10 +96,10 @@ def test_files(fixtures):
     result = runner.invoke(cli.cli, ['acq', 'files', 'x'])
     assert result.exit_code == 0
     assert re.match(
-        r'.*Name +Size\n'
-        r'-+  -+\n'
+        r'.*Name +Size +MD5 *\n'
+        r'-+  -+  -+\n'
         r'fred *\n'
-        r'jim +0 *\n'
+        r'jim +0 +d41d8cd98f00b204e9800998ecf8427e *\n'
         r'sheila *\n$',
         result.output, re.DOTALL)
 

--- a/tests/test_client_acq.py
+++ b/tests/test_client_acq.py
@@ -1,0 +1,103 @@
+"""
+test_client_acq
+----------------------------------
+
+Tests for `alpenhorn.client.acq` module.
+"""
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import pytest
+from click.testing import CliRunner
+import re
+
+import alpenhorn.db as db
+import alpenhorn.acquisition as ac
+import alpenhorn.archive as ar
+import alpenhorn.client as cli
+import alpenhorn.storage as st
+import alpenhorn.util as util
+
+
+@pytest.fixture
+def fixtures(tmpdir):
+    """Initializes an in-memory Sqlite database with data in tests/fixtures"""
+    db._connect()
+
+    import test_import as ti
+
+    yield ti.load_fixtures(tmpdir)
+
+    db.database_proxy.close()
+
+
+@pytest.fixture(autouse=True)
+def no_cli_init(monkeypatch):
+    monkeypatch.setattr(cli.acq, 'config_connect', lambda: None)
+
+
+def test_help(fixtures):
+    """Test the acq command help"""
+    runner = CliRunner()
+
+    help_result = runner.invoke(cli.cli, ['acq', '--help'])
+    assert help_result.exit_code == 0
+    assert """Commands operating on archival data products.""" in help_result.output
+
+
+def test_list(fixtures):
+    """Test the 'acq list' command"""
+    runner = CliRunner()
+
+    help_result = runner.invoke(cli.cli, ['acq', 'list', '--help'])
+    assert help_result.exit_code == 0
+    assert "List known acquisitions." in help_result.output
+
+    # List all registered acquisitions (there is only one, 'x', with files 'red', 'jim', and 'sheila')
+    result = runner.invoke(cli.cli, ['acq', 'list'])
+    assert result.exit_code == 0
+    assert re.match(
+        r'Name +Files\n'
+        r'-+  -+\n'
+        r'x +3 *\n',
+        result.output, re.DOTALL)
+
+    result = runner.invoke(cli.cli, ['acq', 'list', 'y'])
+    assert result.exit_code == 1
+    assert "No such storage node: y" in result.output
+
+    # Check acquisitions present on node 'x' (only 'fred' and 'sheila' from 'x', 'jim' is missing)
+    result = runner.invoke(cli.cli, ['acq', 'list', 'x'])
+    assert result.exit_code == 0
+    assert re.match(
+        r'Name +Files\n'
+        r'-+  -+\n'
+        r'x +2 *\n',
+        result.output, re.DOTALL)
+
+
+def test_files(fixtures):
+    """Test the 'acq files' command"""
+    runner = CliRunner()
+
+    # Check help output
+    help_result = runner.invoke(cli.cli, ['acq', 'files', '--help'])
+    assert help_result.exit_code == 0
+    assert "List files that are in the ACQUISITION." in help_result.output
+
+    # Fail when given a non-existent acquisition
+    result = runner.invoke(cli.cli, ['acq', 'files', 'z'])
+    assert result.exit_code == 1
+    assert "No such acquisition: z" in result.output
+
+    # Check regular case
+    result = runner.invoke(cli.cli, ['acq', 'files', 'x'])
+    assert result.exit_code == 0
+    assert re.match(
+        r'.*Name +Size\n'
+        r'-+  -+\n'
+        r'fred *\n'
+        r'jim +0 *\n'
+        r'sheila *\n',
+        result.output, re.DOTALL)


### PR DESCRIPTION
Current commands:

- `list [NODE]`: with NODE given, lists names of acquisitions and a count of
   their files for data present on the node. Without the argument, lists all
   known acquisitions. (Can be long!)

- `files ACQ`: lists the names of all files that are a part of the acquisition.