### PR TITLE
Rewrite 2/10: The Fair Multi-FIFO Queue

### DIFF
--- a/alpenhorn/queue.py
+++ b/alpenhorn/queue.py
@@ -1,0 +1,420 @@
+"""Fair Multi-FIFO Queue
+
+The Fair Multi-FIFO Queue implements a multi-producer, multi-consumer queue
+similar to the queues implemented by the queue module.  This queue has all
+the same locking semantics and thread-safety as queue.Queue but is not
+subclassed from that.
+
+Each task in the Fair Multi-FIFO Queue is part of a FIFO specified by a key.
+The Fair Multi-FIFO Queue may have many such FIFOs, and it will try to ensure
+that tasks are removed from the queue in a fair manner which tries to keep
+the same number of tasks from each FIFO in progress at all times.
+
+The queue is unbounded.
+"""
+
+import heapq
+import threading
+from time import time
+from typing import Any
+from collections import deque
+from collections.abc import Hashable
+
+
+class FairMultiFIFOQueue:
+    """Create a new Fair Multi-FIFO Queue"""
+
+    __slots__ = [
+        "_all_tasks_done",
+        "_deferrals",
+        "_dlock",
+        "_fifos",
+        "_inprogress_counts",
+        "_joining",
+        "_keys_by_inprogress",
+        "_lock",
+        "_not_empty",
+        "_total_inprogress",
+        "_total_queued",
+    ]
+
+    def __init__(self) -> None:
+        # The FIFO dict
+        self._fifos = {}
+
+        # Total number of queued tasks
+        self._total_queued = 0
+        # Total number of in-progress tasks
+        self._total_inprogress = 0
+        # Counts of in-progress tasks by FIFO
+        self._inprogress_counts = {}
+        # A list of sets of FIFO keys, indexed by number of in-progress tasks
+        #
+        # We initialise element 0 to the empty set to simplify creating new
+        # FIFOs, which will always get added to that set.
+        self._keys_by_inprogress = [set()]
+
+        # The thread lock (mutex) and the conditionals (see queue.py for
+        # details, which this implementation broadly follows)
+        self._lock = threading.Lock()
+        self._not_empty = threading.Condition(self._lock)
+        self._all_tasks_done = threading.Condition(self._lock)
+
+        # Deferred puts.  This is a heapq.
+        self._deferrals = list()
+        # Are we in a join() call?
+        self._joining = False
+        # The lock for _deferrals and _joining, which can be held independently
+        # of the primary _lock.
+        self._dlock = threading.Lock()
+
+    def task_done(self, key: Hashable) -> None:
+        """Report that a task from the FIFO named `key` is done.
+
+        After a consumer has finished processing a task provided to it
+        by a get(), the key provided by that get() must be passed back
+        into this function to report the completion of that task.
+
+        Parameters
+        ----------
+        key : hashable
+            The name of the FIFO that the completed task came from.  The
+            value passed in should previously have been returned from a
+            `get()` call.
+
+        Raises
+        ------
+        ValueError
+            The FIFO named `key` has no in-progress tasks.
+        """
+
+        with self._all_tasks_done:
+            # The number of currently in-progress tasks (including the one
+            # that's finishing now)
+            count = self._inprogress_counts.get(key, 0)
+
+            # If the specified FIFO has no in-progress tasks, raise value error
+            if count <= 0:
+                raise ValueError(f"no unfinished tasks for FIFO {key}")
+
+            # Remove the FIFO from the ordered list
+            self._keys_by_inprogress[count].remove(key)
+
+            # Decrement counts
+            count -= 1
+            self._inprogress_counts[key] = count
+            self._total_inprogress -= 1
+
+            # Put the fifo back in the ordered list.
+            #
+            # XXX Could just delete a FIFO which is now empty here.
+            #
+            # In general, there's no reason to expect an empty FIFO to be reused,
+            # by the caller, and numerous empty FIFOs will slow down get() over time,
+            # so triming could decreate get() execution time.
+            #
+            # However, in our particular case (alpenhornd), the maximum number
+            # of FIFOs is total number of nodes ever active on this host, which is
+            # generally small and static enough not to have to worry about it.
+            self._keys_by_inprogress[count].add(key)
+
+            # XXX Could trim _keys_by_inprogress here.
+            #
+            # In general, it's potentially useful: it's possible for a bunch
+            # of unnecessary empty sets to accumulate at the tail of this list,
+            # so trimming can save memory in cases where large excursions of
+            # in-progress counts happen occasionally.
+            #
+            # However, in our particular case (alpenhornd), at most, the list
+            # will have as many elements as the maximum number of worker threads
+            # that have ever existed at one time, so it's probably not worth the
+            # trouble.
+
+            # Notify waiters when there are no pending tasks
+            if self._total_queued == 0 and self._total_inprogress == 0:
+                self._all_tasks_done.notify_all()  # wakes up all waiting threads
+
+    def join(self) -> None:
+        """Blocks until there's nothing left in the queue.
+
+        This includes waiting for in-progress tasks.  All deferred puts
+        are discarded, including ones added while this call is blocking.
+        """
+        # Discard deferred puts
+        with self._dlock:
+            self._joining = True
+            self._deferrals = list()
+
+        with self._all_tasks_done:
+            while self._total_inprogress > 0 or self._total_queued > 0:
+                # woken up by the notify_all() in task_done()
+                self._all_tasks_done.wait()
+
+        with self._dlock:
+            self._joining = False
+
+    @property
+    def qsize(self) -> int:
+        """Total number of queued tasks.
+
+        Excludes in-progress tasks and deferred puts not yet processed.
+
+        Not to be relied on."""
+        with self._lock:
+            return self._total_queued
+
+    @property
+    def inprogress_size(self) -> int:
+        """Total number of in-progress tasks.
+
+        Not to be relied on.
+        """
+        with self._lock:
+            return self._total_inprogress
+
+    def fifo_size(self, key: Hashable) -> int:
+        """Size of the FIFO named `key`.
+
+        Includes both queued and in-progress tasks, but not deferred
+        puts not yet expired.
+
+        Returns 0 for any non-existent FIFO (i.e for any `key` not
+        previously used).
+
+        Parameters
+        ----------
+        key : hashable
+            The name of the FIFO to return the size of.
+
+        Returns
+        -------
+        fifo_size : int
+            The size of the FIFO as explained above.
+        """
+        with self._lock:
+            if key not in self._fifos:
+                return 0
+            return len(self._fifos[key]) + self._inprogress_counts[key]
+
+    @property
+    def deferred_size(self) -> int:
+        """Total number of deferred puts not yet processed."""
+        with self._dlock:
+            return len(self._deferrals)
+
+    def _put(self, item: Any, key: Hashable) -> None:
+        """Put `item` into the FIFO named `key` without locking.
+
+        Never call this function directly; use put() instead.
+
+        NB: The caller must hold the `_lock` when calling this function!
+
+        Parameters
+        ----------
+        item : anything
+            The item to add to the queue
+        key : hashable
+            The name of the FIFO to which `item` is added
+        """
+        # Create the FIFO, if necessary
+        if key not in self._fifos:
+            fifo = deque()
+            self._fifos[key] = fifo
+            self._inprogress_counts[key] = 0
+            self._keys_by_inprogress[0].add(key)
+        else:
+            fifo = self._fifos[key]
+
+        # push the task onto the FIFO (right-most end)
+        fifo.append(item)
+        self._total_queued += 1
+
+    def put(self, item: Any, key: Hashable, wait: float = 0) -> bool:
+        """Push `item` onto the FIFO named `key`.
+
+        If `wait` <= 0, the item is immediately put into the queue.
+        and the call returns True.  This is the default behaviour.
+
+        If `wait` > 0 and another thread has called `join()` on the
+        queue, then this function does nothing and returns False.
+
+        Otherwise, if `wait` > 0, the put is delayed by _at least_ that
+        many seconds before item is actually added to the queue.  In
+        this case, this call does not wait for the put, but returns
+        True immediately.
+
+        If the FIFO named `key` doesn't exist, it is created.
+
+        Parameters
+        ----------
+        item : anything
+            The item to add to the queue
+        key : hashable
+            The name of the FIFO to which `item` is added
+        wait : float, optional
+            The amount of time (in seconds) to wait before adding `item`
+            to the queue.
+
+        Returns
+        -------
+        result : bool
+            False if `wait` > 0 and another thread is `join()`-ing the
+            queue.  True otherwise.
+        """
+
+        if wait > 0:
+            # Deferred put
+            with self._dlock:
+                # If joining, discard this put
+                if self._joining:
+                    return False
+
+                heapq.heappush(self._deferrals, (time() + wait, item, key))
+        else:
+            # Immediate put
+            with self._not_empty:
+                self._put(item, key)
+                self._not_empty.notify()  # wakes up a single waiting thread
+
+        return True
+
+    def _get(self, t: float) -> tuple[Any, Hashable] | None:
+        """Iterate the `get()` loop once for at most `t` seconds.
+
+        Never call this function directly.  Use get() instead.
+
+        Parameters
+        ----------
+        t : float
+            Maximum timeout (in seconds) for this iteration of the
+            `get()` loop.
+
+        Returns
+        -------
+        If there was nothing to get, returns None.
+
+        Otherwise:
+
+        item : anything
+            The item removed from the queue
+        key : hashable
+            The name of the FIFO from which `item` was popped
+        """
+        timeout_at = time() + t
+        with self._dlock:
+            # If there are delayed puts, don't wait past the expiry of
+            # the earliest
+            if len(self._deferrals) > 0:
+                first_expiry = min(self._deferrals)[0]
+                if timeout_at > first_expiry:
+                    timeout_at = first_expiry
+
+        # Wait until t seconds elapse, or there's something to get
+        wait = timeout_at - time()
+        if wait > 0 and self._total_queued == 0:
+            self._not_empty.wait(wait)
+
+        # Execute all the expired deferred puts
+        with self._dlock:
+            # self._deferrals is a heapq, so self._deferrals[0] is always
+            # the smallest element
+            while len(self._deferrals) > 0 and self._deferrals[0][0] <= time():
+                # heappop removes and returns self._deferrals[0]
+                _, item, key = heapq.heappop(self._deferrals)
+                self._put(item, key)
+
+        # If the queue is still empty, time out
+        if self._total_queued < 1:
+            return None
+
+        # Otherwise, get the next item from the queue:
+
+        # Choose a FIFO by walking _keys_by_inprogress: find the lowest
+        # non-empty set that has a non-empty FIFO in it.
+        key = None
+        for key_set in self._keys_by_inprogress:
+            if len(key_set) > 0:
+                # Look for a non-empty FIFO in this set
+                for candidate in key_set:
+                    if len(self._fifos[candidate]) > 0:
+                        key = candidate
+                        # remove the key from the set
+                        key_set.remove(key)
+                        break
+
+                # If we found a non-empty FIFO, we're done
+                if key is not None:
+                    break
+
+        # Nothing to get
+        if key is None:
+            return None
+
+        fifo = self._fifos[key]
+
+        # Pop the first (left-most) item from this FIFO
+        item = fifo.popleft()
+        self._total_queued -= 1
+        self._total_inprogress += 1
+
+        # Increment the in-progress count and file the key in the right
+        # place in _keys_by_inprogress
+        count = self._inprogress_counts[key] + 1
+        self._inprogress_counts[key] = count
+        # Extend _keys_by_inprogress if necessary
+        if len(self._keys_by_inprogress) == count:
+            self._keys_by_inprogress.append(set([key]))
+        else:
+            self._keys_by_inprogress[count].add(key)
+
+        return (item, key)
+
+    def get(self, timeout: float | None = None) -> tuple[Any, Hashable] | None:
+        """Take the next item from the queue.
+
+        If the queue is empty, blocks until there is something to
+        remove or, if `timeout` is not `None`, until `timeout` seconds
+        have elapsed.
+
+        Parameters
+        ----------
+        timeout : float, optional
+            If not None, the length of time (in seconds) to wait for
+            an item.
+
+        Returns
+        -------
+        On timeout, returns None.
+
+        Otherwise:
+
+        item : anything
+            The item removed from the queue
+        key : hashable
+            The name of the FIFO from which `item` was popped.  This key
+            _must_ be passed to `task_done()` once processing `item` is
+            complete.
+        """
+
+        # This defines the rate at which we check for deferred puts expiring
+        GET_PERIOD = 10  # seconds
+
+        with self._not_empty:
+            if timeout is None:
+                # Wait until there is something in the queue
+                while True:
+                    item = self._get(GET_PERIOD)
+                    if item is not None:
+                        return item
+            else:
+                # Wait until woken up or timeout
+                wait_until = time() + timeout
+                while True:
+                    remaining = wait_until - time()
+                    if remaining <= 0:
+                        return None  # timeout
+                    item = self._get(
+                        remaining if remaining < GET_PERIOD else GET_PERIOD
+                    )
+                    if item is not None:
+                        return item

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest >= 2.10
-pyfakefs >= 3.1
-mock; python_version < '3.0'
+pytest >= 7.0
+pyfakefs >= 5.0
 docker >= 3.0
+chimedb @ git+https://github.com/chime-experiment/chimedb.git

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import pytest
 
 from alpenhorn import config, db, extensions
+from alpenhorn.queue import FairMultiFIFOQueue
 
 
 def pytest_configure(config):
@@ -39,6 +40,12 @@ def set_config(request):
     config.config = None
     extensions._db_ext = None
     extensions._ext = None
+
+
+@pytest.fixture
+def queue():
+    """A test queue."""
+    yield FairMultiFIFOQueue()
 
 
 @pytest.fixture

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,142 @@
+"""FairMultiFIFOQueue tests."""
+
+import pytest
+import threading
+from time import time
+
+
+@pytest.fixture
+def clean_queue(queue):
+    """A clean queue init and teardown"""
+    yield queue
+
+    # Clean the dirty queue
+    queue.join()
+
+    # Check for clean shutdown
+    assert queue.qsize == 0
+    assert queue.inprogress_size == 0
+
+
+def test_emptyget(clean_queue):
+    """Try to get() nothing."""
+    assert clean_queue.get(timeout=0.1) is None
+
+
+def test_putget(clean_queue):
+    """Test synchronous put -> get -> task_done."""
+
+    assert clean_queue.qsize == 0
+    assert clean_queue.inprogress_size == 0
+    assert clean_queue.fifo_size("fifo") == 0  # "fifo" doesn't exist yet
+
+    clean_queue.put("item", "fifo")
+
+    assert clean_queue.qsize == 1
+    assert clean_queue.inprogress_size == 0
+    assert clean_queue.fifo_size("fifo") == 1
+
+    assert clean_queue.get() == ("item", "fifo")
+
+    assert clean_queue.qsize == 0
+    assert clean_queue.inprogress_size == 1
+    assert clean_queue.fifo_size("fifo") == 1  # includes in-progress
+
+    clean_queue.task_done("fifo")
+
+    assert clean_queue.qsize == 0
+    assert clean_queue.inprogress_size == 0
+    assert clean_queue.fifo_size("fifo") == 0
+
+
+def test_deferred(clean_queue):
+    """Test deferred put."""
+    clean_queue.put("item", "fifo", wait=0.1)
+
+    # This won't be sooner than the expiry time of the deferred put
+    timeout = time() + 0.1
+
+    assert clean_queue.qsize == 0
+    assert clean_queue.deferred_size == 1
+
+    while True:
+        item = clean_queue.get(timeout=0.1)
+
+        if item is None:
+            assert clean_queue.qsize == 0
+            assert clean_queue.deferred_size == 1
+        else:
+            assert item == ("item", "fifo")
+            assert clean_queue.qsize == 0
+            assert clean_queue.deferred_size == 0
+            break
+
+        # The get should finish before the timeout
+        assert time() < timeout
+
+    clean_queue.task_done("fifo")
+
+
+def test_wakeget(clean_queue):
+    """Test waking up a get from a put."""
+
+    # Consumer thread
+    def consumer(clean_queue):
+        assert clean_queue.get() == (1, "fifo")
+        clean_queue.task_done("fifo")
+
+    # Start the consumer
+    thread = threading.Thread(target=consumer, args=(clean_queue,), daemon=True)
+    thread.start()
+
+    # Now put something
+    clean_queue.put(1, "fifo")
+
+    # Join the consumer
+    thread.join()
+
+    # Queue should be empty
+    assert clean_queue.qsize == 0
+    assert clean_queue.inprogress_size == 0
+
+
+def test_concurrency(clean_queue):
+    """Test concurrent puts and gets"""
+
+    # Threads to join later
+    threads = list()
+
+    # Producer thread
+    def producer(clean_queue, fifo):
+        for i in range(100):
+            clean_queue.put(i, fifo)
+
+    # Consumer thread
+    def consumer(clean_queue):
+        for i in range(100):
+            item, key = clean_queue.get()
+            clean_queue.task_done(key)
+
+    # Create a bunch of consumers
+    for i in range(10):
+        threads.append(
+            threading.Thread(target=consumer, args=(clean_queue,), daemon=True)
+        )
+
+    # Create the same number producers
+    for i in range(10):
+        threads.append(
+            threading.Thread(target=producer, args=(clean_queue, i), daemon=True)
+        )
+
+    # Start all the threads
+    for thread in threads:
+        thread.start()
+
+    # Wait for the test to complete
+    for thread in threads:
+        thread.join()
+
+    # There shouldn't be anything left
+    assert clean_queue.qsize == 0
+    assert clean_queue.inprogress_size == 0


### PR DESCRIPTION
This PR introduces a "Fair Multi-FIFO Queue", which will be used by alpenhorn as the task scheduler.  (It doesn't use it yet, as the code introduced here isn't actually used anywhere yet.

## Overview

The FMFQ is a multi-producer, multi-consumer queue designed to be similar to the standard `queue.Queue` though it doesn't derive from that code, nor is it a drop-in replacement for it.  All items in the queue are assigned to a FIFO (of which there are many).  The FIFO for a given item is specified by a key.  The queue is "fair" in the sense that it tries to keep the same number of items in-progress at any given time.  (Same number _in-progress_ not _queued_.)

The FIFOs are implemented as `deque`s, though I don't know if that really saves us a whole lot of time.

The queue is unbounded.

## Queue basics

Like the standard `queue.Queue`, there are three primary functions used to interact with the queue:
* `put(item, key, wait=0)` adds `item` to the queue, putting it at the end of the FIFO named `key`.  (For `wait`, see "Deferred puts" below).
* `get(timeout=None)` retrieves the next item from the queue (where the concept of "next" adheres to the fairness criterion described above).  If there is currently nothing in the queue, this function either waits for ever or else until `timeout` expires.   When returning an item from the queue (i.e. not timing out), it also provides the `key` to indicate which particular FIFO the item came from. When this function provides an item from the queue, that item is marked as being _in-progress_.
* `task_done(key)` tells the queue that an item that was obtained from the FIFO named `key` is no longer in-progress.  A typical consumer will have code that looks something like this:
```
item, key = queue.get()
# Do something with item
queue.key(key)
```
The queue doesn't actually care which items are in-progress.  It only keeps track of the number of in-progress items per FIFO. 

## Other methods

There is a `join` method used to shutdown the queue.  It basically waits until everything from the queue is finished.  It's used at the end of alpenhorn when it attempts to shutdown cleanly.

There are also a number of queue-size methods which will be used by alpenhorn to determine whether a node is "idle" or not.

## How the queue is used in alpenhorn

In alpenhorn, queued items are I/O tasks (which will be introduced in a subsequent PR), but that doesn't matter to the queue itself.  The queue can accept any object.  In alpenhorn, the FIFO `key`s are node names, meaning there is a separate queue per node.  The fairness of the queue is needed to prevent one node (i.e. Nearline) from monopolising the worker threads.  If only nearline tasks are present in the queue, they'll be provided to consumers, but if tasks from other nodes are also present, nearline jobs won't overwhelm the system and prevent these other tasks from being handled in a timely manner.

While the queue code doesn't have anything alpenhorn-specific, a few design decisions have been made based on how alpenhorn uses the queue.  Specifically, we assume the number of distinct FIFOs is small and even if they empty out, they will be re-used with the same key.  The implementation here also assumes the number of items put into the queue is large in comparison to the number of FIFOs.  (See the overly verbose comments in the code for further details.)

## Deferred puts

If `put()` is called with a positive value for `wait`, then the put is accepted by the FMFQ but _not_ added to the queue.  Instead it gets put into a `heapq` of "deferred puts".  These items wait around for `wait` seconds to elapse before the item is added to the queue.

Alpenhorn uses deferred puts to implement tasks which need to wait around for something to happen (i.e. nearline recalls).  Having these tasks wait in the "deferred put" heap, means they aren't available for workers to take and the nodes appear idle until the deferrals expire.

The deferred puts are resolved during a `get` call (which will check for expired deferrals).  As a result, often deferred puts never actually show up in the queue, since they're immediately `get`ted.

## Other changes
I've added a workaround for the DB concurrency test.  I don't understand why it fails when using the Sqlite3 connector.  I've also added the CHIMEDB core package to the test-requirements so we can test it with this code.