### PR TITLE
Rewrite 7/14: DefaultIO housekeeping + integrity check

### DIFF
--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -1,0 +1,70 @@
+"""DefaultIO asyncs (functions that run asynchronously in tasks)."""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import logging
+
+if TYPE_CHECKING:
+    from .base import BaseNodeIO
+    from ..archive import ArchiveFileCopy
+    from ..task import Task
+
+log = logging.getLogger(__name__)
+
+
+def check_async(task: Task, io: BaseNodeIO, copy: ArchiveFileCopy) -> None:
+    """Check a file copy.  This is asynchronous.
+
+    First checks for a size mismatch.  If that's okay, then will
+    calculat the MD5 hash of the file copy.
+
+    Updates `copy.has_file` based on the result of the check to one of:
+    - 'Y': file is not corrupt
+    - 'X': file is corrupt
+    - 'N': file is missing
+
+    Parameters
+    ----------
+    task : Task
+        The task instance containing this async.
+    io : Node I/O instance
+        The I/O instance on which the file copy lives
+    copy : ArchiveFileCopy
+        The copy to check
+    """
+
+    copyname = copy.file.path
+    fullpath = copy.path
+
+    # Does the copy exist?
+    if fullpath.exists():
+        # First check the size
+        size = fullpath.stat().st_size
+        if copy.file.size_b and size != copy.file.size_b:
+            log.error(
+                f"File {copyname} on node {io.node.name} is corrupt! "
+                f"Size: {size}; expected: {copy.file.size_b}"
+            )
+            copy.has_file = "X"
+        else:
+            # If size is okay, check MD5 sum
+            md5sum = io.md5(fullpath)
+            if md5sum == copy.file.md5sum:
+                log.info(f"File {copyname} on node {io.node.name} is A-OK!")
+                copy.has_file = "Y"
+                copy.size_b = io.filesize(fullpath, actual=True)
+            else:
+                log.error(
+                    f"File {copyname} on node {io.node.name} is corrupt! "
+                    f"MD5: {md5sum}; expected: {copy.file.md5sum}"
+                )
+                copy.has_file = "X"
+    else:
+        log.error(f"File {copyname} on node {io.node.name} is missing!")
+        copy.has_file = "N"
+
+    # Update the copy status
+    log.info(
+        f"Updating file copy #{copy.id} for file {copyname} on node {io.node.name}."
+    )
+    copy.save()

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -10,11 +10,19 @@ has the value "Default").
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
+import os
 import logging
+import pathlib
 
+from .. import util
 from .base import BaseNodeIO, BaseGroupIO
+from ..task import Task
+
+# The asyncs are over here:
+from ._default_asyncs import check_async
 
 if TYPE_CHECKING:
+    from ..archive import ArchiveFileCopy
     from ..update import UpdateableNode
 
 log = logging.getLogger(__name__)
@@ -22,6 +30,121 @@ log = logging.getLogger(__name__)
 
 class DefaultNodeIO(BaseNodeIO):
     """A simple StorageNode backed by a regular POSIX filesystem."""
+
+    # I/O METHODS
+
+    def bytes_avail(self, fast: bool = False) -> int | None:
+        """bytes_avail: Return amount of free space (in bytes) of the node, or
+        None if that cannot be determined.
+
+        Does not account for space reserved via reserve_bytes().
+
+        Parameters
+        ----------
+        fast : bool
+            If True, then this is a fast call, and I/O classes for which
+            checking available space is expensive may skip it by returning None.
+
+        Returns
+        -------
+        bytes_avail : int or None
+            the total bytes available on the storage system, or None if that
+            can't be or wasn't determined.
+        """
+        x = os.statvfs(self.node.root)
+        return x.f_bavail * x.f_bsize
+
+    def check(self, copy: ArchiveFileCopy) -> None:
+        """Check whether ArchiveFileCopy `copy` is corrupt.
+
+        Does nothing other than queue a `check_async` task.
+
+        Parameters
+        ----------
+        copy : ArchiveFileCopy
+            the file copy to check
+        """
+
+        Task(
+            func=check_async,
+            queue=self._queue,
+            key=self.node.name,
+            args=(self, copy),
+            name=f"Check copy#{copy.id} on {self.node.name}",
+        )
+
+    def check_active(self) -> bool:
+        """Check that this is an active node.
+
+        Checks that the file `node.root`/ALPENHORN_NODE exists and
+        contains the name of the node.
+
+        Returns
+        -------
+        active : bool
+            True if the `ALPENHORN_NODE` check succeeded;
+            False otherwise.
+        """
+
+        file_path = pathlib.Path(self.node.root, "ALPENHORN_NODE")
+        try:
+            with open(file_path, "r") as f:
+                first_line = f.readline()
+                # Check if the actual node name is in the textfile
+                if self.node.name == first_line.rstrip():
+                    # Great! Everything is as expected.
+                    return True
+                log.warning(
+                    f"Node name in file {file_path} does not match expected: "
+                    f"{self.node.name}."
+                )
+        except IOError:
+            log.warning(f"Node file {file_path} could not be read.")
+
+        return False
+
+    def filesize(self, path: pathlib.Path, actual: bool = False) -> int:
+        """Return size in bytes of the file given by `path`.
+
+        Parameters
+        ----------
+        path: path-like
+            The filepath to check the size of.  May be absolute or relative
+            to `node.root`.
+        actual: bool, optional
+            If True, return the amount of space the file actually takes
+            up on the storage system.  Otherwise return apparent size.
+        """
+        path = pathlib.Path(path)
+        if not path.is_absolute():
+            path = pathlib.Path(self.node.root, path)
+
+        if actual:
+            # Per POSIX, blocksize for st_blocks is always 512 bytes
+            return path.stat().st_blocks * 512
+
+        # Apparent size
+        return path.stat().st_size
+
+    def md5(self, path: str | pathlib.Path, *segments) -> str:
+        """Compute the MD5 hash of the file at the specified path.
+
+        This can take a long time: call it from an async.
+
+        Parameters
+        ----------
+        path : PathLike
+            path (or first part of the, path if other `segments` provided) to
+            the file to hash.  Relative to `node.root`.
+        *segments : iterable, optional
+            other path segments path-concatenated and appended to `path`.
+
+        Returns
+        -------
+        md5sum : str
+            the base64-encoded MD5 hash value
+        """
+        return util.md5sum_file(pathlib.Path(self.node.root, path, *segments))
 
 
 class DefaultGroupIO(BaseGroupIO):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,8 @@ def set_config(request):
     # Reset globals
     config.config = None
     extensions._db_ext = None
-    extensions._ext = None
+    extensions._id_ext = None
+    extensions._io_ext = dict()
 
 
 @pytest.fixture
@@ -224,13 +225,13 @@ def mockio():
     # This is our mock I/O module
     class MockIO:
         # The I/O "classes"
-        def NodeIO(*args, **kwargs):
+        def MockNodeIO(*args, **kwargs):
             nonlocal node
             node._instance_args = args
             node._instance_kwargs = kwargs
             return node
 
-        def GroupIO(*args, **kwargs):
+        def MockGroupIO(*args, **kwargs):
             nonlocal group
             group._instance_args = args
             node._instance_kwargs = kwargs
@@ -239,8 +240,8 @@ def mockio():
     MockIO.node = node
     MockIO.group = group
 
-    # Patch sys.modules so import can find our module.
-    with patch.dict("sys.modules", MockIO=MockIO):
+    # Patch extensions._io_ext so alpenhorn can find our module
+    with patch.dict("alpenhorn.extensions._io_ext", mock=MockIO):
         yield MockIO
 
 
@@ -251,14 +252,14 @@ def mockgroupandnode(hostname, queue, storagenode, storagegroup, mockio):
     Yields the group and node.
     """
 
-    stgroup = storagegroup(name="mockgroup", io_class="MockIO.GroupIO")
+    stgroup = storagegroup(name="mockgroup", io_class="Mock")
     stnode = storagenode(
         name="mocknode",
         group=stgroup,
         root="/mocknode",
         host=hostname,
         active=True,
-        io_class="MockIO.NodeIO",
+        io_class="Mock",
     )
 
     # Fix set_nodes

--- a/tests/io/test_defaultnode.py
+++ b/tests/io/test_defaultnode.py
@@ -1,0 +1,48 @@
+"""Test DefaultNodeIO."""
+
+
+def test_bytes_avail(xfs, unode):
+    """test DefaultNodeIO.bytes_avail()"""
+
+    # Set disk size
+    xfs.create_dir("/node")
+    xfs.set_disk_usage(10000)
+
+    assert unode.io.bytes_avail() == 10000.0
+
+
+def test_check_active(xfs, unode):
+    """test DefaultNodeIO.check_active()"""
+
+    assert unode.io.check_active() is False
+
+    xfs.create_file("/node/ALPENHORN_NODE", contents="not-node")
+    assert unode.io.check_active() is False
+
+    with open("/node/ALPENHORN_NODE", mode="w") as f:
+        f.write("simplenode")
+    assert unode.io.check_active() is True
+
+
+def test_filesize(unode, xfs):
+    """test DefaultNodeIO.filesize()"""
+    xfs.create_file("/node/dir/file1", st_size=1000)
+
+    assert unode.io.filesize("dir/file1") == 1000
+    assert unode.io.filesize("/node/dir/file1") == 1000
+    assert unode.io.filesize("/node/dir/file1", actual=True) == 1024
+    assert unode.io.filesize("dir/file1", actual=True) == 1024
+
+
+def test_md5(unode, xfs):
+    """test DefaultNodeIO.md5()"""
+    xfs.create_file("/node/dir/file1")
+
+    # d41...27e is the MD5sum of nothing (i.e. the zero-length message)
+    assert unode.io.md5("dir", "file1") == "d41d8cd98f00b204e9800998ecf8427e"
+
+    # Something slightly less trivial
+    xfs.create_file(
+        "/node/dir/file2", contents="The quick brown fox jumps over the lazy dog"
+    )
+    assert unode.io.md5("dir/file2") == "9e107d9d372bb6826bd81d3542a419d6"

--- a/tests/io/test_defaultnode_check.py
+++ b/tests/io/test_defaultnode_check.py
@@ -1,0 +1,98 @@
+"""Test DefaultNodeIO.check()."""
+
+from alpenhorn.archive import ArchiveFileCopy
+
+
+def test_check_size(xfs, queue, simpleacq, archivefile, unode, archivefilecopy):
+    """Test check async with wrong size."""
+
+    file = archivefile(
+        name="file",
+        acq=simpleacq,
+        size_b=6,
+        md5sum="9e107d9d372bb6826bd81d3542a419d6",
+    )
+    copy = archivefilecopy(file=file, node=unode.db, has_file="M")
+
+    xfs.create_file(copy.path, contents="The quick brown fox jumps over the lazy dog")
+
+    # queue
+    unode.io.check(copy)
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Copy is now corrupt.
+    assert ArchiveFileCopy.get(file=file, node=unode.db).has_file == "X"
+
+
+def test_check_md5sum_good(xfs, queue, simpleacq, archivefile, unode, archivefilecopy):
+    """Test check async with good md5sum."""
+
+    file = archivefile(
+        name="file",
+        acq=simpleacq,
+        size_b=43,
+        md5sum="9e107d9d372bb6826bd81d3542a419d6",
+    )
+    copy = archivefilecopy(file=file, node=unode.db, has_file="M")
+
+    xfs.create_file(copy.path, contents="The quick brown fox jumps over the lazy dog")
+
+    # queue
+    unode.io.check(copy)
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Copy is now okay.
+    assert ArchiveFileCopy.get(file=file, node=unode.db).has_file == "Y"
+
+
+def test_check_md5sum_bad(xfs, queue, simpleacq, archivefile, unode, archivefilecopy):
+    """Test check async with bad md5sum."""
+
+    file = archivefile(name="file", acq=simpleacq, size_b=43, md5sum="incorrect-md5")
+    copy = archivefilecopy(file=file, node=unode.db, has_file="M")
+
+    xfs.create_file(copy.path, contents="The quick brown fox jumps over the lazy dog")
+
+    # queue
+    unode.io.check(copy)
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Copy is now corrupt.
+    assert ArchiveFileCopy.get(file=file, node=unode.db).has_file == "X"
+
+
+def test_check_missing(xfs, queue, simpleacq, archivefile, unode, archivefilecopy):
+    """Test check async with missing file."""
+
+    file = archivefile(
+        name="file",
+        acq=simpleacq,
+        size_b=43,
+        md5sum="9e107d9d372bb6826bd81d3542a419d6",
+    )
+    copy = archivefilecopy(file=file, node=unode.db, has_file="M")
+
+    xfs.create_dir(copy.path.parent)
+
+    # queue
+    unode.io.check(copy)
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Copy is now gone.
+    assert ArchiveFileCopy.get(file=file, node=unode.db).has_file == "N"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,6 +2,7 @@
 
 import pytest
 import pathlib
+import datetime
 import peewee as pw
 
 from alpenhorn.storage import StorageGroup, StorageNode
@@ -292,3 +293,23 @@ def test_allfiles(simplenode, simpleacq, archivefile, archivefilecopy):
     assert simplenode.get_all_files() == set(
         [pathlib.PurePath(simpleacq.name, "file2")]
     )
+
+
+def test_update_avail_gb(simplenode):
+    """test StorageNode.update_avail_gb()"""
+
+    # The test node initially doesn't have this set
+    assert simplenode.avail_gb is None
+
+    # Test a number
+    start = datetime.datetime.now()
+    simplenode.update_avail_gb(10000)
+    # Now the value is set
+    node = StorageNode.get(id=simplenode.id)
+
+    assert node.avail_gb == 10000.0 / 2.0**30
+    assert node.avail_gb_last_checked >= start
+
+    # Test None
+    simplenode.update_avail_gb(None)
+    assert StorageNode.get(id=simplenode.id).avail_gb is None

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,17 @@ import pytest
 from alpenhorn import util
 
 
+def test_md5sum_file(tmp_path):
+    """Test util.md5sum_file"""
+
+    file = tmp_path.joinpath("tmp")
+    file.write_text("")
+    assert util.md5sum_file(file) == "d41d8cd98f00b204e9800998ecf8427e"
+
+    file.write_text("The quick brown fox jumps over the lazy dog")
+    assert util.md5sum_file(file) == "9e107d9d372bb6826bd81d3542a419d6"
+
+
 def test_gethostname_config(hostname):
     """Test util.get_hostname with config"""
 
@@ -15,6 +26,42 @@ def test_gethostname_default():
     host = util.get_hostname()
     assert "." not in host
     assert len(host) > 0
+
+
+def test_pretty_bytes():
+    """Test util.pretty_bytes."""
+    with pytest.raises(ValueError):
+        util.pretty_bytes(-1)
+
+    with pytest.raises(TypeError):
+        util.pretty_bytes(None)
+
+    # This is an overflow
+    assert util.pretty_bytes(1234567890123456789012) == "1234567890123456789012 B"
+
+    # Regular behaviour
+    assert util.pretty_bytes(123456789012345678901) == "107.1 EiB"
+    assert util.pretty_bytes(12345678901234567890) == "10.7 EiB"
+    assert util.pretty_bytes(1234567890123456789) == "1.1 EiB"
+    assert util.pretty_bytes(123456789012345678) == "109.7 PiB"
+    assert util.pretty_bytes(12345678901234567) == "11.0 PiB"
+    assert util.pretty_bytes(1234567890123456) == "1.1 PiB"
+    assert util.pretty_bytes(123456789012345) == "112.3 TiB"
+    assert util.pretty_bytes(12345678901234) == "11.2 TiB"
+    assert util.pretty_bytes(1234567890123) == "1.1 TiB"
+    assert util.pretty_bytes(123456789012) == "115.0 GiB"
+    assert util.pretty_bytes(12345678901) == "11.5 GiB"
+    assert util.pretty_bytes(1234567890) == "1.1 GiB"
+    assert util.pretty_bytes(123456789) == "117.7 MiB"
+    assert util.pretty_bytes(12345678) == "11.8 MiB"
+    assert util.pretty_bytes(1234567) == "1.2 MiB"
+    assert util.pretty_bytes(123456) == "120.6 kiB"
+    assert util.pretty_bytes(12345) == "12.1 kiB"
+    assert util.pretty_bytes(1234) == "1.2 kiB"
+    assert util.pretty_bytes(123) == "123 B"
+    assert util.pretty_bytes(12) == "12 B"
+    assert util.pretty_bytes(1) == "1 B"
+    assert util.pretty_bytes(0) == "0 B"
 
 
 def test_pretty_deltat():


### PR DESCRIPTION
_This is the first of four PRs to move I/O operations to the `DefaultIO` framework._

## Overview

Three parts of the update loop are handled here:
* node check (checking for the `ALPENHORN_NODE` file).
* free space update
* integrity check of file copies with `has_file=='M'`

Also, I've made a change to the way third-party I/O classes are loaded; see the following section.

## I/O module loading

Following discussion with Richard, this PR modifies how third-party I/O modules are found by alpenhorn from the behaviour originally introduced in Rewrite part 5/14 (#148).

The old behaviour was to simply have the full import path given in, say, `StorageNode.io_class`.  Instead of doing that, this PR introduces a new extension type called "io-module" which extensions should use to provide alpenhorn with third-party I/O modules.   The benefit here is all I/O modules are imported at start-up, rather than the first time alpenhorn sees a particular storage object.

The value associated with the "io-modules" key returned by `register_extensions` is a dictionary whose keys are I/O module names and whose values are the modules themselves.  The third-party modules may not have names that duplicate any of the internal modules in `alpenhorn.io`, nor may multiple extensions provide modules with the same name.

The module name must follow the convention that the internal modules use: if there is a node or group with `io_class` equal to, say, `MyCustomIO`, then there must be an I/O module with name (=dict key) `mycustomio` (i.e. lowercased-version) and that I/O module must define the class `MyCustomIONodeIO` or `MyCustomIOGroupIO` as appropriate.

The prior behaviour of allowing a full import path in the `io_class` column is no longer allowed.

A missing I/O class at runtime is not fatal: if that happens, `alpenhornd` will report an error in the log and act as if the node or group that requested the I/O class is not active (i.e. the affected node/group is ignored during the update loop).  Because an attempt at I/O class instantiation happens every time through the loop, the error message about the missing class will be repeated each time through the loop.  This is intentional, to make it clear to operators why the node/group is not being updated.

## Node check

This is a relatively minor change.  The function `util.alpenhorn_node_check` becomes the I/O method `node.io.check_avail` (i.e. `DefaultNodeIO.check_avail`) but is essentially unchanged and is called in the same place in `update.update_node_active`.

## Free space

The outer function, `update.update_node_free_space` is moved to `util.update_avail_gb` because it will be called from other places beside the main loop in the future.  The function is changed to call `node.io.bytes_avail` where the actual stat occurs to fetch the amount of free space.

This PR also adds a boolean parameter `fast` to `update_avail_gb` which is passed on to `node.io.bytes_avail`.  The invocation of `update_avail_gb` from the main loop has `fast=False`, but the other invocations will have `fast=True`.  This boolean will allow I/O modules for which finding the free space is slow to skip the optional `fast=True` invocations.

The code also permits `node.io.bytes_avail` to return `None`, meaning the free space couldn't be determined (or doesn't make sense).

## Integrity check

Running the integrity check is the first asynchronous task added to this rewrite (the function `check_async`).  The asynchronous part of the check is put in `alpenhorn/io/_default_asyncs.py`, mostly for tidiness and to keep the size of `Default.py` manageable.

The integrity check is as follows:
* Does the file exist?  If not set `has_file='N'` and we're done.
* Next, is the file size correct?  If not set `has_file='X'` and we're done.  This is a new step for this PR which avoids having to calculate the MD5 hash in some instances.
* Calculate the MD5 and check it against the DB to determine `has_file='Y'` or `has_file='X'`

## Other changes
* The unused function `util.is_md5_hash` is deleted.
* The parameter `cmd_line` is removed from `util.md5sum_file`.  It was never set to anything other than the default.  Removing it removes an unnecessary dependency on an external program.