### PR TITLE
Rewrite 5/14: I/O framework

### DIFF
--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -156,7 +156,7 @@ def connect() -> None:
     if isinstance(db, pw.MySQLDatabase):
         CurrentTimestampField = pw.TimestampField(
             null=True,
-            constraints=[SQL("ON UPDATE CURRENT_TIMESTAMP")],
+            constraints=[pw.SQL("ON UPDATE CURRENT_TIMESTAMP")],
         )
 
 

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -1,0 +1,210 @@
+"""BaseIO classes.
+
+Provides the basic infrastructure for StorageNode and StorageGroup I/O.
+
+These are very low-level classes.  Any module implementing the I/O class for
+something even remotely resembling a POSIX filesystem may be better served
+by subclassing from DefaultIO instead of from here directly.
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import logging
+
+if TYPE_CHECKING:
+    from ..queue import FairMultiFIFOQueue
+    from ..storage import StorageNode, StorageGroup
+    from ..update import UpdateableNode
+
+log = logging.getLogger(__name__)
+
+
+class BaseNodeIO:
+    """Base class for StorageNode I/O modules in alpenhorn.
+
+    Parameters
+    ----------
+    node : StorageNode
+        the node
+    queue : FairMultiFIFOQueue
+        the task queue
+    config : dict
+        the parsed `node.io_config`. If `node.io_config` is None,
+        this is an empty `dict`.
+    """
+
+    # SETUP
+
+    def __init__(
+        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue
+    ) -> None:
+        self.node = node
+        self._queue = queue
+        self.config = config
+
+    def update(self, node: StorageNode) -> None:
+        """Update the cached StorageNode instance.
+
+                Called once per update loop on pre-existing I/O instances to
+        replace their `self.node` with a new instance fetched from
+        the database.  The new `node` instance reflects changes made
+        to the database record outside of alpenhornd.
+
+        None of `node.id`, `node.name`, `node.io_class`, or `node.io_config`
+        are different than the old `self.node`'s values.  (Changes in these
+        attributes cause alpenhorn to re-create the I/O instance instead of
+        calling this method.)
+
+        If called, this method is called before the `before_update` hook,
+        but it is not called during the main loop iteration that creates
+        the I/O instance.
+
+        Parameters
+        ----------
+        node : StorageNode
+            the updated node instance read from the database
+        """
+        self.node = node
+
+    # HOOKS
+
+    def before_update(self, idle: bool) -> bool:
+        """Pre-update hook.
+
+        Called each update loop before node updates happen.
+
+        Parameters
+        ----------
+        idle : bool
+            If False, updates for this node are going to be skipped this
+            update loop.
+
+        Returns
+        -------
+        do_update : bool
+            Whether to proceed with the update or not (skip it).  If
+            False, the update will be skipped.
+        """
+        # By default, we do nothing and allow the update to continue
+        return True
+
+    def idle_update(self) -> None:
+        """Idle update hook.
+
+        Called after a regular update that wasn't skipped, but only if,
+        after the regular update, there were no tasks pending or in
+        progress for this node (i.e. `self.idle` is True).
+
+        This is the place to put low-priority tasks that should only happen
+        if no other I/O is happening on the node.
+        """
+        # By default do nothing.
+        pass
+
+    def after_update(self) -> None:
+        """Post-update hook.  Called at the end of the update loop.
+
+        This method is called once per update loop, after all other processing
+        has happened on the node.
+        """
+        # Do nothing
+        pass
+
+
+class BaseGroupIO:
+    """Base class for StorageGroup IO modules in alpenhorn.
+
+    Parameters
+    ----------
+    group : StorageGroup
+        The group
+    config : dict
+        The parsed `group.io_config`. If `group.io_config` is None,
+        this is an empty `dict`.
+    """
+
+    # SETUP
+
+    def __init__(self, group: StorageGroup, config: dict) -> None:
+        self.group = group
+        self.config = config
+
+    def set_nodes(self, nodes: list[UpdateableNode]) -> list[UpdateableNode]:
+        """Set the list of local active nodes in this group.
+
+        This method is called to communicate to the I/O instance the list
+        of locally-active nodes.
+
+        This method is called each main loop, after regular
+        node I/O has completed but before any group I/O updates commence.
+
+        If group I/O cannot proceed with the supplied list of nodes,
+        implementations should raise ValueError with a message which will
+        be written to the log.
+
+        Otherwise, it may choose to operate on any non-empty subset of
+        `nodes`.  In this case it should return the list of nodes which has
+        been selected, and record the list locally, if needed.
+
+        Parameters
+        ----------
+        nodes : list of UpdateableNodes
+            local active nodes in this group.  Will never be empty.
+
+        Returns
+        -------
+        selected_nodes : list of UpdateableNodes
+            `nodes` or a non-empty subset of `nodes` on which group I/O
+            will be performed.
+
+                Raises
+                ------
+        ValueError
+            `nodes` was not sufficient to permit group I/O to proceed.
+        """
+        raise NotImplementedError("method must be re-implemented in subclass.")
+
+    # HOOKS
+
+    def before_update(self, idle: bool) -> bool:
+        """Pre-update hook.
+
+        This method is called once per update loop, before any other
+        processing happens on this group.
+
+        Parameters
+        ----------
+        idle : boolean
+                If False, the group update is going to be skipped.
+
+        Returns
+        -------
+        do_update : bool
+            Whether to proceed with the update or not (skip it).  If
+            False, the update will be skipped.
+        """
+        # By default, we do nothing and allow the update to continue
+        return True
+
+    def idle_update(self) -> None:
+        """Idle update hook.
+
+        Called after a regular update that wasn't skipped, but only if after
+        the regular update, there were no tasks pending or in progress this
+        group (i.e. self.idle is True).
+
+        This is the place to put low-priority tasks that should only happen
+        if no other I/O is happening on the group.
+        """
+        # By default do nothing.
+        pass
+
+    def after_update(self) -> None:
+        """Post-update hook.
+
+        This method is called once per update loop, after all other processing
+        has happened on the group but before the node `after_update` hooks
+        are called.
+        """
+        # Do nothing
+        pass

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -1,0 +1,62 @@
+"""Alpenhorn Default I/O classes.
+
+The Alpenhorn Default I/O classes largely re-create the legacy I/O behaviour
+of previous versions of Alpenhorn.
+
+These I/O classes are used by StorageNodes and StorageGroups which do not
+explicitly specify `io_class` (as well as being used explicitly when `io_class`
+has the value "Default").
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import logging
+
+from .base import BaseNodeIO, BaseGroupIO
+
+if TYPE_CHECKING:
+    from ..update import UpdateableNode
+
+log = logging.getLogger(__name__)
+
+
+class DefaultNodeIO(BaseNodeIO):
+    """A simple StorageNode backed by a regular POSIX filesystem."""
+
+
+class DefaultGroupIO(BaseGroupIO):
+    """A simple StorageGroup.
+
+    Permits any number of StorageNodes in the group, but only permits at most
+    one to be active on a given host at any time.
+    """
+
+    # SETUP
+
+    def set_nodes(self, nodes: list[UpdateableNode]) -> list[UpdateableNode]:
+        """Set the list of nodes to operate on.
+
+        DefaultGroupIO only accepts a single node to operate on.
+
+        Parameters
+        ----------
+        nodes : list of UpdateableNodes
+            The local active nodes in this group.  Will never be
+            empty.
+
+        Returns
+        -------
+        nodes : list of UpdateableNodes
+            `nodes`, if `len(nodes) == 1`
+
+        Raises
+        ------
+        ValueError
+            whenever `len(nodes) != 1`
+        """
+
+        if len(nodes) != 1:
+            raise ValueError(f"Too many active nodes in group {self.group.name}.")
+
+        self.node = nodes[0]
+        return nodes

--- a/alpenhorn/util.py
+++ b/alpenhorn/util.py
@@ -111,6 +111,49 @@ def get_hostname() -> str:
     return socket.gethostname().split(".")[0]
 
 
+def pretty_deltat(seconds: float) -> str:
+    """Return a nicely formatted time delta.
+
+    Parameters
+    ----------
+    seconds : float
+        The time delta, in seconds
+
+    Returns
+    -------
+    pretty_deltat : str
+        A human-readable indication of the time delta.
+
+    Raises
+    ------
+    TypeError
+        `seconds` was non-numeric
+    ValueError
+        `seconds` was less than zero
+    """
+
+    # Reject weird stuff
+    try:
+        seconds = float(seconds)
+    except (TypeError, ValueError):
+        raise TypeError("non-numeric time delta")
+
+    if seconds < 0:
+        # If the delta is negative, just print it
+        return f"{seconds:.1f}s"
+
+    hours, seconds = divmod(seconds, 3600)
+    minutes, seconds = divmod(seconds, 60)
+
+    if hours > 0:
+        return f"{int(hours)}h{int(minutes):02}m{int(seconds):02}s"
+    if minutes > 0:
+        return f"{int(minutes)}m{int(seconds):02}s"
+
+    # For short durations, include tenths of a second
+    return f"{seconds:.1f}s"
+
+
 def alpenhorn_node_check(node):
     """Check for valid ALPENHORN_NODE file contents
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Common fixtures"""
 import pytest
+from unittest.mock import patch, MagicMock
 
 from alpenhorn import config, db, extensions
 from alpenhorn.queue import FairMultiFIFOQueue
@@ -11,6 +12,7 @@ from alpenhorn.acquisition import (
     FileType,
 )
 from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from alpenhorn.update import UpdateableNode, UpdateableGroup
 
 
 def pytest_configure(config):
@@ -54,6 +56,59 @@ def set_config(request):
 def queue():
     """A test queue."""
     yield FairMultiFIFOQueue()
+
+
+@pytest.fixture
+def mock_statvfs(fs):
+    """Mocks os.statvfs to work with pyfakefs."""
+
+    def _mocked_statvfs(path):
+        """A mock of os.statvfs that reports the size of the pyfakefs filesystem."""
+        nonlocal fs
+
+        # Anything with a __dict__ works here.
+        class Result:
+            f_bavail = fs.get_disk_usage().free
+            f_bsize = 1
+
+        return Result
+
+    with patch("os.statvfs", _mocked_statvfs):
+        yield
+
+
+@pytest.fixture
+def mock_stat(fs):
+    """Mocks pathlib.PosixPath.stat to work with pyfakefs."""
+
+    def _mocked_stat(path):
+        """Mock of pathlib.PosixPath.stat to report the size of pyfakefs files."""
+        nonlocal fs
+
+        from math import ceil
+
+        file = fs.get_object(path)
+        size = file.size
+
+        # Anything with a __dict__ works here.
+        class Result:
+            # stat reports sizes in 512-byte blocks
+            st_blocks = ceil(size / 512)
+            st_size = size
+            st_mode = file.st_mode
+
+        return Result
+
+    with patch("pathlib.PosixPath.stat", _mocked_stat):
+        yield
+
+
+@pytest.fixture
+def xfs(fs, mock_statvfs, mock_stat):
+    """An extended pyfakefs.
+
+    Patches more stuff for proper behaviour with alpenhorn unittests"""
+    return fs
 
 
 @pytest.fixture
@@ -113,6 +168,111 @@ def dbproxy(set_config):
     yield db.database_proxy
 
     db.close()
+
+
+@pytest.fixture
+def dbtables(dbproxy):
+    """Create all the usual tables in the database."""
+
+    dbproxy.create_tables(
+        [
+            StorageGroup,
+            StorageNode,
+            AcqType,
+            ArchiveAcq,
+            FileType,
+            ArchiveFile,
+            ArchiveFileCopy,
+            ArchiveFileCopyRequest,
+        ]
+    )
+
+
+@pytest.fixture
+def loop_once(dbtables):
+    """Ensure the main loop runs at most once."""
+
+    waited = False
+
+    def _wait(timeout=None):
+        nonlocal waited
+        waited = True
+
+    def _is_set():
+        nonlocal waited
+        return waited
+
+    mock = MagicMock()
+    mock.wait = _wait
+    mock.is_set = _is_set
+
+    # This mocks the imported global_abort in update.py
+    with patch("alpenhorn.update.global_abort", mock):
+        yield mock
+
+
+@pytest.fixture
+def unode(simplenode, queue):
+    """Returns an UpdateableNode."""
+    return UpdateableNode(queue, simplenode)
+
+
+@pytest.fixture
+def mockio():
+    """A mocked I/O module.
+
+    Access the mocks via mockio.group and mockio.node.
+    """
+    # The I/O instances
+    node = MagicMock()
+    node.bytes_avail.return_value = 10000
+    group = MagicMock()
+
+    # This is our mock I/O module
+    class MockIO:
+        # The I/O "classes"
+        def NodeIO(*args, **kwargs):
+            nonlocal node
+            node._instance_args = args
+            node._instance_kwargs = kwargs
+            return node
+
+        def GroupIO(*args, **kwargs):
+            nonlocal group
+            group._instance_args = args
+            node._instance_kwargs = kwargs
+            return group
+
+    MockIO.node = node
+    MockIO.group = group
+
+    # Patch sys.modules so import can find our module.
+    with patch.dict("sys.modules", MockIO=MockIO):
+        yield MockIO
+
+
+@pytest.fixture
+def mockgroupandnode(hostname, queue, storagenode, storagegroup, mockio):
+    """An UpdateableGroup and Updateablenode with mocked I/O classes.
+
+    Yields the group and node.
+    """
+
+    stgroup = storagegroup(name="mockgroup", io_class="MockIO.GroupIO")
+    stnode = storagenode(
+        name="mocknode",
+        group=stgroup,
+        root="/mocknode",
+        host=hostname,
+        active=True,
+        io_class="MockIO.NodeIO",
+    )
+
+    # Fix set_nodes
+    mockio.group.set_nodes = lambda nodes: nodes
+
+    node = UpdateableNode(queue, stnode)
+    yield mockio, UpdateableGroup(group=stgroup, nodes=[node], idle=True), node
 
 
 # Data table fixtures.  Each of these will add a row with the specified

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,102 @@
+"""An end-to-end test of the alpenhorn daemon.
+
+Things that this end-to-end test does:
+   - nothing! (none of the I/O has been fixed)
+
+The purpose of this test isn't to exhaustively exercise all parts
+of the daemon, but to check the connectivity of the high-level blocks
+of the main update loop.
+"""
+
+import yaml
+import pytest
+import peewee as pw
+from click.testing import CliRunner
+from urllib.parse import quote as urlquote
+
+from alpenhorn.service import cli
+from alpenhorn.db import database_proxy, EnumField
+from alpenhorn.storage import StorageGroup, StorageNode
+from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from alpenhorn.acquisition import (
+    AcqType,
+    ArchiveAcq,
+    ArchiveFile,
+    FileType,
+)
+
+
+# database URI for a shared in-memory database
+DB_URI = "file:e2edb?mode=memory&cache=shared"
+
+
+@pytest.fixture
+def e2e_db(xfs, hostname):
+    """Create and populate the DB for the end-to-end test."""
+
+    # Open
+    db = pw.SqliteDatabase(DB_URI, uri=True)
+    assert db is not None
+    database_proxy.initialize(db)
+    EnumField.native = False
+
+    # Create tables
+    db.create_tables(
+        [
+            AcqType,
+            ArchiveAcq,
+            ArchiveFile,
+            ArchiveFileCopy,
+            ArchiveFileCopyRequest,
+            FileType,
+            StorageGroup,
+            StorageNode,
+        ]
+    )
+
+    # Populate tables
+    # ---------------
+
+    # A Default-IO group with one node
+    dftgrp = StorageGroup.create(name="dftgroup")
+    StorageNode.create(
+        name="dftnode",
+        group=dftgrp,
+        root="/dft",
+        host=hostname,
+        active=True,
+        min_avail_gb=0,
+        max_total_gb=-1.0,
+    )
+    xfs.create_file("/dft/ALPENHORN_NODE", contents="dftnode")
+
+    yield
+
+
+@pytest.fixture
+def e2e_config(xfs, hostname):
+    """Fixture creating the config file for the end-to-end test."""
+
+    # The config.
+    #
+    # The weird value for "url" here gets around playhouse.db_url not
+    # url-decoding the netloc of the supplied URL.  The netloc is used
+    # as the "database" value, so to get the URI in there, we need to pass
+    # it as a parameter, which WILL get urldecoded and supercede the empty
+    # netloc.
+    config = {
+        "base": {"hostname": hostname},
+        "database": {"url": "sqlite:///?database=" + urlquote(DB_URI) + "&uri=true"},
+        "service": {"num_workers": 4},
+    }
+
+    # Put it in a file
+    xfs.create_file("/etc/alpenhorn/alpenhorn.conf", contents=yaml.dump(config))
+
+
+def test_cli(e2e_db, e2e_config, loop_once):
+    runner = CliRunner()
+
+    result = runner.invoke(cli, catch_exceptions=False)
+
+    assert result.exit_code == 0

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -13,7 +13,7 @@ def test_schema(dbproxy, simplenode):
 
 def test_group_model(storagegroup):
     storagegroup(name="min")
-    storagegroup(name="max", notes="Notes")
+    storagegroup(name="max", io_class="IOClass", io_config="{ioconfig}", notes="Notes")
 
     # name is unique
     with pytest.raises(pw.IntegrityError):
@@ -23,11 +23,15 @@ def test_group_model(storagegroup):
     assert StorageGroup.select().where(StorageGroup.name == "min").dicts().get() == {
         "id": 1,
         "name": "min",
+        "io_class": None,
+        "io_config": None,
         "notes": None,
     }
     assert StorageGroup.select().where(StorageGroup.name == "max").dicts().get() == {
         "id": 2,
         "name": "max",
+        "io_class": "IOClass",
+        "io_config": "{ioconfig}",
         "notes": "Notes",
     }
 
@@ -44,6 +48,8 @@ def test_storage_model(storagegroup, storagenode):
         avail_gb=2.2,
         avail_gb_last_checked=3.3,
         host="host.host",
+        io_class="IOClass",
+        io_config="{ioconfig}",
         max_total_gb=4.4,
         min_avail_gb=5.5,
         notes="Notes",
@@ -67,6 +73,8 @@ def test_storage_model(storagegroup, storagenode):
         "avail_gb": None,
         "avail_gb_last_checked": None,
         "host": None,
+        "io_class": None,
+        "io_config": None,
         "max_total_gb": None,
         "min_avail_gb": 0,
         "notes": None,
@@ -85,6 +93,8 @@ def test_storage_model(storagegroup, storagenode):
         "avail_gb": 2.2,
         "avail_gb_last_checked": 3.3,
         "host": "host.host",
+        "io_class": "IOClass",
+        "io_config": "{ioconfig}",
         "max_total_gb": 4.4,
         "min_avail_gb": 5.5,
         "notes": "Notes",

--- a/tests/test_update_group.py
+++ b/tests/test_update_group.py
@@ -1,0 +1,27 @@
+"""Tests for UpdateableGroup."""
+
+
+def test_group_idle(queue, mockgroupandnode):
+    """Test DefaultGroupIO.idle."""
+    mockio, group, node = mockgroupandnode
+
+    # Currently idle
+    assert group.idle is True
+
+    # Enqueue something into this node's queue
+    queue.put(None, node.name)
+
+    # Now not idle
+    assert group.idle is False
+
+    # Dequeue it
+    task, key = queue.get()
+
+    # Still not idle, because task is in-progress
+    assert group.idle is False
+
+    # Finish the task
+    queue.task_done(node.name)
+
+    # Now idle again
+    assert group.idle is True

--- a/tests/test_update_node.py
+++ b/tests/test_update_node.py
@@ -1,0 +1,119 @@
+"""Tests for UpdateableNode."""
+
+import pytest
+
+from alpenhorn.storage import StorageNode
+from alpenhorn.update import UpdateableNode
+
+
+def test_bad_ioclass(simplenode):
+    """A missing I/O class is a problem."""
+
+    simplenode.io_class = "Missing"
+    with pytest.raises(ModuleNotFoundError):
+        UpdateableNode(None, simplenode)
+
+    simplenode.io_class = "alpenhorn.update.Missing"
+    with pytest.raises(ImportError):
+        UpdateableNode(None, simplenode)
+
+
+def test_reinit(storagenode, simplegroup, queue):
+    """Test UpdateableNode.reinit."""
+
+    # Create a node
+    stnode = storagenode(name="node", group=simplegroup)
+    node = UpdateableNode(queue, stnode)
+
+    # No I/O re-init
+    stnode = StorageNode.get(id=stnode.id)
+    assert stnode is not node.db
+    io = node.io
+    assert not node.reinit(stnode)
+    assert io is node.io
+
+    # But storagenode is updated
+    assert stnode is node.db
+
+    # Also no I/O re-init
+    stnode = StorageNode.get(id=stnode.id)
+    assert stnode is not node.db
+    stnode.avail_gb = 3
+    stnode.save()
+    io = node.io
+    assert not node.reinit(stnode)
+    assert io is node.io
+    assert stnode is node.db
+
+    # Changing io_config forces re-init
+    stnode = StorageNode.get(id=stnode.id)
+    assert stnode is not node.db
+    stnode.io_config = "{}"
+    stnode.save()
+    assert node.reinit(stnode)
+    assert io is not node.io
+    assert stnode is node.db
+
+    # Changing io_class forces re-init
+    stnode = StorageNode.get(id=stnode.id)
+    assert stnode is not node.db
+    stnode.io_class = "Default"
+    stnode.save()
+    io = node.io
+    assert node.reinit(stnode)
+    assert io is not node.io
+    assert stnode is node.db
+
+    # Changing id forces re-init
+    #
+    # Alpenhornd indexes UpdateabelNodes by node name, so this would happen if
+    # StorageNode records have their names swapped around somehow, though we
+    # don't need to do that in this test
+    stnode = storagenode(
+        name="node2",
+        group=simplegroup,
+        io_class=stnode.io_class,
+        io_config=stnode.io_config,
+    )
+    assert stnode is not node.db
+    io = node.io
+    assert node.reinit(stnode)
+    assert io is not node.io
+    assert stnode is node.db
+
+
+def test_bad_ioconfig(simplenode):
+    """io_config not resolving to a dict is an error."""
+    simplenode.io_config = "true"
+
+    with pytest.raises(ValueError):
+        UpdateableNode(None, simplenode)
+
+    # But this is fine
+    simplenode.io_config = "{}"
+    UpdateableNode(None, simplenode)
+
+
+def test_idle(unode, queue):
+    """Test UpdateableNode.idle"""
+
+    # Currently idle
+    assert unode.idle is True
+
+    # Enqueue something into this node's queue
+    queue.put(None, unode.name)
+
+    # Now not idle
+    assert unode.idle is False
+
+    # Dequeue it
+    task, key = queue.get()
+
+    # Still not idle, because task is in-progress
+    assert unode.idle is False
+
+    # Finish the task
+    queue.task_done(unode.name)
+
+    # Now idle again
+    assert unode.idle is True

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 """alpenhorn.util tests."""
+import pytest
 
 from alpenhorn import util
 
@@ -14,3 +15,22 @@ def test_gethostname_default():
     host = util.get_hostname()
     assert "." not in host
     assert len(host) > 0
+
+
+def test_pretty_deltat():
+    """Test util.pretty_deltat."""
+
+    with pytest.raises(TypeError):
+        util.pretty_deltat(None)
+
+    assert util.pretty_deltat(1234567) == "342h56m07s"
+    assert util.pretty_deltat(123456) == "34h17m36s"
+    assert util.pretty_deltat(12345) == "3h25m45s"
+    assert util.pretty_deltat(1234) == "20m34s"
+    assert util.pretty_deltat(123) == "2m03s"
+    assert util.pretty_deltat(12) == "12.0s"
+    assert util.pretty_deltat(1) == "1.0s"
+    assert util.pretty_deltat(0.1) == "0.1s"
+    assert util.pretty_deltat(0.01) == "0.0s"
+    assert util.pretty_deltat(0) == "0.0s"
+    assert util.pretty_deltat(-1) == "-1.0s"


### PR DESCRIPTION
This PR introduces the I/O framework for `StorageNode`s and `StorageGroup`s, although none of the actual I/O is implemented in this PR.  It also rewrites the daemon main loop to integrate the queue, workers, and new I/O framework, although, again, the existing I/O is left as-is for now and does not make use of the new asynchronous task structure.

## StorageNode and StorageGroup I/O framework
This PR adds two new optional (i.e. null-allowing) string fields to both `StorageGroup` and `StorageNode`:
* `io_class` which provides the name of the I/O class for a node/group.  Node and group I/O classes are separate, and a the list of valid names is different for each.  If this field is left empty, it is treated as if it had the value `Default`.
* `io_config` which provides a JSON blob of configuration data, if any, to be interpreted by the I/O class.  The Default I/O classes ignore this field, but others (like Nearline) will require certain data.

The I/O classes can be found in the `alpenhorn/io` directory, although it's pretty barren for the moment:
*  The base I/O classes, which don't actually do any I/O, are in the file `base.py`.  `"base"` cannot be used for the `io_class` property.  (I mean, the field _can_ be set to that value, but it won't work, because `base.py` and the classes `BaseNodeIO` and `BaseGroupIO` have different capitalisation.)
* The Default I/O class, which is what you get if you leave `io_class` empty, is implemented in `Default.py`.  But for now, it's just a re-class of the classes in `base.py` to make I/O class instantiation work properly in the tests.  The `DefaultNodeIO` class is for a "standard" POSIX filesystem.  The `DefaultGroupIO` class is for a simple StorageGroup with only one node in it.

In general, there is no requirement that a group of a given type be populated with nodes of the same type.  The `DefaultGroupIO` class, for instance, doesn't care at all what the `io_class` of its constituent node is.   (There can be exceptions: `NearlineGroupIO` class needs a `NearlineNodeIO` node in it.) Some I/O classes implement only one of Group or Node I/O.

## UpdateableNode and UpdateableGroup
The I/O class for a Storage object is managed by a new pair of classes defined in `update.py`: `UpdateableNode` and `UpdateableGroup`.  These are primarily container classes for a Storage object and it's I/O class instance.  They provide access to both objects for the update code.

These Updateable instances persist through update loops when possible.  A node or group going away will cause the Updatable instance being destroyed.  The Storage object they contain are replaced ever loop (because new Storage objects are created as a side effect of querying the database for the list of current nodes).  I/O instances are only re-instanced between loops if the Storage object's `id`, `io_config` or `io_class` change.

`UpdateableNode` subsumes the old top-level functions in `update.py` for updating nodes (so, e.g. `update_node()` is now `UpdateableNode.update()`.

## Daemon start-up and main loop rewrite
This PR updates the daemon for the db changes in #144, and ties in the new functionality of the task queue (#145) and the worker pool (#146).

The daemon start-up now has the necessary `db.init()` call, and also now instantiates the queue and worker pool in preparation for multithreading (although there are no actual tasks yet being used in this update).  The initial number of workers to start has been added to the `service` section of the alpenhorn config.

The main loop has been re-written for the new I/O framework. A single iteration of main loop looks like this:


**The I/O update:**
* query the database for the list of active nodes on the host
* (re-)instantiate all the I/O classes for the active nodes
* Loop over nodes:
  * check if the node is actually active on the host (`update_node_active`).  If it isn't forget about this node.
  * check the queue to determine whether this node is idle at the start of the loop, or if it still has on-going I/O from a previous iteration.  (If it isn't idle, it's not going to be updated this time through the loop).
  * build up a list of active groups on the host (by finding unique values of `node.group`).
  * Call the I/O layer `before_update` hook.  This function may also cancel the node update for this time through the loop
  * If the node was idle at the start of the loop _and_ the `before_update` hook didn't cancel the update, do all the normal node I/O updates (delete/check/&c.)
* Loop over groups:
  * As with nodes, call the I/O layer `before_update` hook.  This function may also cancel the group update for this time through the loop
  * If all nodes in the group were idle at the start of the loop _and_ the `before_update` hook didn't cancel the update, do all the normal group I/O updates
* This is the end of the "regular I/O" update.
* If node or groups were idle at the end of the regular update, run low-priority "idle updates" on them.  This is going to be stuff like re-checking files on Nearline to see if the restored/released state saved in the DB is correct.
* Finally, run the I/O layer `after_update` hook on groups and then nodes.

**Housekeeping in the main loop:**
After all the I/O updates are complete for one iteration of the loop, several housekeeping tasks are performed each update loop:
* the worker pool scans for cleanly-exited workers (due to `peewee.OperationalError`) and restarts them
* If there are no workers in the pool, some time is spent executing I/O tasks in the main loop (see `serial_io()`).  This allows alpenhorn to fall-back to the non-multithreaded update system whenever it happens to have no workers to execute I/O tasks. (including when using a non-threadsafe DB, which will force the worker pool to be empty).
* The sleep at the bottom of the loop will now wake up early if a `global_abort` is triggered by a worker thread.

This rewrite of the main loop is essentially complete.  A few, relatively small, changes will happen in a future PR when the `auto_import` module is updated.  Additionally, most of the I/O update code in `update.py` will be moved into the I/O classes.

## Broken by this PR
This PR comments out all the actual I/O updates in the main loop so that I can run tests on the framework.  This will be resolved in the later DefaultIO PRs (#150 et seqq.)

## An afterthought
I think this is sufficient to declare this PR closes #60 