### PR TITLE
Rewrite 8/14: DefaultIO file deletion

### DIFF
--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -2,11 +2,13 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
+import errno
 import logging
+
+from ..archive import ArchiveFileCopy
 
 if TYPE_CHECKING:
     from .base import BaseNodeIO
-    from ..archive import ArchiveFileCopy
     from ..task import Task
 
 log = logging.getLogger(__name__)
@@ -68,3 +70,81 @@ def check_async(task: Task, io: BaseNodeIO, copy: ArchiveFileCopy) -> None:
         f"Updating file copy #{copy.id} for file {copyname} on node {io.node.name}."
     )
     copy.save()
+
+
+def delete_async(task: Task, copies: list[ArchiveFileCopy]) -> None:
+    """Delete some file copies, if possible.
+
+    Copies are only deleted if sufficient archived copies exist
+    elsewhere.  If there aren't sufficient copies, the deletion doesn't
+    happen, but the request to delete isn't resolved (so a future
+    update loop will again try to delete the copy).
+
+    Parameters
+    ----------
+    task : Task
+        The task instance containing this async.
+    copies : list of ArchiveFileCopy
+        The list of copies to delete.  Never empty.
+    """
+
+    # Node name
+    name = copies[0].node.name
+
+    # The number archive copies needed to delete a copy.
+    # Need at least two _other_ copies to be able to delete a file.
+    copies_required = 3 if copies[0].node.archive else 2
+
+    # Process candidates for deletion
+    for copy in copies:
+        shortname = copy.file.path
+
+        # Archived count
+        ncopies = copy.file.archive_count
+
+        # If at least two _other_ copies exist, we can delete the file.
+        if ncopies < copies_required:
+            log.warning(
+                f"Too few archive copies ({ncopies}) "
+                f"to delete {shortname} on {name}."
+            )
+            continue  # Skip this one
+
+        fullpath = copy.path
+        try:
+            fullpath.unlink()  # Remove the actual file
+            log.info(f"Removed file copy {shortname} on {name}")
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                # Already deleted, which is not a problem.
+                log.info(f"File copy {shortname} missing on {name} during delete")
+            else:
+                log.warning(f"Error deleting {shortname}: {e}")
+                continue  # Welp, that didn't work
+
+        # Check if any containing directory is now empty
+        # and remove if they are.
+        dirname = fullpath.parent
+
+        # try to delete the directories.
+        while dirname != ".":
+            try:
+                dirname.rmdir()
+                log.info(f"Removed directory {dirname} on {name}")
+            except OSError as e:
+                if e.errno == errno.ENOTEMPTY:
+                    # This is fine, but stop trying to rmdir.
+                    break
+                elif e.errno == errno.ENOENT:
+                    # Already deleted, which is fine.
+                    pass
+                else:
+                    log.warning(f"Error deleting directory {dirname} on {name}: {e}")
+                    # Otherwise, let's try to soldier on
+
+            dirname = dirname.parent
+
+        # Update the DB
+        ArchiveFileCopy.update(has_file="N", wants_file="N").where(
+            ArchiveFileCopy.id == copy.id
+        ).execute()

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -159,6 +159,16 @@ class BaseNodeIO:
         assume the database is correct), which is the default behaviour."""
         return self.node.active
 
+    def delete(self, copies: list[ArchiveFileCopy]) -> None:
+        """Delete the ArchiveFileCopy list `copies` from the node.
+
+        Parameters
+        ----------
+        copies : list of ArchiveFileCopy
+            The list of copies to delete.  May be empty.
+        """
+        raise NotImplementedError("method must be re-implemented in subclass.")
+
     def filesize(self, path: pathlib.Path, actual: bool = False) -> int:
         """Return size in bytes of the file given by `path`.
 

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -19,7 +19,7 @@ from .base import BaseNodeIO, BaseGroupIO
 from ..task import Task
 
 # The asyncs are over here:
-from ._default_asyncs import check_async
+from ._default_asyncs import check_async, delete_async
 
 if TYPE_CHECKING:
     from ..archive import ArchiveFileCopy
@@ -102,6 +102,23 @@ class DefaultNodeIO(BaseNodeIO):
             log.warning(f"Node file {file_path} could not be read.")
 
         return False
+
+    def delete(self, copies: list[ArchiveFileCopy]) -> None:
+        """Queue a single asynchronous I/O task to delete the list of file copies."""
+
+        # Nothing to do
+        if len(copies) == 0:
+            return
+
+        Task(
+            func=delete_async,
+            queue=self._queue,
+            key=self.node.name,
+            args=(copies,),
+            name="Delete copies "
+            + str([copy.id for copy in copies])
+            + f" from {self.node.name}",
+        )
 
     def filesize(self, path: pathlib.Path, actual: bool = False) -> int:
         """Return size in bytes of the file given by `path`.

--- a/tests/io/test_defaultnode_delete.py
+++ b/tests/io/test_defaultnode_delete.py
@@ -1,0 +1,218 @@
+"""Test DefaultNodeIO.delete()."""
+
+import pytest
+import pathlib
+from unittest.mock import patch
+
+from alpenhorn.archive import ArchiveFileCopy
+from alpenhorn.io._default_asyncs import delete_async
+
+
+@pytest.fixture
+def mock_archive_count():
+    """Mock ArchiveFile.archive_count to return a number big enough to allow deletion."""
+
+    @property
+    def _mock_archive_count(self):
+        return 6
+
+    with patch("alpenhorn.archive.ArchiveFile.archive_count", _mock_archive_count):
+        yield
+
+
+def test_zero_len(queue, unode):
+    """Test doing nothing when given nothing."""
+
+    unode.io.delete([])
+
+    assert queue.qsize == 0
+
+
+def test_ncopies(
+    xfs,
+    queue,
+    unode,
+    simplegroup,
+    storagenode,
+    simpleacq,
+    archivefile,
+    archivefilecopy,
+    storage_type="F",
+):
+    """Test not deleting from non-archival node when there are not enough other copies of the file."""
+
+    # Need to make the containing directory
+    xfs.create_dir("/node/simpleacq")
+
+    unode.db.storage_type = storage_type
+    unode.db.save()
+
+    arc1 = storagenode(name="arc1", group=simplegroup, root="/arc1", storage_type="A")
+    arc2 = storagenode(name="arc2", group=simplegroup, root="/arc2", storage_type="A")
+
+    # Can't be deleted from node: only one archive copy
+    file1 = archivefile(name="file1", acq=simpleacq)
+    copy1 = archivefilecopy(file=file1, node=unode.db, has_file="Y")
+    archivefilecopy(file=file1, node=arc1, has_file="Y")
+
+    # Can't be deleted from node: only one archive copy
+    file2 = archivefile(name="file2", acq=simpleacq)
+    copy2 = archivefilecopy(file=file2, node=unode.db, has_file="Y")
+    archivefilecopy(file=file2, node=arc1, has_file="Y")
+    archivefilecopy(file=file2, node=arc2, has_file="N")
+
+    # Can be deleted from node: two archived copies
+    file3 = archivefile(name="file3", acq=simpleacq)
+    copy3 = archivefilecopy(file=file3, node=unode.db, has_file="Y")
+    archivefilecopy(file=file3, node=arc1, has_file="Y")
+    archivefilecopy(file=file3, node=arc2, has_file="Y")
+
+    unode.io.delete([copy1, copy2, copy3])
+
+    assert queue.qsize == 1
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # copy1 and copy2 aren't deleted, but copy3 is
+    assert list(
+        ArchiveFileCopy.select(ArchiveFileCopy.has_file)
+        .where(ArchiveFileCopy.node == unode.db)
+        .tuples()
+        .execute()
+    ) == [
+        ("Y",),
+        ("Y",),
+        ("N",),
+    ]
+
+
+def test_ncopies_archive(
+    xfs,
+    queue,
+    unode,
+    simplegroup,
+    storagenode,
+    simpleacq,
+    archivefile,
+    archivefilecopy,
+):
+    """Same as previous but on an archive node."""
+
+    test_ncopies(
+        xfs,
+        queue,
+        unode,
+        simplegroup,
+        storagenode,
+        simpleacq,
+        archivefile,
+        archivefilecopy,
+        storage_type="A",
+    )
+
+
+def test_delete_dirs(
+    xfs,
+    queue,
+    simplegroup,
+    storagenode,
+    archiveacq,
+    archivefile,
+    archivefilecopy,
+    mock_archive_count,
+):
+    """Test deleting directories (and some files)."""
+    node = storagenode(name="node", group=simplegroup, root="/node")
+
+    copies = list()
+
+    acq1 = archiveacq(name="acq/1")
+    copies.append(
+        archivefilecopy(
+            file=archivefile(name="file/1", acq=acq1),
+            node=node,
+            has_file="Y",
+        )
+    )
+    copies.append(
+        archivefilecopy(
+            file=archivefile(name="file/2", acq=acq1),
+            node=node,
+            has_file="Y",
+        )
+    )
+    copies.append(
+        archivefilecopy(
+            file=archivefile(name="file/3", acq=acq1),
+            node=node,
+            has_file="Y",
+        )
+    )
+
+    acq2 = archiveacq(name="acq/2")
+    copies.append(
+        archivefilecopy(
+            file=archivefile(name="file/4", acq=acq2),
+            node=node,
+            has_file="Y",
+        )
+    )
+    copies.append(
+        archivefilecopy(
+            file=archivefile(name="file/5", acq=acq2),
+            node=node,
+            has_file="Y",
+        )
+    )
+
+    acq3 = archiveacq(name="acq3")
+    copies.append(
+        archivefilecopy(
+            file=archivefile(name="file6", acq=acq3),
+            node=node,
+            has_file="Y",
+        )
+    )
+
+    # Create files
+    for copy in copies:
+        xfs.create_file(copy.path, contents=copy.file.name)
+
+    # Delete everyhing except for copy[2]
+    delete_copies = copies.copy()
+    del delete_copies[2]
+
+    # Call async directly for simplicity.
+    delete_async(None, delete_copies)
+
+    # Only copies[2] remains
+    assert ArchiveFileCopy.select().where(ArchiveFileCopy.has_file == "Y").count() == 1
+
+    # Check files
+    assert pathlib.Path(copies[2].path).exists()
+    for copy in delete_copies:
+        assert not pathlib.Path(copy.path).exists()
+
+    # Check dirs.  The only one remaining should be copies[2] parents
+    # (which are also the parents of copies[0] and [1])
+    parent = pathlib.Path(copies[2].path).parent
+    # acq/1/file
+    assert parent.exists()
+    # acq/1
+    assert parent.parent.exists()
+    # acq
+    assert parent.parent.parent.exists()
+
+    parent = pathlib.Path(copies[3].path).parent
+    # acq/2/file
+    assert not parent.exists()
+    # acq/2
+    assert not parent.parent.exists()
+    # acq
+    assert parent.parent.parent.exists()
+
+    # acq3
+    assert not pathlib.Path(copies[5].path).parent.exists()


### PR DESCRIPTION
This is a relatively straightforward PR which mostly moves the guts of `update.update_node_delete` into `alpenhorn.io._default_asyncs.delete_async` which gets shoved into a task by `node.io.delete`.

I can't tell if it is for sure, but it seems weird to make an asynchronous task to delete a single file, so I've made the remaining code in `update.update_node_delete` group a bunch of them together and pass that to the I/O layer to delete together in the same task.

The bunch size I've chosen is 10.  Don't really know if that's a good number.  It's in the ballpark of the number of files that alpenhorn-1 tends to delete at a time (which, in turn, is related to the number of files it can transfer per hour).

I'm willing to entertain different values for the bunch size, including the value 1 (i.e. get rid of the bunching), but it seems like 1 or 10 or 100 are sort of the kind of numbers we should be considering here.