### PR TITLE
fix(tests): Fix test-suite for Click changes in Python 3.9

### DIFF
--- a/alpenhorn/client/transport.py
+++ b/alpenhorn/client/transport.py
@@ -172,9 +172,8 @@ def format(serial_num):
                     print("%s is already mounted at %s" % (l.split()[0], root))
                 else:
                     print(
-                        "%s is a mount point, but %s is already mounted there." % (
-                            root, l.split()[0]
-                        )
+                        "%s is a mount point, but %s is already mounted there."
+                        % (root, l.split()[0])
                     )
     except subprocess.CalledProcessError as e:
         print(

--- a/tests/test_client_node.py
+++ b/tests/test_client_node.py
@@ -1029,7 +1029,10 @@ def test_scan_with_limiting(fixtures):
     node = st.StorageNode.get(name="x")
     result = runner.invoke(cli.cli, args=["node", "scan", "-vv", "--acq", "x", "x"])
     assert result.exit_code == 0
-    assert 'Acquisition "x" is outside the current directory and will be ignored.' in result.output
+    assert (
+        'Acquisition "x" is outside the current directory and will be ignored.'
+        in result.output
+    )
     assert (
         acq_file.copies.join(st.StorageNode).where(st.StorageNode.name == "x").count()
         == 0


### PR DESCRIPTION
I think all of these failures are due to the test suite relying on particular behaviour exhibited by `Click` that is not part of `Click`'s public API and that has changed between versions.

Tests which depends on the text flow of usage output (`--help`) are inherently fragile because they assume `Click`'s text reflowing isn't going to change.

Similarly tests which look for `Click`-produced error messages ("Invalid value for [...]") also aren't a good idea.

The rest of these tests were dependent on the `click.progressbar` call in `client.node.verify` not printing the supplied `"Scanning files"` label, which it _might_ not do if the elapsed time is small enough, but is also something that can't be relied on.  (This is worked around by replacing `re.match` calls with `re.search` to not tie the search pattern to the start of the string.)

Also fix a typo in alpenhorn/client/transport.py