### PR TITLE
Rewrite 3/10: Tasks and Worker Pool

### DIFF
--- a/alpenhorn/logger.py
+++ b/alpenhorn/logger.py
@@ -10,7 +10,7 @@ root_logger = logging.getLogger()
 log_stream = logging.StreamHandler()
 
 log_fmt = logging.Formatter(
-    "%(asctime)s %(levelname)s >> %(message)s", "%b %d %H:%M:%S"
+    "%(asctime)s %(levelname)s >> [%(threadName)s] %(message)s", "%b %d %H:%M:%S"
 )
 
 log_stream.setFormatter(log_fmt)

--- a/alpenhorn/pool.py
+++ b/alpenhorn/pool.py
@@ -1,0 +1,362 @@
+"""Worker thread framework."""
+
+import signal
+import logging
+import threading
+from types import FrameType
+from peewee import OperationalError
+
+from . import db
+from .queue import FairMultiFIFOQueue
+
+log = logging.getLogger(__name__)
+
+# This is the big red button: a worker thread will set this if
+# a task produces an uncaught exception.  Once set, all workers
+# will exit as soon as possible.
+#
+# During a global abort, there is no guarantee that the queue
+# nor the worker pool are in a consistent state.
+global_abort = threading.Event()
+
+
+class Worker(threading.Thread):
+    """A worker thread.
+
+    Parameters
+    ----------
+    queue : FairMultiFIFOQueue
+        The queue
+    index : integer
+        The index of this thread.  Only used to set the threadName.
+    """
+
+    def __init__(self, queue: FairMultiFIFOQueue, index: int) -> None:
+        # thread constructor; daemon=True means the thread will be cancelled if the
+        # main thread dies
+        threading.Thread.__init__(self, name=f"Worker#{index}", daemon=True)
+
+        self._worker_stop = threading.Event()
+        self._queue = queue
+
+    def run(self) -> None:
+        """The worker thread main loop.
+
+        Invoked by the .start() method of the worker thread.
+
+        Starts by creating a database connection, which is assumed to be
+        thread-safe (re-entrant).
+
+        Waits and executes tasks from self._queue as they become available.
+        Runs until the self._worker_stop event fires.
+
+        A database error (peewee.OperationalError), will result in this worker
+        cleanly abandonning its current task and exiting.  The main thread
+        will restart it to recover the connection.
+
+        Any other exception will result in this thread firing the
+        global_abort event which will result in a clean-as-possible exit of
+        all of alpenhornd.
+        """
+
+        log.info("Started.")
+
+        db.connect()
+
+        while True:
+            # Exit if told to stop
+            if global_abort.is_set():
+                log.info("Stopped due to global abort.")
+                return
+            if self._worker_stop.is_set():
+                log.info("Stopped.")
+                return
+
+            # Wait for a task:
+            item = self._queue.get(timeout=5)
+
+            if item is not None:
+                task, key = item
+
+                # Abandon working if alpenhornd is aborting
+                if global_abort.is_set():
+                    log.info("Stopped due to global abort.")
+                    self._queue.task_done(key)
+                    return
+
+                # Otherwise, execute the task.
+                log.debug(f"Beginning task {task}")
+                try:
+                    task()
+                except OperationalError as operr:
+                    # Try to clean up. This runs task.do_cleanup()
+                    # until it raises something other than OperationalError
+                    # or finishes.  Each time it is run, at least one cleanup
+                    # function will be shifted out of the queue, so at most
+                    # we'll call it once per registered cleanup function
+                    try:
+                        while True:
+                            try:
+                                task.do_cleanup()
+                                break  # Clean exit, so we're done
+                            except OperationalError:
+                                pass  # Yeah, we know already; try the next one
+                    except Exception:
+                        # Errors upon errors: time to crash and burn
+                        global_abort.set()
+                        log.exception(
+                            "Aborting due to uncaught exception in task cleanup"
+                        )
+                        return 1
+
+                    log.debug(f"Finished task {task}")
+                    self._queue.task_done(key)  # Keep the queue sanitised
+
+                    # Requeue this task if necessary
+                    task.requeue()
+
+                    log.error(f"Exiting due to db error: {operr}")
+                    return 1  # Thread exits, will be respawned in the main loop
+                except Exception:
+                    global_abort.set()
+                    log.exception("Aborting due to uncaught exception in task")
+                    return 1
+
+                self._queue.task_done(key)
+
+                log.debug(f"Finished task {task}")
+
+    def stop_working(self) -> None:
+        """Tell the worker to stop after finishing the current task."""
+        self._worker_stop.set()
+
+
+class WorkerPool:
+    """A pool of worker threads to handle asynchronous tasks from a queue.
+
+    The number of workers in the pool may be adjusted on the fly.
+
+    Parameters
+    ----------
+    num_workers : int
+        The _initial_ number of workers to start
+    queue : FairMultiFIFOQueue
+        The task queue
+    """
+
+    __slots__ = ["_queue", "_mutex", "_all_workers", "_workers"]
+
+    def __init__(self, num_workers: int, queue: FairMultiFIFOQueue) -> None:
+        self._queue = queue
+
+        # For pool updates
+        self._mutex = threading.Lock()
+
+        # Running workers (ones being monitored)
+        self._workers = list()
+
+        # A list of _all_ workers which aren't known to be dead.  In
+        # addition to all the workers in _workers, this also includes all
+        # workers stopped by del_worker(), which may still be running.
+        self._all_workers = list()
+
+        # Start initial workers
+        for _ in range(num_workers):
+            self._new_worker()
+
+    def _new_worker(self, index: int | None = None) -> None:
+        """Create and start a new worker thread.
+
+        If `index` is None, the new worker will be appended to the list
+        of workers.  Otherwise the existing worker with the specified
+        `index` is replaced.
+
+        This function assumes the pool is clean.  If used outside of the
+        constructor, callers should acquire the mutex first.
+
+        Parameters
+        ----------
+        index : int or None
+            If restartng an exited worker, this is the index of the
+            worker to restart.
+        """
+
+        # Create the worker
+        worker = Worker(
+            queue=self._queue,
+            index=len(self._workers) if index is None else index,
+        )
+
+        if index is None:
+            # Append
+            self._workers.append(worker)
+        else:
+            # Replace
+            self._workers[index] = worker
+
+        # This is always an append
+        self._all_workers.append(worker)
+
+        # Start working
+        worker.start()
+
+    def add_worker(self, blocking: bool = True) -> None:
+        """Increment the number of workers in the pool.
+
+        Does nothing if blocking is False and the mutex cannot be acquired.
+
+        Parameters
+        ----------
+        blocking : bool, optional
+            If False, exit and do nothing if the lock can't be acquired.
+        """
+        if self._mutex.acquire(blocking=blocking):
+            self._new_worker()
+            self._mutex.release()
+        else:
+            log.warning("WorkerPool ignoring increment request: pool not clean")
+
+    def del_worker(self, blocking: bool = True) -> None:
+        """Decrement the number of workers in the pool.
+
+        This funciton always attempts to stop the highest indexed worker, even if
+        other workers are idle.  If the worker is in the middle of a task, the
+        task will be completed before the worker terminates.
+
+        Does nothing if blocking is False and the mutex cannot be acquired.
+
+        Also does nothing if the pool is empty (i.e. there's no worker to stop).
+
+        Parameters
+        ----------
+        blocking : bool, optional
+            If False, exit and do nothing if the lock can't be acquired.
+        """
+
+        if self._mutex.acquire(blocking=blocking):
+            if len(self._workers) == 0:
+                log.warning("WorkerPool ignoring decrement request: no workers")
+            else:
+                # Cut the worker loose
+                worker = self._workers.pop()
+
+                # Fire the stop event
+                worker.stop_working()
+
+            # Release the lock
+            self._mutex.release()
+        else:
+            log.warning("WorkerPool ignoring decrement request: pool not clean")
+
+    def check(self) -> None:
+        """Check for workers which have unexpectedly exited and restart them.
+
+        Most crashes of a worker thread will result in a global abort for
+        purposes of data integrity, but a OperationaLError, which generally
+        results from a lost connection to the database, doesn't.  In that
+        case, we just restart the thread to re-try the DB connection.
+
+        If the global_abort has been raised, this function does nothing.
+        """
+        # No reason to do anything during a global abort
+        if global_abort.is_set():
+            return
+
+        # Find joined workers
+        with self._mutex:
+            for index, worker in enumerate(self._workers):
+                if not worker.is_alive():
+                    # Remove from the _all_workers list, since we
+                    # obviously don't have to wait for it to join
+                    self._all_workers.remove(worker)
+
+                    # Respawn
+                    log.warning("Respawning dead worker #{index}")
+                    self._new_worker(index)
+
+    def __len__(self) -> int:
+        """Return the number of running worker threads.
+
+        The value returned does not include workers which have been told to
+        stop but haven't yet."""
+        with self._mutex:
+            return len(self._workers)
+
+    def shutdown(self) -> None:
+        """Stop all worker threads and wait for them to terminate."""
+
+        with self._mutex:
+            # Signal all current workers
+            for worker in self._workers:
+                worker.stop_working()
+
+            # Wait for _all_ workers
+            for worker in self._all_workers:
+                worker.join()
+
+            # Probably we're about to exit, but just so everything stays copacetic:
+            self._workers = list()
+            self._all_workers = list()
+
+
+class EmptyPool:
+    """A stand-in for WorkerPool for when we aren't threaded.
+
+    It has the same methods as WorkerPool, but does nothing and is always
+    empty."""
+
+    def __len__(self) -> None:
+        return 0
+
+    def _do_nothing(self) -> None:
+        pass
+
+    shutdown = _do_nothing
+    del_worker = _do_nothing
+    check = _do_nothing
+
+    # Not quite nothing
+    def add_worker(self) -> None:
+        log.info("Ignoring request to add worker: serial I/O only")
+
+
+# The pool that receives signals
+_signalpool = None
+
+
+# The signal handlers themselves
+def _handle_usr1(signum: signal.Signals, frame: FrameType) -> None:
+    """SIGUSR1 signal handler.
+
+    Sends an increment request to the worker pool.
+    """
+    log.info("Caught SIGUSR1: incrementing workers.")
+    _signalpool.add_worker(blocking=False)
+
+
+def _handle_usr2(signum: signal.Signals, frame: FrameType) -> None:
+    """SIGUSR2 signal handler.
+
+    Sends an decrement request to the worker pool.
+    """
+    log.info("Caught SIGUSR2: decrementing workers.")
+    _signalpool.del_worker(blocking=False)
+
+
+# Called from the main thread start-up to enable the
+# worker incrment/decrement signals
+def setsignals(pool: WorkerPool | EmptyPool) -> None:
+    """Points signal handlers at `pool`.
+
+    SIGUSR1 will result in a new worker being started.
+    SIGUSR2 will result in a worker being deleted.
+
+    Parameters
+    ----------
+    pool : WorkerPool or EmptyPool
+        The pool to point the signal handlers to
+    """
+    global _signalpool
+    _signalpool = pool
+    signal.signal(signal.SIGUSR1, _handle_usr1)
+    signal.signal(signal.SIGUSR2, _handle_usr2)

--- a/alpenhorn/task.py
+++ b/alpenhorn/task.py
@@ -1,0 +1,211 @@
+"""An asynchronous I/O task handled by a worker thread."""
+
+import logging
+from collections import deque
+from inspect import isgenerator
+from collections.abc import Callable, Hashable
+
+from .queue import FairMultiFIFOQueue
+
+log = logging.getLogger(__name__)
+
+
+class Task:
+    """An asynchronous I/O task handled by a worker thread.
+
+    The task is placed into `queue` and waits for a worker thread
+    to pop and execute it.
+
+    The body of the task is provided by the `func` callable.
+    While `func` is executing, the provided Task object can be used in
+    func to register cleanup functions.
+
+    The value returned from calling `func` is ignored.
+
+    If `func` raises ``pw.OperationalError``, and the task is running in a
+    worker, the worker will terminate (and be respawned by the main
+    loop).  In this case, the value of `requeue` indicates how to handle
+    re-running this task:
+    - If `requeue` is True, the task will put a copy of itself back into
+         the queue before exiting.  This is appropriate for Tasks
+         produced by the `auto_import` watchers, which aren't going to
+         fire again.
+    - If `requeue` is false, the task is not requeued, but simply
+         abandonned.  This is appropriate for Tasks produced by the main
+         loop, since a subsequeunt update loop will determine whether
+         the task needs to be performed again.
+
+    All other uncaught exceptions from `func` will result in a global
+    abort of alpenhorn.
+
+    Parameters
+    ----------
+    func : callable
+            the code executed by the worker.  The first positional
+            argument to `func` is always the task itself.
+    queue : FairMultiFIFOQueue
+            the task is automatically added to this queue
+    key : hashable
+            the name of the FIFO used when added to `queuee
+    requeue : boolean
+            should the task be requeued if the worker aborts due to a DB
+            error?  Typically ``True`` for `auto_import` tasks and
+            ``False`` for main update loop tasks
+    name : string
+            the name of the task.  Used in log messages
+    args : list or tuple
+            additional positional arguments passed to `func`
+    kwargs : dict
+            keywork arguments passed to `func`
+    """
+
+    __slots__ = [
+        "_args",
+        "_cleanup",
+        "_func",
+        "_generator",
+        "_key",
+        "_kwargs",
+        "_name",
+        "_queue",
+        "_requeue",
+    ]
+
+    def __init__(
+        self,
+        func: Callable,
+        queue: FairMultiFIFOQueue,
+        key: Hashable,
+        requeue: bool = False,
+        name: str = "Task",
+        args: tuple | list = tuple(),
+        kwargs: dict = dict(),
+    ) -> None:
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+        self._name = name
+        self._queue = queue
+        self._key = key
+        self._cleanup = deque()
+        self._requeue = requeue
+
+        # a generator returned by calling _func (because it yields)
+        self._generator = None
+
+        # Enqueue ourself
+        queue.put(self, key)
+
+    def __call__(self) -> bool:
+        """This method is invoked by the worker thread to run the task.
+
+        Returns True if the task is finished.
+        """
+
+        # If we have no generator, run _func and check whether it yielded
+        if self._generator is None:
+            result = self._func(self, *self._args, **self._kwargs)
+            if isgenerator(result):
+                # If calling _func returned a generator (because it contains a
+                # yield statement), remember it so we can iterate it.
+                self._generator = result
+
+                # No return here: we need to iterate the generator once to start
+                # up the function for the first time.
+            else:
+                # Otherwise, a regular function.  Task is done.
+                self.do_cleanup()
+                return True
+
+        # We're working on a generator.  Iterate it once to get the next
+        # yielded value.
+        try:
+            result = next(self._generator)
+            # yielding no value results in immediate re-queueing
+            if result is None:
+                result = 0
+            # Requeue ourself so we can iterate another time.
+            log.debug(
+                f"Requeueing yielded task {self._name} in FIFO {self._key} "
+                f"with delay {result} seconds"
+            )
+            self._queue.put(self, self._key, wait=result)
+            return False
+        except StopIteration:
+            # Function exited without yielding (i.e. we're done)
+            self._generator = None
+            self.do_cleanup()
+            return True
+
+    def do_cleanup(self) -> None:
+        """Run through the cleanup stack."""
+
+        # We pop here to handle the case where a pw.OperationalError
+        # in a cleanup function causes the worker to cancel.
+        #
+        # If that happens it will call this function on it's way out
+        # the door and we don't want to re-reun clean-up functions
+        # we've already tried.
+        while len(self._cleanup) > 0:
+            func, args, kwargs = self._cleanup.popleft()
+            func(*args, **kwargs)
+
+    def __str__(self) -> str:
+        return self._name
+
+    def requeue(self) -> None:
+        """If requested, re-queue a new copy of this task.
+
+        This method is expected to be called from within the task.
+
+        Note that the task put back into the queue is a _copy_: a yielding
+        task will be restarted from the beginning, and won't pick up from
+        where it was when it called requeue().
+        """
+        if self._requeue:
+            log.info(f"Requeueing task {self._name} in FIFO {self._key}")
+            Task(
+                func=self._func,
+                queue=self._queue,
+                key=self._key,
+                requeue=True,
+                name=self._name,
+                args=self._args,
+                kwargs=self._kwargs,
+            )
+
+    def on_cleanup(
+        self,
+        func: Callable,
+        args: tuple | list = tuple(),
+        kwargs: dict = dict(),
+        first: bool = True,
+    ) -> None:
+        """Register a cleanup function.
+
+        Add func (with tuple args and dict kwargs) to the list of
+        functions to run after the task finishes.
+
+        If first is True, the function is pushed to the start of the
+        list (as if the list were a stack); otherwise it is pushed to
+        the end of the list (as if the list were a FIFO). Both methods
+        of pushing may be freely mixed.
+
+        This method is expected to be called from within the task.
+
+        Parameters
+        ----------
+        func : callable
+            The function to execute on error.
+        args : tuple or list, optional
+            Positional arguments to `func`
+        kwargs : dict, optional
+            Keyword arguments to `func`
+        first : bool, optional
+            If True, `func` will be executed before all other currently
+            registered cleanup functions.
+        """
+        if first:
+            self._cleanup.appendleft((func, args, kwargs))
+        else:
+            self._cleanup.append((func, args, kwargs))

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,185 @@
+"""Test workers and the worker pool."""
+
+import os
+import signal
+import peewee
+import threading
+from time import sleep
+
+import pytest
+
+from alpenhorn.pool import WorkerPool, EmptyPool, setsignals, global_abort
+
+# Event to indicate that the worker that consumed the opperr_task
+# is exiting
+operr_done = threading.Condition()
+
+
+def operr_task():
+    """A fake task that raises peewee.OperationalError."""
+    raise peewee.OperationalError("test")
+
+
+# Attributes to make the function look like a Task to the worker
+operr_task.do_cleanup = lambda: None
+
+
+# task.requeue() is the last thing called as the worker exits
+# So we trigger the condition here
+def trigger_operr_done():
+    global operr_done
+    with operr_done:
+        operr_done.notify()
+
+
+operr_task.requeue = trigger_operr_done
+
+
+def empty_task():
+    """A fake task that does nothing."""
+
+
+def crash_task():
+    """A fake task that raises RuntimeError."""
+    raise RuntimeError("test")
+
+
+# Used by tests to tell the teardown of the pool() fixture how
+# many workers have been deleted and need to be given a task
+# to consume to avoid the 5-second timeout.
+deleted_count = 0
+
+
+@pytest.fixture
+def pool(dbproxy, queue):
+    """Create a WorkerPool."""
+
+    p = WorkerPool(num_workers=2, queue=queue)
+
+    global deleted_count
+    deleted_count = 0
+
+    yield p
+
+    # Delete all the workers.  We only need to do this to get the timing
+    # correct between the worker_stop() and the putting of all the empty
+    # tasks.
+    nworkers = len(p)
+    for _ in range(nworkers):
+        p.del_worker(blocking=True)
+
+    # Add some do-nothing tasks for the workers to consume to avoid having
+    # to wait 5 seconds for timeout after each test.
+    #
+    # This won't take care of previously deleted workers.  The test
+    # should adjust deleted_count as necessary.
+    for _ in range(nworkers + deleted_count):
+        queue.put(empty_task, "fifo")
+
+    # This waits for deleted workers
+    p.shutdown()
+
+    # Pool should be empty after shutdown
+    assert len(p) == 0
+    del p
+
+
+@pytest.fixture
+def empty_pool():
+    """Create an EmptyPool."""
+
+    p = EmptyPool()
+
+    yield p
+
+    p.shutdown()
+
+
+def test_adddel(pool):
+    """Test adding and deleting workers."""
+    assert len(pool) == 2
+    pool.add_worker()
+    assert len(pool) == 3
+    pool.del_worker()
+    assert len(pool) == 2
+    pool.del_worker()
+    assert len(pool) == 1
+    pool.del_worker()
+    assert len(pool) == 0
+    pool.del_worker()  # Should not fail
+    assert len(pool) == 0
+    pool.add_worker()
+    assert len(pool) == 1
+
+    # For fixture teardown (to avoid a 5 second wait)
+    global deleted_count
+    deleted_count = 3
+
+
+def test_adddelempty(empty_pool):
+    """Test adding and deleting workers from the empty pool."""
+    assert len(empty_pool) == 0
+    empty_pool.add_worker()
+    assert len(empty_pool) == 0
+    empty_pool.del_worker()
+    assert len(empty_pool) == 0
+
+
+def test_signal(pool):
+    """Test signalling the pool."""
+    assert len(pool) == 2
+    setsignals(pool)
+    os.kill(os.getpid(), signal.SIGUSR1)
+    assert len(pool) == 3
+    setsignals(pool)
+    os.kill(os.getpid(), signal.SIGUSR2)
+    assert len(pool) == 2
+
+    # For fixture teardown (to avoid a 5 second wait)
+    global deleted_count
+    deleted_count = 1
+
+
+def test_check(queue, pool):
+    """Test WorkerPool.check()."""
+
+    # Count the number of running threads
+    thread_count = threading.active_count()
+
+    # Force a worker to exit
+    queue.put(operr_task, "fifo")
+
+    # Wait for the worker to exit
+    global operr_done
+    with operr_done:
+        operr_done.wait()
+        # Wait a teeny bit longer
+        sleep(0.05)
+
+    # Worker count is still two: dead workers are part of the count.
+    assert len(pool) == 2
+
+    # But we should have one fewer running threads
+    assert threading.active_count() == thread_count - 1
+
+    # Restart the dead worker
+    pool.check()
+
+    # Worker count hasn't changed
+    assert len(pool) == 2
+
+    # But we're back up to a full complement of threads
+    assert threading.active_count() == thread_count
+
+
+def test_crash(queue, pool):
+    """Test the global abort."""
+
+    # Force a worker to crash
+    queue.put(crash_task, "fifo")
+
+    # Wait for the worker to crash
+    global_abort.wait()
+
+    # Do some clean-up so the queue fixture can exit
+    queue.task_done("fifo")

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,0 +1,176 @@
+"""Test Tasks"""
+
+from alpenhorn.task import Task
+
+
+def test_args(queue):
+    """Verify that args passed to the task are passed on to the func."""
+
+    task_ran = False
+
+    def _task(task, arg, kwarg=None):
+        assert isinstance(task, Task)
+        assert arg == "arg"
+        assert kwarg == "kwarg"
+
+        nonlocal task_ran
+        task_ran = True
+
+    Task(_task, queue, "fifo", args=("arg",), kwargs={"kwarg": "kwarg"})
+
+    # Get the task and execute it
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Check that it ran
+    assert task_ran
+
+
+def test_yield(queue):
+    """Test a yielding task."""
+
+    task_stage = 0
+    first_task = None
+    last_task = None
+
+    def _task(task):
+        nonlocal task_stage
+        task_stage = 1
+
+        nonlocal first_task
+        first_task = task
+
+        yield
+
+        task_stage = 2
+
+        nonlocal last_task
+        last_task = task
+
+    Task(_task, queue, "fifo")
+
+    # Pop the task
+    task, key = queue.get()
+
+    # Verify queue is empty
+    assert queue.qsize == 0
+
+    # Run the task
+    task()
+    queue.task_done(key)
+
+    # After the yield, the task has requeued itself
+    assert queue.qsize == 1
+    assert task_stage == 1
+
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Check that it ran to the end
+    assert task_stage == 2
+
+    # Verify that the same Task instance was run both times
+    assert first_task == last_task
+
+
+def test_yieldwait(queue):
+    """Test yielding with deferred queueing."""
+    task_finished = False
+
+    def _task(task):
+        # Any number > 0 causes a deferred put
+        yield 1e-5
+
+        nonlocal task_finished
+        task_finished = True
+
+    Task(_task, queue, "fifo")
+    assert queue.qsize == 1
+    assert queue.deferred_size == 0
+
+    # Run the task
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # put stays deferred until a get() is performed on the queue
+    assert queue.qsize == 0
+    assert queue.deferred_size == 1
+
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    assert queue.qsize == 0
+    assert queue.deferred_size == 0
+    assert task_finished
+
+
+def test_cleanup(queue):
+    """Test task clean-up running."""
+
+    cleaned_up = False
+
+    def _task(task):
+        nonlocal cleaned_up
+
+        def _cleanup():
+            nonlocal cleaned_up
+            cleaned_up = True
+
+        task.on_cleanup(_cleanup)
+
+    Task(_task, queue, "fifo")
+
+    # Run the task
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Check that cleanup happened
+    assert cleaned_up
+
+
+def test_requeue(queue):
+    """Test requeueing"""
+
+    def _task(task):
+        task.requeue()
+
+    # Queue a non-requeuing version to check that the requeue() call is ignored.
+    Task(_task, queue, "fifo")
+
+    # Get the task
+    task, key = queue.get()
+
+    # Queue is empty
+    assert queue.qsize == 0
+    task()
+    queue.task_done(key)
+
+    # Queue is still empty
+    assert queue.qsize == 0
+
+    # Now try a requeuing task
+    Task(_task, queue, "fifo", requeue=True)
+
+    # Get the task
+    task, key = queue.get()
+
+    # Queue is empty
+    assert queue.qsize == 0
+    task()
+    queue.task_done(key)
+
+    # Queue is _not_ empty
+    assert queue.qsize == 1
+
+    # We can do it again: because _task always requeues, there's
+    # no way to ever get it out of the queue
+    task, key = queue.get()
+    assert queue.qsize == 0
+    task()
+    queue.task_done(key)
+    assert queue.qsize == 1


### PR DESCRIPTION
This PR adds the asynchronous Task (a callable object containing the code of an I/O job), the Worker (a thread object that executes Tasks), and the Pool (a container which manages the Workers).  This PR does not integrate these new objects with the rest of alpenhorn (for that, see #148), but does make use of the queue introduced in #145.

## Tasks

The `Task` class is a callable container class.  I/O tasks are made by creating instances of this class by providing the Task class with a function (containing the I/O code) along with any arguments needed to be passed to the function.  The first positional argument to a task function will be the task object itself.

Tasks are immediately and automatically placed onto the queue when they are instantiated, which might seem a little unintuitive, and originally the queueing needed to be done explicitly, but because the queue is one of the parameters that is needed when instantiating the task anyways, I found the task-creation code was _always_ the following:
```
task = Task(queue=queue, key=key, <other-args>...)
queue.put(task, key)
```
which is a bit redundant, so I streamlined it.

The Task instance itself is callable, and when called it will, in turn, execute the provided I/O function. (For lack of a better term, I call these inner functions containing the guts of the I/O task "async"s.  These asyncs can either be regular functions or else they can be generator-functions (because they contain a `yield` statement).  Yielding asyncs are used in places where the task needs to wait for something external to happen (i.e. nearline recall).  When this happens, the async yields a number indicating how long to wait before resuming the task.

The task takes care of these generator-functions and will requeue them if they yield (which is why the `queue` and FIFO `key` need to given to them when a new Task is created.

The async functions can also register clean-up functions (via the passed-in `Task` object) which will run after the async returns.  These are used sparingly within alpenhorn, mostly for bookkeeping purposes.

## Workers

A `Worker` is a `Thread` subclass which contains the logic for pulling `Task`s from the queue an executing them.  On start-up, each Worker calls `db.connect()` to create a database connection and then enters a loop where it waits (via `queue.get()`) for I/O Tasks to be enqueued.  It executes a Task once it gets one and then calls `queue.task_done()` when completed.  Each Worker has a `threading.Event` which can be used to stop it in-between task executions.

Workers will try to exit cleanly when a task they're executing raises `peewee.OperationalError`. If necessary, it will requeue the task it was working on, so it will get executed again, before it exits.  (The `pool` will notice these clean exits and restart the worker; see below.)

If tasks raise some other Exception, then the worker exits uncleanly.  In this case it will trigger the `global_abort` Event before it exits.  Triggering the `global_abort` will cause alpenhorn as a whole to attempt to exit cleanly.  All workers monitor the global abort and will exit cleanly as soon as they finish their current task when they notice it has been set.

## The Pool

The workers are managed by the pool, which is responsible for starting and stopping them.  Calling the `pool.check` method (which alpenhorn will do once per update loop) will restart any cleanly-exited workers (assuming a global abort isn't in progress).

Because I don't yet know how many workers is reasonable, the number of workers can be increased or decreased on the fly by sending SIGUSR1 and SIGUSR2.  Alpenhorn is designed (or will be in a future PR in this series) to keep working even with zero workers.  In that case, tasks will be executed synchronously during the main update loop.

If the database extension in use is not threadsafe (the default fallback db in `db.py` is not, although the CHIMEDB one we will be using is), then a separate worker pool called `EmptyPool` is (will be) used by alpenhorn instead.  This EmptyPool behaves just like the default worker Pool except it never has any workers in it and attempts to add more won't do that.  As a result, when using EmptyPool, all I/O happens synchronously.