### PR TITLE
Rewrite 9/14: I/O util (pull request inner functions)

### DIFF
--- a/alpenhorn/archive.py
+++ b/alpenhorn/archive.py
@@ -5,7 +5,7 @@ import peewee as pw
 from alpenhorn.acquisition import ArchiveFile
 from alpenhorn.storage import StorageGroup, StorageNode
 
-from .db import EnumField, CurrentTimestampField, base_model
+from .db import EnumField, base_model
 
 
 class ArchiveFileCopy(base_model):
@@ -39,10 +39,8 @@ class ArchiveFileCopy(base_model):
     size_b : integer
         Allocated size of file in bytes (i.e. actual size on the Storage
         medium.)
-    last_update : timestamp
-        The time at which this record was last updated.  If using
-        a MySQL database, this property is automatically set to the
-        current time whenever the row is updated.
+    last_update : datetime
+        The time at which this record was last updated.
     """
 
     file = pw.ForeignKeyField(ArchiveFile, backref="copies")
@@ -51,7 +49,7 @@ class ArchiveFileCopy(base_model):
     wants_file = EnumField(["Y", "M", "N"], default="Y")
     ready = pw.BooleanField(default=False)
     size_b = pw.BigIntegerField(null=True)
-    last_update = CurrentTimestampField
+    last_update = pw.DateTimeField(default=datetime.datetime.now)
 
     @property
     def path(self) -> pathlib.Path:

--- a/alpenhorn/config.py
+++ b/alpenhorn/config.py
@@ -56,6 +56,17 @@ Example config:
         # are I/O run tasks in the main thread, in cases when there are no
         # worker threads
         serial_io_timeout: 900
+
+        # These two optional parameters control how long a pull job is
+        # allowed to run before being forceably killed.  The timeout (in
+        # seconds) for a pull of a file of size "size_b" bytes is:
+        #
+        #   pull_timeout_base + size_b / pull_bytes_per_second
+        #
+        # If pull_bytes_per_second is zero, the timeout is disabled (the
+        # job will rum forever if it doesn't exit; not recommended).
+        pull_timeout_base: 300
+        pull_bytes_per_second: 20000000
 """
 
 import logging

--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -35,10 +35,11 @@ After `init()` has been called, database access is possible.  Each thread
 needing database access must separately call `connect()` to initialise the
 database proxy.
 """
-import logging
-import datetime
-import peewee as pw
+from __future__ import annotations
 from typing import Any
+
+import logging
+import peewee as pw
 from playhouse import db_url
 
 from . import config, extensions
@@ -55,11 +56,6 @@ _db_ext = None
 
 database_proxy = pw.Proxy()
 threadsafe = None
-
-# A peewee Timestamp field which auto-updates to the
-# current time when the row is updated in MySQL, but
-# does nothing special in other Database types
-CurrentTimestampField = pw.TimestampField(default=datetime.datetime.now)
 
 
 def _capability(key: str) -> Any:
@@ -131,8 +127,6 @@ def connect() -> None:
     Should be called per-thread before any database operations are attempted.
     """
 
-    global CurrentTimestampField
-
     # If fetch the database config, if present
     if "database" in config.config:
         database_config = config.config["database"]
@@ -152,12 +146,6 @@ def connect() -> None:
         EnumField.native = True
     else:
         EnumField.native = False
-
-    if isinstance(db, pw.MySQLDatabase):
-        CurrentTimestampField = pw.TimestampField(
-            null=True,
-            constraints=[pw.SQL("ON UPDATE CURRENT_TIMESTAMP")],
-        )
 
 
 def _connect(config: dict) -> pw.Database:

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 import errno
 import logging
+from datetime import datetime
 
 from ..archive import ArchiveFileCopy
 
@@ -69,6 +70,7 @@ def check_async(task: Task, io: BaseNodeIO, copy: ArchiveFileCopy) -> None:
     log.info(
         f"Updating file copy #{copy.id} for file {copyname} on node {io.node.name}."
     )
+    copy.last_update = datetime.now()
     copy.save()
 
 
@@ -145,6 +147,6 @@ def delete_async(task: Task, copies: list[ArchiveFileCopy]) -> None:
             dirname = dirname.parent
 
         # Update the DB
-        ArchiveFileCopy.update(has_file="N", wants_file="N").where(
-            ArchiveFileCopy.id == copy.id
-        ).execute()
+        ArchiveFileCopy.update(
+            has_file="N", wants_file="N", last_update=datetime.now()
+        ).where(ArchiveFileCopy.id == copy.id).execute()

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -1,0 +1,425 @@
+"""I/O utility functions."""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import re
+import time
+import pathlib
+import peewee as pw
+from datetime import datetime
+from tempfile import TemporaryDirectory
+
+from ..archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from .. import config, db, util
+
+if TYPE_CHECKING:
+    from ..base import BaseNodeIO
+
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def _pull_timeout(size_b: int) -> float | None:
+    """Given a file of `size_b` bytes, return the timeout in seconds.
+
+    The timeout used for a bbcp or rsync call is
+
+        pull_timeout_base + file.size_b / pull_bytes_per_second
+
+    where `pull_timeout_base` and `pull_bytes_per_second` may
+    be given in the "service" section of the config.
+
+    If `pull_bytes_per_second` is zero, None is returned (disabling
+    the timeout).
+
+    If not given, the defaults are:
+
+        pull_timeout_base = 300          (five minutes)
+        pull_bytes_per_second = 20000000 (20MB/s)
+
+    which are conservative CHIME values for cedar.
+
+    Sample values with the defaults here:
+
+    File              Time @ 50MB/s     Timeout
+
+    100GB chime_hfb       33m           1h 28m
+     30GB chimestack      10m              30m
+      2GB chimegain       40s               6m
+    230MB chimetiming      5s               5m
+    """
+
+    # These may be overridden at runtime via the config
+    PULL_TIMEOUT_BASE = 300  # 5 minutes base
+    PULL_BYTES_PER_SECOND = 20000000  # 20MB/s
+
+    base = config.config["service"].get("pull_timeout_base", PULL_TIMEOUT_BASE)
+    bps = config.config["service"].get("pull_bytes_per_second", PULL_BYTES_PER_SECOND)
+
+    if bps == 0:
+        return None
+
+    return base + size_b / bps
+
+
+def bbcp(from_path: str, to_dir: str, size_b: int) -> dict:
+    """Transfer a file with BBCP.
+
+    Command times out after `_pull_timeout(size_b)` seconds have elapsed.
+
+    Parameters
+    ----------
+    from_path : str
+        Source location
+    to_dir : str
+        Destination directory
+    size_b : int
+        Size of the file to transfer.  Only used to
+        set the timeout.
+
+    Returns
+    -------
+    ioresult : dict
+        Result of the transfer, with keys:
+        "ret": int
+            exit code of bbcp (0 == success)
+        "md5sum": str
+            MD5 hash of the transferred file.  Only present
+            if ret == 0
+        "stderr": str
+            Standard error output from bbcp
+        "check_src": bool
+            True unless it's clear that a failure wasn't
+            due to a problem with the source file.
+    """
+    ret, stdout, stderr = util.run_command(
+        [  # See: https://www.slac.stanford.edu/~abh/bbcp/
+            "bbcp",
+            #
+            #
+            # -V (AKA --vverbose, with two v's) is here because
+            # bbcp is weirdly broken.
+            #
+            # There's a bug in bbcp (which DVW doesn't want
+            # to explain in this comment), that affects the
+            # CHIME site-to-cedar transfers, but (essentially)
+            # turning on two-v-verbose mode changes the code
+            # path in bbcp to avoid the bug. We do not care
+            # _at all_ about the extra verbose output: it all
+            # just goes in the bin.  XXX Probably we should
+            # patch the bbcp on cedar to fix the bug.
+            "-V",
+            #
+            #
+            # force: delete an existing destination file before
+            # transfer
+            "-f",
+            #
+            #
+            # Use a reverse connection to get through a firewall
+            # (This may not be appropriate everywhere -- more reason
+            # we need an edge table in the database.)
+            "-z",
+            #
+            #
+            # Port to use
+            "--port",
+            "4200",
+            #
+            #
+            # TCP window size.  4M is what Linux typically limits
+            # you to (cf. /proc/sys/net/ipv4/tcp_wmem)
+            "-W",
+            "4M",
+            #
+            #
+            # Number of streams
+            "-s",
+            "16",
+            #
+            #
+            # Do block-level checksumming to detect transmission
+            # errors
+            "-e",
+            #
+            #
+            # Calculate _and print_ a MD5 checksum of the whole file
+            # on the source.  MD5ing is done on the source to avoid
+            # the need for the file transfer to occur in order
+            # (which can cause bbcp to lock up).
+            #
+            # See https://www.slac.stanford.edu/~abh/bbcp/#_Toc392015140
+            # and https://github.com/chime-experiment/alpenhorn/pull/15
+            "-E",
+            "%md5=",
+            from_path,
+            to_dir,
+        ],
+        timeout=_pull_timeout(size_b),
+    )
+
+    # Attempt to parse STDERR for the md5 hash
+    ioresult = {"ret": ret, "stderr": stderr, "check_src": True}
+    if ret == 0:
+        mo = re.search("md5 ([a-f0-9]{32})", stderr)
+        if mo is None:
+            log.error(
+                f"BBCP transfer has gone awry. STDOUT: {stdout}\n STDERR: {stderr}"
+            )
+            return {
+                "ret": -1,
+                "stderr": "Unable to read m5sum from bbcp output",
+                "check_src": False,
+            }
+        else:
+            ioresult["md5sum"] = mo.group(1)
+
+    return ioresult
+
+
+def rsync(from_path: str, to_dir: str, size_b: int, local: bool) -> dict:
+    """Rsync a file (either local or remote).
+
+    Command times out after `_pull_timeout(size_b)` seconds have elapsed.
+
+    Parameters
+    ----------
+    from_path : str
+        Source location
+    to_dir : str
+        Destination directory
+    size_b : int
+        Size of the file to transfer.  Only used to
+        set the timeout.
+    local : bool
+        False if this is a network transfer.  In that
+        case, compression is turned on in rsync.
+
+    Returns
+    -------
+    ioresult : dict
+        Result of the transfer, with keys:
+        "ret": int
+            exit code of rsync (0 == success)
+        "md5sum": bool
+            True if ret == 0, absent otherwise
+        "stderr": str
+            Standard error output from rsync
+        "check_src": bool
+            True unless it's clear that a failure wasn't
+            due to a problem with the source file.
+    """
+
+    if local:
+        remote_args = list()
+    else:
+        remote_args = [
+            "--compress",
+            "--rsync-path=ionice -c2 -n4 rsync",
+            "--rsh=ssh -q",
+        ]
+
+    ret, stdout, stderr = util.run_command(
+        ["rsync"]
+        + remote_args
+        + [
+            "--quiet",
+            "--times",
+            "--protect-args",
+            "--perms",
+            "--group",
+            "--owner",
+            "--copy-links",
+            "--sparse",
+            from_path,
+            to_dir,
+        ],
+        timeout=_pull_timeout(size_b),
+    )
+
+    ioresult = {"ret": ret, "stderr": stderr}
+
+    # If the rsync error occured during `mkstemp` or during a write, this is a
+    # problem on the destination, not the source
+    if ret:
+        if "mkstemp" in stderr:
+            log.warning("rsync file creation failed")
+            ioresult["check_src"] = False
+        elif "write failed on" in stderr:
+            log.warning(
+                "rsync failed to write to destination: "
+                + stderr[stderr.rfind(":") + 2 :].strip()
+            )
+            ioresult["check_src"] = False
+        else:
+            # Other error, perhaps due to source
+            ioresult["check_src"] = True
+    else:
+        # rsync guarantees the md5 sum of a file is not changed if a
+        # transfer succeeds (ret == 0)
+        ioresult["md5sum"] = True
+
+    return ioresult
+
+
+def hardlink(from_path, to_dir, filename) -> dict | None:
+    """Hard link `from_path` as `to_dir/filename`
+
+    Atomically overwrites an existing `to_dir/filename`.
+
+    If hardlinking fails, this funciton assumes it's because src and dest
+    aren't on the same filesystem (i.e., failure is probably not for an
+    interesting reason).
+
+    Parameters
+    ----------
+    from_path : str
+        Source location
+    to_dir : str
+        Destination directory
+    filename : str
+        Destination filename
+
+    Returns
+    -------
+    ioresult : dict or None
+        None if hardlinking failed otherwise, the dict
+        `{"ret": 0, "md5sum": True}`
+    """
+
+    from_path = pathlib.Path(from_path)
+    dest_path = pathlib.Path(to_dir, filename)
+
+    # Neither POSIX nor libc have any facilities to atomically overwite
+    # an existing file with a hardlink, so we have to do this ridiculousness:
+    try:
+        # Create a temporary directory as a subdirectory of the destination dir
+        with TemporaryDirectory(dir=to_dir) as tmpdir:
+            # We can be certain that we can create anything we want in here
+            tmp_path = pathlib.Path(tmpdir, filename)
+            # Try to create the new hardlink in the tempdir
+            tmp_path.hardlink_to(from_path)
+            # Hardlink succeeded!  Overwrite any existing file atomically
+            tmp_path.rename(dest_path)
+    except OSError as e:
+        # Link creation failed for some reason
+        log.debug(f"hardlink failed: {e}")
+        return None
+
+    # md5sum is obviously correct
+    return {"ret": 0, "md5sum": True}
+
+
+def copy_request_done(
+    req: ArchiveFileCopyRequest,
+    io: BaseNodeIO,
+    success: bool,
+    md5ok: bool | str,
+    start_time: float,
+    check_src: bool = True,
+    stderr: str | None = None,
+) -> bool:
+    """Update the database after attempting a copy request.
+
+    Parameters
+    ----------
+    req : ArchiveFileCopyRequest
+        The copy request that was attempted
+    io : Node I/O instance
+        The I/O instance of the destination node
+    success : bool
+        True unless the file transfer failed.
+    md5ok : boolean or str
+        Either a boolean indicating if the MD5 sum was correct or
+        else a string MD5 sum which we need to verify.  Ignored if
+        success is not True.
+    start_time : float
+        time.time() when the transfer was started
+    check_src : boolean
+        if success is False, should the source file be marked suspect?
+    stderr : str or None
+        if success is False, this will be copied into the log
+
+    Returns
+    -------
+    good_transfer : bool
+        True if the parameters indicate the transfer was successful
+        or False if the transfer failed.
+    """
+
+    # Check the result
+    if not success:
+        if stderr is None:
+            stderr = "Unspecified error."
+        if check_src:
+            # If the copy didn't work, then the remote file may be corrupted.
+            log.error(f"Copy failed: {stderr};  Marking source file suspect.")
+            ArchiveFileCopy.update(has_file="M", last_update=datetime.now()).where(
+                ArchiveFileCopy.file == req.file,
+                ArchiveFileCopy.node == req.node_from,
+            ).execute()
+        else:
+            # An error occurred that can't be due to the source
+            # being corrupt
+            log.error(f"Copy failed: {stderr}")
+        return False
+
+    # Otherwise, transfer was completed, remember end time
+    end_time = time.time()
+
+    # Check integrity.
+    if isinstance(md5ok, str):
+        md5ok = md5ok == req.file.md5sum
+    if not md5ok:
+        log.error(
+            f"MD5 mismatch on node {io.node.name}; "
+            f"Marking source file {req.file.name} on node {req.node_from} suspect."
+        )
+        ArchiveFileCopy.update(has_file="M", last_update=datetime.now()).where(
+            ArchiveFileCopy.file == req.file,
+            ArchiveFileCopy.node == req.node_from,
+        ).execute()
+        return False
+
+    # Transfer successful
+    trans_time = end_time - start_time
+    rate = req.file.size_b / trans_time
+    log.info(
+        f"Pull complete (md5sum correct). "
+        f"Transferred {util.pretty_bytes(req.file.size_b)} "
+        f"in {util.pretty_deltat(trans_time)} [{util.pretty_bytes(rate)}/s]"
+    )
+
+    with db.database_proxy.atomic():
+        # Upsert the FileCopy
+        size = io.filesize(req.file.path, actual=True)
+        try:
+            ArchiveFileCopy.insert(
+                file=req.file,
+                node=io.node,
+                has_file="Y",
+                wants_file="Y",
+                ready=True,
+                size_b=size,
+                last_update=datetime.now(),
+            ).execute()
+        except pw.IntegrityError:
+            ArchiveFileCopy.update(
+                has_file="Y",
+                wants_file="Y",
+                ready=True,
+                size_b=size,
+                last_update=datetime.now(),
+            ).where(
+                ArchiveFileCopy.file == req.file, ArchiveFileCopy.node == io.node
+            ).execute()
+
+        # Mark AFCR as completed
+        ArchiveFileCopyRequest.update(
+            completed=True,
+            transfer_started=datetime.fromtimestamp(start_time),
+            transfer_completed=datetime.fromtimestamp(end_time),
+        ).where(ArchiveFileCopyRequest.id == req.id).execute()
+
+    return True

--- a/tests/io/test_ioutil.py
+++ b/tests/io/test_ioutil.py
@@ -1,0 +1,193 @@
+"""Test alpenhorn.io.ioutil"""
+
+import pytest
+
+from alpenhorn.io import ioutil
+
+
+@pytest.mark.run_command_result(0, "", "md5 d41d8cd98f00b204e9800998ecf8427e")
+@pytest.mark.alpenhorn_config({"service": {"pull_timeout_base": 1000}})
+def test_bbcp_config_timeout(mock_run_command, set_config):
+    """Test setting timeout via config."""
+
+    assert ioutil.bbcp("from/path", "to/dir", 1e8) == {
+        "check_src": True,
+        "md5sum": "d41d8cd98f00b204e9800998ecf8427e",
+        "ret": 0,
+        "stderr": "md5 d41d8cd98f00b204e9800998ecf8427e",
+    }
+
+    args = mock_run_command()
+    assert args["timeout"] == 1005.0  # 1000 seconds base + 5 seconds for 1e8 bytes
+
+
+@pytest.mark.run_command_result(0, "", "md5 d41d8cd98f00b204e9800998ecf8427e")
+@pytest.mark.alpenhorn_config({"service": {"pull_bytes_per_second": 0}})
+def test_bbcp_no_timeout(mock_run_command, set_config):
+    """Test disabling timeout via config."""
+
+    assert ioutil.bbcp("from/path", "to/dir", 1e8) == {
+        "check_src": True,
+        "md5sum": "d41d8cd98f00b204e9800998ecf8427e",
+        "ret": 0,
+        "stderr": "md5 d41d8cd98f00b204e9800998ecf8427e",
+    }
+
+    args = mock_run_command()
+    assert args["timeout"] is None  # pull_bytes_per_second = 0 disables
+
+
+@pytest.mark.run_command_result(0, "", "md5 d41d8cd98f00b204e9800998ecf8427e")
+def test_bbcp_good(mock_run_command):
+    """Test a successful ioutil.bbcp() call."""
+
+    assert ioutil.bbcp("from/path", "to/dir", 1e8) == {
+        "check_src": True,
+        "md5sum": "d41d8cd98f00b204e9800998ecf8427e",
+        "ret": 0,
+        "stderr": "md5 d41d8cd98f00b204e9800998ecf8427e",
+    }
+
+    args = mock_run_command()
+    assert args["timeout"] == 305.0  # 300 seconds base + 5 seconds for 1e8 bytes
+
+
+@pytest.mark.run_command_result(0, "", "")
+def test_bbcp_nomd5(mock_run_command):
+    """Test a ioutil.bbcp() call with md5 sum missing from commmand output."""
+
+    assert ioutil.bbcp("from/path", "to/dir", 1e8) == {
+        "check_src": False,
+        "ret": -1,
+        "stderr": "Unable to read m5sum from bbcp output",
+    }
+
+
+@pytest.mark.run_command_result(1, "", "bbcp_stderr")
+def test_bbcp_fail(mock_run_command):
+    """Test a ioutil.bbcp() failed command."""
+
+    assert ioutil.bbcp("from/path", "to/dir", 1e8) == {
+        "check_src": True,
+        "ret": 1,
+        "stderr": "bbcp_stderr",
+    }
+
+
+@pytest.mark.run_command_result(0, "", "")
+def test_rsync_good(mock_run_command):
+    """Test successful ioutil.rsync() commands."""
+
+    # Local rsync
+    assert ioutil.rsync("from/path", "to/dir", 1e8, True) == {
+        "md5sum": True,
+        "ret": 0,
+        "stderr": "",
+    }
+
+    # Local rsync doesn't compress
+    args = mock_run_command()
+    assert "--compress" not in args["cmd"]
+    assert args["timeout"] == 305.0
+
+    # Remote rsync
+    assert ioutil.rsync("from/path", "to/dir", 1e8, False) == {
+        "md5sum": True,
+        "ret": 0,
+        "stderr": "",
+    }
+
+    # Remote rsync does compress
+    args = mock_run_command()
+    assert "--compress" in args["cmd"]
+    assert args["timeout"] == 305.0
+
+
+@pytest.mark.run_command_result(1, "", "mkstemp")
+def test_rsync_mkstemp(mock_run_command):
+    """Test catching a mkstemp error in ioutil.rsync()."""
+
+    assert ioutil.rsync("from/path", "to/dir", 1e8, True) == {
+        "check_src": False,
+        "ret": 1,
+        "stderr": "mkstemp",
+    }
+
+
+@pytest.mark.run_command_result(1, "", "write failed on")
+def test_rsync_write(mock_run_command):
+    """Test catching a write error in ioutil.rsync()."""
+
+    assert ioutil.rsync("from/path", "to/dir", 1e8, True) == {
+        "check_src": False,
+        "ret": 1,
+        "stderr": "write failed on",
+    }
+
+
+@pytest.mark.run_command_result(1, "", "rsync_stderr")
+def test_rsync_fail(mock_run_command):
+    """Test general failure in ioutil.rsync()."""
+
+    assert ioutil.rsync("from/path", "to/dir", 1e8, True) == {
+        "check_src": True,
+        "ret": 1,
+        "stderr": "rsync_stderr",
+    }
+
+
+def test_hardlink(tmp_path):
+    """Test successful ioutil.hardlink() call."""
+
+    # Create src and dest in a temporary directory
+    srcdir = tmp_path.joinpath("src")
+    srcdir.mkdir()
+    file = srcdir.joinpath("file")
+    file.write_text("data")
+    dstdir = tmp_path.joinpath("dst")
+    dstdir.mkdir()
+    destfile = dstdir.joinpath("file")
+
+    assert ioutil.hardlink(file, dstdir, "file") == {"ret": 0, "md5sum": True}
+    assert destfile.read_text() == "data"
+
+
+def test_hardlink_clobber(tmp_path):
+    """Test successful overwrite in ioutil.hardlink() call."""
+
+    # Create src and dest in a temporary directory
+    srcdir = tmp_path.joinpath("src")
+    srcdir.mkdir()
+    file = srcdir.joinpath("file")
+    file.write_text("data")
+    dstdir = tmp_path.joinpath("dst")
+    dstdir.mkdir()
+    destfile = dstdir.joinpath("file")
+    destfile.write_text("other_data")
+
+    assert destfile.read_text() == "other_data"
+    assert ioutil.hardlink(file, dstdir, "file") == {"ret": 0, "md5sum": True}
+    assert destfile.read_text() == "data"
+
+
+def test_hardlink_fail(tmp_path):
+    """Test failed ioutil.hardlink() call."""
+
+    # Create src but not dest
+    srcdir = tmp_path.joinpath("src")
+    srcdir.mkdir()
+    file = srcdir.joinpath("file")
+    file.write_text("data")
+    dstdir = tmp_path.joinpath("dst")
+    destfile = dstdir.joinpath("file")
+
+    assert ioutil.hardlink(file, dstdir, "file") is None
+    with pytest.raises(FileNotFoundError):
+        destfile.read_text()
+
+    # Try with access error instead
+    dstdir.mkdir(mode=0o400)
+
+    assert ioutil.hardlink(file, dstdir, "file") is None
+    with pytest.raises(PermissionError):
+        destfile.read_text()

--- a/tests/io/test_ioutil_crd.py
+++ b/tests/io/test_ioutil_crd.py
@@ -1,0 +1,250 @@
+"""Test alpenhorn.io.ioutil.copy_request_done()."""
+
+import time
+import pytest
+import datetime
+
+
+from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from alpenhorn.io.ioutil import copy_request_done
+from alpenhorn.update import UpdateableNode
+
+
+@pytest.fixture
+def db_setup(
+    mock_filesize,
+    storagegroup,
+    storagenode,
+    simplefile,
+    archivefilecopy,
+    archivefilecopyrequest,
+):
+    """DB setup for copy_request_done checks with no pre-existing dest copy."""
+
+    group_to = storagegroup(name="group_to")
+    node_to = storagenode(name="node_to", group=group_to, root="/node_to")
+    node_from = storagenode(
+        name="node_from", group=storagegroup(name="group_from"), root="/node_from"
+    )
+
+    return (
+        UpdateableNode(None, node_to).io,
+        archivefilecopy(file=simplefile, node=node_from, has_file="Y"),
+        archivefilecopyrequest(file=simplefile, node_from=node_from, group_to=group_to),
+        time.time() - 2,  # start_time
+    )
+
+
+@pytest.fixture
+def db_setup_with_copy(db_setup, archivefilecopy):
+    """DB setup for copy_request_done checks with pre-existing dest copy."""
+    node_to = db_setup[0].node
+    req = db_setup[1]
+
+    dstcopy = archivefilecopy(file=req.file, node=node_to, has_file="N", ready=False)
+
+    # We re-get to launder the record through the DB
+    return *db_setup, ArchiveFileCopy.get(id=dstcopy.id)
+
+
+def test_fail_chksrc(db_setup):
+    """Test failed transfer with check_src==True"""
+
+    io, copy, req, start_time = db_setup
+
+    assert (
+        copy_request_done(
+            req,
+            io,
+            success=False,
+            md5ok=False,
+            start_time=start_time,
+            check_src=True,
+        )
+        is False
+    )
+
+    # request is not resolved
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert not afcr.completed
+    assert not afcr.cancelled
+
+    # reqeust to re-check src has been made
+    assert ArchiveFileCopy.get(id=copy.id).has_file == "M"
+
+
+def test_fail_nochksrc(db_setup):
+    """Test failed transfer with check_src==False"""
+
+    io, copy, req, start_time = db_setup
+
+    assert (
+        copy_request_done(
+            req,
+            io,
+            success=False,
+            md5ok=False,
+            start_time=start_time,
+            check_src=False,
+        )
+        is False
+    )
+
+    # request is not resolved
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert not afcr.completed
+    assert not afcr.cancelled
+
+    # reqeust to re-check src has not been made
+    assert ArchiveFileCopy.get(id=copy.id).has_file != "M"
+
+
+def test_md5ok_false(db_setup):
+    """Test successful transfer with md5ok==False"""
+
+    io, copy, req, start_time = db_setup
+
+    assert (
+        copy_request_done(
+            req,
+            io,
+            success=True,
+            md5ok=False,
+            start_time=start_time,
+        )
+        is False
+    )
+
+    # request is not resolved
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert not afcr.completed
+    assert not afcr.cancelled
+
+    # reqeust to re-check src has been made
+    assert ArchiveFileCopy.get(id=copy.id).has_file == "M"
+
+
+def test_md5ok_bad(db_setup):
+    """Test successful transfer with a non-matching md5ok string"""
+
+    io, copy, req, start_time = db_setup
+
+    assert (
+        copy_request_done(
+            req,
+            io,
+            success=True,
+            md5ok="incorrect-md5sum",
+            start_time=start_time,
+        )
+        is False
+    )
+
+    # request is not resolved
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert not afcr.completed
+    assert not afcr.cancelled
+
+    # reqeust to re-check src has been made
+    assert ArchiveFileCopy.get(id=copy.id).has_file == "M"
+
+
+def test_md5ok_true(db_setup):
+    """Test successful transfer with a md5ok==True"""
+
+    io, copy, req, start_time = db_setup
+
+    before = datetime.datetime.now() - datetime.timedelta(seconds=2)
+    assert (
+        copy_request_done(
+            req,
+            io,
+            success=True,
+            md5ok=True,
+            start_time=start_time,
+        )
+        is True
+    )
+    after = datetime.datetime.now()
+
+    # request is resolved
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed
+    assert not afcr.cancelled
+    assert afcr.transfer_started == datetime.datetime.fromtimestamp(start_time)
+    assert afcr.transfer_completed >= before
+    assert afcr.transfer_completed <= after
+
+    # reqeust to re-check src has not been made
+    assert ArchiveFileCopy.get(id=copy.id).has_file != "M"
+
+    # Check copy on dest
+    dstcopy = ArchiveFileCopy.get(
+        ArchiveFileCopy.node == io.node, ArchiveFileCopy.file == req.file
+    )
+    assert dstcopy.has_file == "Y"
+    assert dstcopy.wants_file == "Y"
+    assert dstcopy.ready is True
+    assert dstcopy.size_b == 512 * 3
+    assert dstcopy.last_update >= before
+    assert dstcopy.last_update <= after
+
+
+def test_md5ok_str(db_setup):
+    """Test successful transfer with a matching md5ok string"""
+
+    io, copy, req, start_time = db_setup
+
+    assert (
+        copy_request_done(
+            req,
+            io,
+            success=True,
+            md5ok="d41d8cd98f00b204e9800998ecf8427e",
+            start_time=start_time,
+        )
+        is True
+    )
+
+    # request is resolved
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed
+    assert not afcr.cancelled
+
+    # reqeust to re-check src has been made
+    assert ArchiveFileCopy.get(id=copy.id).has_file != "M"
+
+    # dest copy exists
+    assert (
+        ArchiveFileCopy.get(
+            ArchiveFileCopy.node == io.node, ArchiveFileCopy.file == req.file
+        ).has_file
+        == "Y"
+    )
+
+
+def test_dstcopy(db_setup_with_copy):
+    """Test successful transfer with existing destination copy record."""
+
+    io, copy, req, start_time, dstcopy = db_setup_with_copy
+
+    assert (
+        copy_request_done(
+            req,
+            io,
+            success=True,
+            md5ok=True,
+            start_time=start_time,
+        )
+        is True
+    )
+
+    # Verify update-in-place of ArchiveFileCopy
+    newcopy = ArchiveFileCopy.get(
+        ArchiveFileCopy.node == io.node, ArchiveFileCopy.file == req.file
+    )
+    assert newcopy.id == dstcopy.id
+    assert newcopy.has_file == "Y"
+    assert newcopy.wants_file == "Y"
+    assert newcopy.ready is True
+    assert newcopy.size_b == 512 * 3

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,6 +4,36 @@ import pytest
 from alpenhorn import util
 
 
+def test_run_retval0():
+    """Test getting success from run_command."""
+    retval, stdout, stderr = util.run_command(["true"])
+    assert retval == 0
+
+
+def test_run_retval1():
+    """Test getting failure from run_command."""
+    retval, stdout, stderr = util.run_command(["false"])
+    assert retval != 0
+
+
+def test_run_stdout():
+    """Test getting stdout from run_command."""
+    retval, stdout, stderr = util.run_command(["echo", "stdout"])
+    assert stderr == ""
+    assert stdout == "stdout\n"
+    assert retval == 0
+
+
+def test_run_stderr():
+    """Test getting stdout from run_command."""
+    retval, stdout, stderr = util.run_command(
+        ["python3", "-c", "import os; os.write(2, b'stderr')"]
+    )
+    assert stderr == "stderr"
+    assert stdout == ""
+    assert retval == 0
+
+
 def test_md5sum_file(tmp_path):
     """Test util.md5sum_file"""
 


### PR DESCRIPTION
This PR primarily moves parts of the file transfer code out of `update.py` and into `alpenhorn/io/ioutil.py`.  My original thought with these bits was that they would be useful to other I/O types other than the `Default` I/O, but that hasn't actually happened in this rewrite.  Nevertheless, it's good to split up the unmanageably long `update_node_requests`.

## Updates to previous rewrite PRs
This PR removes my ham-fisted attempt to create an auto-updating `CurrentTimestampField` (using MySQL's `ON UPDATE CURRENT_TIMESTAMP` clause) from way back in part 4 (#147) which wasn't going to work for a number of reasons.  In it's place is a simple `DateTimeField` which gets explicitly updated when necessary.

The only potential downside here is that changes made to the `ArchiveFileCopy` table outside of alpenhorn won't benefit from automatic updates of this cell, but I don't think we're ever updating that table outside of alpenhorn anyways.

## File transfer methods

There are three functions handling the various transfer methods moved into `ioutil`:
* bbcp
* rsync
* hardlink

These three functions all return an "ioresult" dict with standard-ish keys indicating the result of the transfer.

## Post transfer DB update
The final functionality moved to `ioutil` is a function that essentially takes the `ioresult` provided by the three transfer functions, determines whether the transfer succeeded or failed, and then and updates the database to reflect what happened. (This is `copy_request_done`.)

## Updates to `update.py`
Even though it's still commented out, I've updated `update.update_node_requests` to use these new functions.  In the next PR, `update_node_requests` will be converted to the new I/O system and these changes will be incorporated there.

## Changes to `util.py`
* `run_command` now takes an optional `timeout` parameter and will kill the subprocess if a specified timeout is exceeded.  I don't know why, but ever since I moved alpenhorn to the `chimedat` user, we've been running into issues where the `bbcp` transfer rate drops to zero without the transfer failing.  Not sure what's going on there, but this will work around the problem nicely.
* `command_available` has been deleted.  This is just a worse version of `shutil.which` (now used in its place).  Furthermore, `distutils`, which this function was based on is deprecated and scheduled for removal in 3.12.