### PR TITLE
Fix a failing unit test caused by checking for wrong quotes

### DIFF
--- a/tests/test_client_node.py
+++ b/tests/test_client_node.py
@@ -71,7 +71,10 @@ def test_create_node(fixtures):
 
     result = runner.invoke(cli.cli, ['node', 'create', '--storage_type=Z', 'z', 'root', 'hostname', 'bar'])
     assert result.exit_code == 2  # Click usage error
-    assert "Invalid value for '--storage_type': invalid choice: Z. (choose from A, T, F)" in result.output
+    assert re.search(
+        r"Error: Invalid value for ['\"]--storage_type['\"]: "
+        r"invalid choice: Z. \(choose from A, T, F\)",
+        result.output, re.DOTALL)
 
 
 def test_list_nodes(fixtures):

--- a/tests/test_client_node.py
+++ b/tests/test_client_node.py
@@ -71,7 +71,7 @@ def test_create_node(fixtures):
 
     result = runner.invoke(cli.cli, ['node', 'create', '--storage_type=Z', 'z', 'root', 'hostname', 'bar'])
     assert result.exit_code == 2  # Click usage error
-    assert 'Invalid value for "--storage_type": invalid choice: Z. (choose from A, T, F)' in result.output
+    assert "Invalid value for '--storage_type': invalid choice: Z. (choose from A, T, F)" in result.output
 
 
 def test_list_nodes(fixtures):


### PR DESCRIPTION
This definitely did not use to fail, and it check an error message thrown by Click itself, so it might be a recent update switched between single and double quotes to show valid choices for a multi-choice parameter.