### PR TITLE
Rewrite 10/14: DefaultIO file pulls

### DIFF
--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -2,17 +2,165 @@
 from __future__ import annotations
 from typing import TYPE_CHECKING
 
+import time
 import errno
+import shutil
 import logging
+import pathlib
 from datetime import datetime
 
-from ..archive import ArchiveFileCopy
+from . import ioutil
+from ..archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from ..update import RemoteNode
 
 if TYPE_CHECKING:
     from .base import BaseNodeIO
+    from .updownlock import UpDownLock
     from ..task import Task
 
 log = logging.getLogger(__name__)
+
+
+def pull_async(
+    task: Task, io: BaseNodeIO, tree_lock: UpDownLock, req: ArchiveFileCopyRequest
+) -> None:
+    """Fulfill `req` by pulling a file onto the local node.
+
+    Things to try:
+        - hard link (for nodes on the same filesystem)
+        - bbcp (if source is not on this host)
+        - rsync if all else fails
+
+    Parameters
+    ----------
+    task : Task
+        The task instance containing this async.
+    io : Node I/O instance
+        The I/O instance for the pull destination node.
+    tree_lock : UpDownLock
+        The directory tree modificiation lock.
+    req : ArchiveFileCopyRequest
+        The request we're fulfilling.
+    """
+
+    # Before we were queued, NodeIO reserved space for this file.
+    # Automatically release bytes on task completion
+    task.on_cleanup(io.release_bytes, args=(req.file.size_b,))
+
+    # We know dest is local, so if source is too, this is a local transfer
+    local = req.node_from.local
+
+    # The Remote Node
+    remote = RemoteNode(req.node_from)
+
+    # Source spec
+    if local:
+        from_path = remote.io.file_path(req.file)
+    else:
+        try:
+            from_path = remote.io.file_addr(req.file)
+        except ValueError:
+            log.warning(
+                f"Skipping request for {req.file.path} "
+                f"due to unconfigured route to host for node {req.node_from.name}."
+            )
+            return
+
+    to_file = pathlib.Path(io.node.root, req.file.path)
+    to_dir = to_file.parent
+
+    # Placeholder file
+    placeholder = pathlib.Path(to_dir, f".{to_file.name}.placeholder")
+
+    # Create directories.  This must be done while locking up the tree lock
+    with tree_lock.up:
+        if not to_dir.exists():
+            log.info(f'Creating directory "{to_dir}".')
+            to_dir.mkdir(parents=True)
+
+        # If the file doesn't exist, create a placeholder so we can release
+        # the tree lock without having to wait for the transfer to complete
+        if not to_file.exists():
+            placeholder.touch(mode=0o600, exist_ok=True)
+
+    # Giddy up!
+    start_time = time.time()
+    log.info(f'Transferring file "{req.file.path}":')
+
+    # Attempt to transfer the file. Each of the methods below needs to return
+    # a dict with required key:
+    #  - ret : integer
+    #        return code (0 == success)
+    # optional keys:
+    #  - md5sum : string or True
+    #        If True, the sum is guaranteed to be right; otherwise, it's a
+    #        md5sum to check against the source.  Must be present if ret == 0
+    #  - stderr : string
+    #        if given, printed to the log when ret != 0
+    #  - check_src : bool
+    #        if given and False, the source file will _not_ be marked suspect
+    #        when ret != 0; otherwise, a failure results in a source check
+
+    # First we need to check if we are copying over the network
+    if not local:
+        if shutil.which("bbcp") is not None:
+            # First try bbcp which is a fast multistream transfer tool. bbcp can
+            # calculate the md5 hash as it goes, so we'll do that to save doing
+            # it at the end.
+            ioresult = ioutil.bbcp(from_path, to_dir, req.file.size_b)
+        elif shutil.which("rsync") is not None:
+            # Next try rsync over ssh.
+            ioresult = ioutil.rsync(from_path, to_dir, req.file.size_b, local)
+        else:
+            # We have no idea how to transfer the file...
+            log.error("No commands available to complete remote pull.")
+            ioresult = {"ret": -1, "check_src": False}
+
+    else:
+        # Okay, great we're just doing a local transfer.
+
+        # First try to just hard link the file. This will only work if we
+        # are on the same filesystem.  If it didn't work, ioresult will be None
+        #
+        # But don't do this if it creates a hardlink between an archive node and
+        # a non-archive node
+        if req.node_from.archive == io.node.archive:
+            ioresult = ioutil.hardlink(from_path, to_dir, req.file.name)
+        else:
+            ioresult = None
+
+        # If we couldn't just link the file, try copying it with rsync.
+        if ioresult is None:
+            if shutil.which("rsync") is not None:
+                ioresult = ioutil.rsync(from_path, to_dir, req.file.size_b, local)
+            else:
+                log.error("No commands available to complete local pull.")
+                ioresult = {"ret": -1, "check_src": False}
+
+    # Delete the placeholder, if we created it
+    placeholder.unlink(missing_ok=True)
+
+    if not ioutil.copy_request_done(
+        req,
+        io,
+        check_src=ioresult.get("check_src", True),
+        md5ok=ioresult.get("md5sum", None),
+        start_time=start_time,
+        stderr=ioresult.get("stderr", None),
+        success=(ioresult["ret"] == 0),
+    ):
+        # Remove file, on error
+        try:
+            to_file.unlink(missing_ok=True)
+        except OSError as e:
+            log.error(f"Error removing corrupt file {to_file}: {e}")
+
+    # Whatever has happened, update free space, if possible
+    new_avail = io.bytes_avail(fast=True)
+
+    # This was a fast update, so don't save "None" to the database
+    if new_avail is not None:
+        io.node.update_avail_gb(new_avail)
 
 
 def check_async(task: Task, io: BaseNodeIO, copy: ArchiveFileCopy) -> None:
@@ -74,7 +222,9 @@ def check_async(task: Task, io: BaseNodeIO, copy: ArchiveFileCopy) -> None:
     copy.save()
 
 
-def delete_async(task: Task, copies: list[ArchiveFileCopy]) -> None:
+def delete_async(
+    task: Task, tree_lock: UpDownLock, copies: list[ArchiveFileCopy]
+) -> None:
     """Delete some file copies, if possible.
 
     Copies are only deleted if sufficient archived copies exist
@@ -86,6 +236,8 @@ def delete_async(task: Task, copies: list[ArchiveFileCopy]) -> None:
     ----------
     task : Task
         The task instance containing this async.
+    tree_lock : UpDownLock
+        The directory tree modificiation lock.
     copies : list of ArchiveFileCopy
         The list of copies to delete.  Never empty.
     """
@@ -128,23 +280,26 @@ def delete_async(task: Task, copies: list[ArchiveFileCopy]) -> None:
         # and remove if they are.
         dirname = fullpath.parent
 
-        # try to delete the directories.
-        while dirname != ".":
-            try:
-                dirname.rmdir()
-                log.info(f"Removed directory {dirname} on {name}")
-            except OSError as e:
-                if e.errno == errno.ENOTEMPTY:
-                    # This is fine, but stop trying to rmdir.
-                    break
-                elif e.errno == errno.ENOENT:
-                    # Already deleted, which is fine.
-                    pass
-                else:
-                    log.warning(f"Error deleting directory {dirname} on {name}: {e}")
-                    # Otherwise, let's try to soldier on
+        # try to delete the directories.  This must be done while locking down the tree lock
+        with tree_lock.down:
+            while dirname != ".":
+                try:
+                    dirname.rmdir()
+                    log.info(f"Removed directory {dirname} on {name}")
+                except OSError as e:
+                    if e.errno == errno.ENOTEMPTY:
+                        # This is fine, but stop trying to rmdir.
+                        break
+                    elif e.errno == errno.ENOENT:
+                        # Already deleted, which is fine.
+                        pass
+                    else:
+                        log.warning(
+                            f"Error deleting directory {dirname} on {name}: {e}"
+                        )
+                        # Otherwise, let's try to soldier on
 
-            dirname = dirname.parent
+                dirname = dirname.parent
 
         # Update the DB
         ArchiveFileCopy.update(

--- a/alpenhorn/io/updownlock.py
+++ b/alpenhorn/io/updownlock.py
@@ -1,0 +1,267 @@
+"""UpDownLock: A two-way threading lock.
+
+This is a shared two-way lock used for thread synchronization.
+
+This lock behaves similarly to a regular `threading.RLock`, but
+can be in one of three states: locked up, locked down, or
+unlocked.
+
+All threads wanting to acquire the lock must choose one of the
+two locked states to acquire the lock in.  When the lock is
+in one of the locked states, any other threads wanting to
+acquire the lock in that same state may do so (i.e. multiple
+threads can hold the lock in a particular state), but threads
+wanting the other lock state must wait for the lock to become
+unlocked before they can aquire the lock.
+
+Alpenhorn uses this lock to prevent race conditions while
+modifying the directory tree of a StorageNode: threads which
+are in the process of creating directories must do so while
+holding the up lock and threads which are in the process of
+removing directories must do so while holding the down lock.
+
+The lock ensures only one operation (creation or removal) can
+happen at any given time.
+"""
+
+import time
+import threading
+from collections import defaultdict
+
+
+class _UpDownLock:
+    """UpDownLock internals.
+
+    Used to prevent a reference loop.
+    """
+
+    __slots__ = ["count", "_lock", "_owners", "_is_unlocked"]
+
+    def __init__(self) -> None:
+        # This tracks the state of the lock:
+        #  > 0: the lock is in the "up" state
+        #  = 0: the lock is unlocked
+        #  < 0: the lock is in the "down" state
+        #
+        # The absolute value indicates how many times
+        # the lock is held
+        self.count = 0
+
+        # Protects self._count
+        self._lock = threading.Lock()
+
+        # Dict of threads holding the lock.  Keys are the
+        # thread IDs.  Values are how many times that thread
+        # owns the lock.
+        self._owners = defaultdict(int)
+
+        # Is the lock unlocked?  Handles threads waiting for
+        # unlock.
+        self._is_unlocked = threading.Condition(threading.RLock())
+
+    def acquire(self, blocking: bool, timeout: float, is_down: bool) -> bool:
+        """Acquire the lock in the specified state."""
+
+        now = time.monotonic()
+        me = threading.get_ident()
+
+        # Try to acquire the lock
+        with self._lock:
+            if is_down:
+                ok_to_lock = self.count <= 0
+            else:
+                ok_to_lock = self.count >= 0
+
+            if ok_to_lock:
+                if is_down:
+                    self.count -= 1
+                else:
+                    self.count += 1
+                self._owners[me] += 1
+                return True
+
+            # If we already hold the lock in the other state, fail
+            if self._owners[me] > 0:
+                raise RuntimeError("Can't acquire both locking states.")
+
+        # If not blocking, fail
+        if not blocking:
+            return False
+
+        # Otherwise, wait until unlocked
+        with self._is_unlocked:
+            if timeout < 0:
+                self._is_unlocked.wait()
+            else:
+                end_at = None
+                notified = False
+
+                # Wait until either we're notified or else we timeout
+                while not notified and (end_at is None or time.monotonic() < end_at):
+                    # We do it this way to ensure this loop runs at least once
+                    if end_at is None:
+                        end_at = now + timeout
+
+                    # This might be negative; threading.condition is okay
+                    # with that (essentially it makes wait() non-blocking)
+                    timeout = end_at - time.monotonic()
+                    notified = self._is_unlocked.wait(timeout)
+
+                # If we're out of time, fail
+                if not notified:
+                    return False
+
+                # If we were notfied, but we're also out of time, convert to
+                # non blocking, to try one last time
+                if timeout <= 0:
+                    blocking = False
+
+        # If we got here, we were notified of the lock unlocking; try again,
+        # possibly with a reduced timeout and/or converted to non-blocking
+        return self.acquire(blocking, timeout, is_down)
+
+    def release(self, is_down: bool) -> None:
+        """Release the lock with the given state.
+
+        Raises RuntimeError if the lock was not held in the state.
+        """
+
+        me = threading.get_ident()
+
+        with self._lock:
+            if is_down:
+                ok_to_unlock = self.count < 0
+            else:
+                ok_to_unlock = self.count > 0
+
+            # Check ownership
+            if ok_to_unlock:
+                if self._owners[me] == 0:
+                    ok_to_unlock = False
+
+            if not ok_to_unlock:
+                raise RuntimeError(
+                    f"Lock not held in {'down' if is_down else 'up'} state."
+                )
+
+            # Otherwise, unlock
+            if is_down:
+                self.count += 1
+            else:
+                self.count -= 1
+            self._owners[me] -= 1
+
+            # If we're now unlocked, notifiy waiters
+            if self.count == 0:
+                with self._is_unlocked:
+                    self._is_unlocked.notify_all()
+
+
+class _UpDownAccessor:
+    """Lock accessor for one of the lock states.
+
+    To acquire the lock in this state, use the `acquire` method.
+
+    To release the lock in this state, use the `release` method.
+
+    This accessor can also be used as a context manager.
+    """
+
+    __slots__ = ["_is_down", "_internals"]
+
+    def __init__(self, is_down: bool, internals: _UpDownLock) -> None:
+        self._is_down = is_down
+        self._internals = internals
+
+    def acquire(self, blocking: bool = True, timeout: float = -1) -> bool:
+        """Acquire the lock once.
+
+        Parameters
+        ----------
+        blocking : bool
+            If True, block until the lock can be acquired (or timeout expires).
+            If False, this method immediately returns False if the lock cannot
+            be acquired.
+        timeout : float
+            If set to a positive value, and `blocking` is True, wait at most
+            `timeout` seconds before failing to acquire the lock (returning
+            False).
+
+        Returns
+        -------
+        success : bool
+            True if the lock was acquired.  False otherwise.
+
+        Raises
+        ------
+        RuntimeError:
+            Lock is already being held in the opposite state.
+        """
+        return self._internals.acquire(
+            blocking=blocking, timeout=timeout, is_down=self._is_down
+        )
+
+    def release(self) -> None:
+        """Release the lock once.
+
+        Raises
+        ------
+        RuntimeError:
+            The lock was not being held in this state.
+        """
+        self._internals.release(is_down=self._is_down)
+
+    # Context manager
+    __enter__ = acquire
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.release()
+        return False  # Re-raise exception, if any
+
+
+class UpDownLock:
+    """A two-way thread lock.
+
+    This is a threading synchronization primitive, similar to
+    a standard `threading.RLock`, but one which can be locked in
+    two different states ("up" and "down).
+
+    When locked in one of the states, any number of threads can
+    hold the lock in that state, but threads attempting to
+    acquire the lock in the other state must wait for the
+    lock to unlock first.
+
+    If a thread holds the lock in one a particular state, it may
+    re-acquire the lock in that state again without blocking
+    (i.e. the lock is re-entrant in this case), but a thread holding
+    the lock in one state may not attempt to also acquire the lock
+    in the opposite state as well. (This will result in a
+    RuntimeError.) A thread must release the lock once for each time
+    it has acquired the lock.
+
+    The two states of the lock are accessed via `UpDownLock.up`
+    and `UpDownLock.down`. These accessors provide `acquire` and
+    `release` methods which work as they do with the standard
+    `threading.Lock`.  The accessors may also be used as context
+    managers.
+    """
+
+    __slots__ = ["up", "down", "_internals"]
+
+    def __init__(self) -> None:
+        self._internals = _UpDownLock()
+        self.up = _UpDownAccessor(is_down=False, internals=self._internals)
+        self.down = _UpDownAccessor(is_down=True, internals=self._internals)
+
+    def __repr__(self) -> str:
+        count = self._internals.count
+        if count == 0:
+            state = "unlocked"
+        elif count > 0:
+            state = "locked up"
+        else:
+            state = "locked down"
+        return (
+            f"<UpDownLock object state={state} count={abs(count)} "
+            f"at {hex(id(self))}>"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -438,7 +438,7 @@ def simplecopy(
     acq = archiveacq(name="simplecopy_acq")
     file = archivefile(name="simplecopy_file", acq=acq, size_b=2**20)
     group = storagegroup(name="simplecopy_group")
-    node = storagenode(name="simplecopy_node", group=group)
+    node = storagenode(name="simplecopy_node", group=group, root="/simplecopy_node")
     return archivefilecopy(file=file, node=node)
 
 

--- a/tests/io/test_defaultgroup.py
+++ b/tests/io/test_defaultgroup.py
@@ -1,0 +1,72 @@
+"""Test DefaultGroupIO."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from alpenhorn.update import UpdateableNode, UpdateableGroup
+
+
+@pytest.fixture
+def groupnode(xfs, queue, storagegroup, storagenode):
+    """Fixture setting up a default test group.
+
+    Returns both the group and the node."""
+    stgroup = storagegroup(name="group")
+    node = UpdateableNode(
+        queue, storagenode(name="node", group=stgroup, active=True, root="/node")
+    )
+    group = UpdateableGroup(group=stgroup, nodes=[node], idle=True)
+
+    # Create the directory
+    xfs.create_dir("/node")
+
+    return group, node
+
+
+def test_too_many_nodes(storagegroup, storagenode):
+    """Test DefaultGroupIO rejecting more than one node."""
+
+    stgroup = storagegroup(name="group")
+    node1 = UpdateableNode(None, storagenode(name="node1", group=stgroup, active=True))
+    node2 = UpdateableNode(None, storagenode(name="node2", group=stgroup, active=True))
+
+    group = UpdateableGroup(group=stgroup, nodes=[node1, node2], idle=True)
+    assert group._nodes is None
+
+
+def test_just_enough_nodes(storagegroup, storagenode):
+    """Test DefaultGroupIO accepting one node."""
+
+    stgroup = storagegroup(name="group")
+    node = UpdateableNode(None, storagenode(name="node1", group=stgroup, active=True))
+
+    group = UpdateableGroup(group=stgroup, nodes=[node], idle=True)
+    assert group._nodes == [node]
+
+
+def test_exists(xfs, groupnode):
+    """Test DefaultGroupIO.exists."""
+
+    group, node = groupnode
+
+    # Make something on the node
+    xfs.create_file("/node/acq/file")
+
+    # Check
+    assert group.io.exists("acq/file") == node
+    assert group.io.exists("acq/no-file") is None
+    assert group.io.exists("no-acq/no-file") is None
+
+
+def test_pull_handoff(groupnode, simplerequest):
+    """Test DefaultGroupIO.pull()."""
+
+    # We mock the DefaultNodeIO.pull() method because we don't need to test it here.
+    group, node = groupnode
+    node.io.pull = MagicMock(return_value=None)
+
+    # Call pull
+    group.io.pull(simplerequest)
+
+    # Check for hand-off to the node
+    node.io.pull.assert_called_with(simplerequest)

--- a/tests/io/test_defaultnode_delete.py
+++ b/tests/io/test_defaultnode_delete.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from alpenhorn.archive import ArchiveFileCopy
 from alpenhorn.io._default_asyncs import delete_async
+from alpenhorn.io.updownlock import UpDownLock
 
 
 @pytest.fixture
@@ -185,8 +186,8 @@ def test_delete_dirs(
     delete_copies = copies.copy()
     del delete_copies[2]
 
-    # Call async directly for simplicity.
-    delete_async(None, delete_copies)
+    # Call async directly with a fake UpDownLock
+    delete_async(None, UpDownLock(), delete_copies)
 
     # Only copies[2] remains
     assert ArchiveFileCopy.select().where(ArchiveFileCopy.has_file == "Y").count() == 1

--- a/tests/io/test_defaultnode_pull.py
+++ b/tests/io/test_defaultnode_pull.py
@@ -1,0 +1,443 @@
+"""Test DefaultNodeIO.pull()"""
+
+import os
+import pytest
+import pathlib
+from unittest.mock import patch
+
+from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from alpenhorn.update import UpdateableNode
+
+
+@pytest.fixture
+def have_bbcp(mock_run_command):
+    """Pretend to have bbcp
+
+    Mocks shutil.which to indicate bbcp is present.
+
+    Also mocks util.run_command to emulate running bbcp.  Use the
+    run_command_result marker to specify the result of running bbcp."""
+
+    from shutil import which as real_which
+
+    def _mocked_which(cmd, mode=os.F_OK | os.X_OK, path=None):
+        nonlocal real_which
+        if cmd == "bbcp":
+            return "BBCP"
+        return real_which(cmd, mode, path)
+
+    with patch("shutil.which", _mocked_which):
+        yield mock_run_command
+
+
+@pytest.fixture
+def have_rsync(mock_run_command):
+    """Pretend to have rsync
+
+    Mocks shutil.which to indicate rsync is present.
+
+    Also mocks util.run_command to emulate running rsync.  Use the
+    run_command_result marker to specify the result of running rsync."""
+
+    from shutil import which as real_which
+
+    def _mocked_which(cmd, mode=os.F_OK | os.X_OK, path=None):
+        nonlocal real_which
+        if cmd == "rsync":
+            return "RSYNC"
+        return real_which(cmd, mode, path)
+
+    with patch("shutil.which", _mocked_which):
+        yield mock_run_command
+
+
+@pytest.fixture
+def test_req(
+    xfs,
+    hostname,
+    queue,
+    storagegroup,
+    storagenode,
+    simplefile,
+    archivefilecopy,
+    archivefilecopyrequest,
+):
+    """Create a test ArchiveFileCopyRequest.
+
+    Returns a two-element tuple: (node_to, copy_request)"""
+
+    group_to = storagegroup(name="group_to")
+    node_to = UpdateableNode(
+        queue,
+        storagenode(name="node_to", group=group_to, host=hostname, root="/node_to"),
+    )
+    node_from = storagenode(
+        name="node_from",
+        group=storagegroup(name="group_from"),
+        root="/node_from",
+        host=hostname,  # By default the transfer is local
+        username="user",
+        address="addr",
+    )
+
+    copy = archivefilecopy(file=simplefile, node=node_from, has_file="Y")
+
+    # Create source file and dest root
+    xfs.create_dir("/node_to")
+    xfs.create_file(copy.path, st_size=copy.size_b)
+    return (
+        node_to,
+        archivefilecopyrequest(file=simplefile, node_from=node_from, group_to=group_to),
+    )
+
+
+@pytest.fixture
+def pull_async(test_req):
+    """Put a pull_async Task on the queue.
+
+    Returns a two-element tuple: (node_to, copy_request)"""
+    node, req = test_req
+    node.io.pull(req)
+
+    return test_req
+
+
+def test_pull_sync_undermin(queue, test_req):
+    """test DefaultNodeIO.pull synchronous under_min check"""
+
+    node, req = test_req
+
+    # set up node to fail under_min check
+    node.db.avail_gb = 1.0
+    node.db.min_avail_gb = 2.0
+    node.io.pull(req)
+
+    # No job should be queued and req isn't resolved.
+    assert queue.qsize == 0
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+
+def test_pull_sync_overmax(queue, test_req, archivefile, archivefilecopy):
+    """test DefaultNodeIO.pull synchronous over_max check"""
+
+    # Init I/O layer
+    node, req = test_req
+
+    # set up node to fail over_max check
+    file = archivefile(name="file2", acq=req.file.acq, size_b=100000)
+    archivefilecopy(file=file, node=node.db, has_file="Y")
+    node.db.max_total_gb = file.size_b / 2**21  # i.e. half of file.size_b
+    node.io.pull(req)
+
+    # No job should be queued and req isn't resolved.
+    assert queue.qsize == 0
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+
+def test_pull_sync_fit(xfs, queue, test_req):
+    """test DefaultNodeIO.pull synchronous fit check"""
+
+    node, req = test_req
+
+    # set up node to fail reserve_bytes check
+    xfs.set_disk_usage(10000)
+    node.io.reserve_bytes(4000)
+    node.io.pull(req)
+
+    # No job should be queued and req isn't resolved.
+    assert queue.qsize == 0
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+
+def test_pull_async_noroute(queue, pull_async):
+    """Test no route for remote pull."""
+
+    node, req = pull_async
+
+    # Make the request non-local
+    req.node_from.host = "other-host"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Req isn't resolved.
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+    # Source is not being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file != "M"
+
+
+@pytest.mark.run_command_result(1, "", "bbcp_stderr")
+def test_pull_async_bbcp_fail(queue, have_bbcp, pull_async):
+    """Test an unsuccessful bbcp remote pull."""
+
+    node, req = pull_async
+
+    # Make the request non-local
+    req.node_from.host = "other-host"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Verify that bbcp ran
+    assert "bbcp" in have_bbcp()["cmd"]
+
+    # Req isn't resolved.
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+    # Source is being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file == "M"
+
+
+@pytest.mark.run_command_result(0, "", "md5 d41d8cd98f00b204e9800998ecf8427e")
+def test_pull_async_bbcp_succeed(queue, have_bbcp, mock_filesize, pull_async):
+    """Test a successful bbcp remote pull."""
+
+    node, req = pull_async
+
+    # Make the request non-local
+    req.node_from.host = "other-host"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Req is complete.
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is True
+    assert afcr.cancelled is False
+
+    # Verify that bbcp ran
+    assert "bbcp" in have_bbcp()["cmd"]
+
+    # Target copy exists
+    afc = ArchiveFileCopy.get(node=node.db, file=req.file)
+    assert afc.has_file == "Y"
+
+    # Source is not being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file != "M"
+
+
+@pytest.mark.run_command_result(1, "", "rsync_stderr")
+def test_pull_async_remote_rsync_fail(queue, have_rsync, pull_async):
+    """Test an unsuccessful rsync remote pull."""
+
+    node, req = pull_async
+
+    # Make the request non-local
+    req.node_from.host = "other-host"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Verify that rsync ran
+    assert "rsync" in have_rsync()["cmd"]
+
+    # Req isn't resolved.
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+    # Source is being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file == "M"
+
+
+@pytest.mark.run_command_result(0, "", "md5 d41d8cd98f00b204e9800998ecf8427e")
+def test_pull_async_remote_rsync_succeed(queue, have_rsync, mock_filesize, pull_async):
+    """Test a successful rsync remote pull."""
+
+    node, req = pull_async
+
+    # Make the request non-local
+    req.node_from.host = "other-host"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Verify that rsync ran
+    assert "rsync" in have_rsync()["cmd"]
+
+    # Req is complete.
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is True
+    assert afcr.cancelled is False
+
+    # Target copy exists
+    afc = ArchiveFileCopy.get(node=node.db, file=req.file)
+    assert afc.has_file == "Y"
+
+    # Source is not being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file != "M"
+
+
+def test_pull_async_remote_nomethod(queue, pull_async):
+    """Test remote pull with no command available."""
+
+    node, req = pull_async
+
+    # Make the request non-local
+    req.node_from.host = "other-host"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Req isn't resolved.
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+    # Source is not being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file != "M"
+
+
+def test_pull_async_link(queue, pull_async):
+    """Test creating hardlink."""
+
+    node, req = pull_async
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Req is resolved after successful hardlink
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is True
+    assert afcr.cancelled is False
+
+    # Target copy exists
+    afc = ArchiveFileCopy.get(node=node.db, file=req.file)
+    assert afc.has_file == "Y"
+
+    # Source is not being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file != "M"
+
+
+def test_pull_async_link_arccontam(queue, pull_async):
+    """Test not creating hardlinks between archive nodes."""
+
+    node, req = pull_async
+
+    # Make one node non-archival
+    node.db.storage_type = "F"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Req isn't resolved because we have no rsync, so failure
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+    # Source is not being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file != "M"
+
+
+@pytest.mark.run_command_result(0, "", "stderr")
+def test_pull_async_local_rsync_succeed(queue, have_rsync, mock_filesize, pull_async):
+    """Test a successful rsync remote pull."""
+
+    node, req = pull_async
+
+    # Make one node non-archival to avoid hardlinking
+    node.db.storage_type = "F"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Verify that rsync ran
+    assert "rsync" in have_rsync()["cmd"]
+
+    # Req is complete.
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is True
+    assert afcr.cancelled is False
+
+    # Target copy exists
+    afc = ArchiveFileCopy.get(node=node.db, file=req.file)
+    assert afc.has_file == "Y"
+
+    # Source is not being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file != "M"
+
+
+@pytest.mark.run_command_result(1, "", "rsync_stderr")
+def test_pull_async_local_rsync_fail(queue, have_rsync, pull_async):
+    """Test an unsuccessful rsync local pull."""
+
+    node, req = pull_async
+
+    # Make one node non-archival to avoid hardlinking
+    node.db.storage_type = "F"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Verify that rsync ran
+    assert "rsync" in have_rsync()["cmd"]
+
+    # Req isn't resolved.
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+    # Source is being re-checked
+    assert ArchiveFileCopy.get(node=req.node_from, file=req.file).has_file == "M"
+
+
+def test_pull_fail_unlink(xfs, queue, pull_async):
+    """Test failure deleting the destination."""
+
+    node, req = pull_async
+
+    # Destination path
+    path = pathlib.Path(node.db.root, req.file.path)
+
+    # Create destination file
+    xfs.create_file(path)
+
+    # Verify
+    assert path.exists()
+
+    # Force hardlinking to fail
+    node.db.storage_type = "T"
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Pull failure
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is False
+
+    # File is gone
+    assert not path.exists()

--- a/tests/io/test_defaultnoderemote.py
+++ b/tests/io/test_defaultnoderemote.py
@@ -1,0 +1,37 @@
+"""Test DefaultNodeRemote."""
+
+import pytest
+
+from alpenhorn.update import RemoteNode
+
+
+def test_file_addr(simplenode, simplefile):
+    """Test DefaultNodeRemote.file_addr"""
+
+    simplenode.address = None
+    simplenode.username = "user"
+
+    with pytest.raises(ValueError):
+        assert RemoteNode(simplenode).io.file_addr(simplefile) is None
+
+    simplenode.address = "addr"
+    simplenode.username = None
+
+    with pytest.raises(ValueError):
+        assert RemoteNode(simplenode).io.file_addr(simplefile) is None
+
+    simplenode.address = "addr"
+    simplenode.username = "user"
+
+    assert (
+        RemoteNode(simplenode).io.file_addr(simplefile)
+        == "user@addr:/node/simplefile_acq/simplefile"
+    )
+
+
+def test_file_path(simplecopy):
+    """Test DefaultNodeRemote.file_name"""
+
+    assert RemoteNode(simplecopy.node).io.file_path(simplecopy.file) == str(
+        simplecopy.path
+    )

--- a/tests/io/test_updownlock.py
+++ b/tests/io/test_updownlock.py
@@ -1,0 +1,343 @@
+"""Test the UpDownLock"""
+
+import pytest
+import threading
+from time import sleep
+
+from alpenhorn.io.updownlock import UpDownLock
+
+
+@pytest.fixture
+def udlock():
+    """Provide and check an UpDownLock
+
+    Yields a newly-created lock and after the test
+    ensures it's unlocked.
+    """
+
+    lock = UpDownLock()
+
+    # Verify we're unlocked to begin with
+    assert "unlocked" in repr(lock)
+
+    yield lock
+
+    # Must be unlocked again after the test
+    assert "unlocked" in repr(lock)
+
+
+def test_lock_up(udlock):
+    """Test the up lock."""
+
+    assert udlock.up.acquire()
+
+    # Check
+    assert "locked up" in repr(udlock)
+    assert "count=1 " in repr(udlock)
+
+    udlock.up.release()
+
+
+def test_lock_down(udlock):
+    """Test the down lock."""
+
+    assert udlock.down.acquire()
+
+    # Check
+    assert "locked down" in repr(udlock)
+    assert "count=1 " in repr(udlock)
+
+    udlock.down.release()
+
+
+def test_unlock_release(udlock):
+    """Releasing an unlocked lock raises RuntimeError."""
+
+    with pytest.raises(RuntimeError):
+        udlock.up.release()
+
+    with pytest.raises(RuntimeError):
+        udlock.down.release()
+
+
+def test_antirelease(udlock):
+    """Releasing the wrong state raises RuntimeError."""
+
+    assert udlock.up.acquire()
+    with pytest.raises(RuntimeError):
+        udlock.down.release()
+    udlock.up.release()
+
+    assert udlock.down.acquire()
+    with pytest.raises(RuntimeError):
+        udlock.up.release()
+    udlock.down.release()
+
+
+def test_acquire_both(udlock):
+    """Attempting to acquire both lock states raises RuntimeError."""
+
+    assert udlock.up.acquire()
+    with pytest.raises(RuntimeError):
+        udlock.down.acquire()
+    udlock.up.release()
+
+    assert udlock.down.acquire()
+    with pytest.raises(RuntimeError):
+        udlock.up.acquire()
+    udlock.down.release()
+
+
+def test_reentry_up(udlock):
+    """Test lock re-entry."""
+
+    # Test the up lock
+    assert udlock.up.acquire()
+    assert udlock.up.acquire()
+    assert udlock.up.acquire()
+
+    # Check
+    assert "locked up" in repr(udlock)
+    assert "count=3" in repr(udlock)
+
+    udlock.up.release()
+    udlock.up.release()
+
+    # Still locked
+    assert "locked up" in repr(udlock)
+    assert "count=1" in repr(udlock)
+
+    udlock.up.release()
+
+
+def test_reentry_down(udlock):
+    """Test lock re-entry."""
+
+    # Test the down lock
+    assert udlock.down.acquire()
+    assert udlock.down.acquire()
+    assert udlock.down.acquire()
+
+    # Check
+    assert "locked down" in repr(udlock)
+    assert "count=3" in repr(udlock)
+
+    udlock.down.release()
+    udlock.down.release()
+
+    # Still locked
+    assert "locked down" in repr(udlock)
+    assert "count=1" in repr(udlock)
+
+    udlock.down.release()
+
+
+def test_threads_up(udlock):
+    """Test acquiring the lock from multiple threads."""
+
+    # Number of threads to run
+    n = 3
+
+    # Synchronisation barrier
+    barrier = threading.Barrier(1 + n)
+
+    def thread(udlock, barrier):
+        udlock.up.acquire()
+
+        # Wait for check to complete
+        barrier.wait()
+        barrier.wait()
+
+        # Now release
+        udlock.up.release()
+
+    # Create threads
+    threads = list()
+    for _ in range(n):
+        threads.append(
+            threading.Thread(target=thread, args=(udlock, barrier), daemon=True)
+        )
+
+    # Start threads
+    for thread in threads:
+        thread.start()
+
+    # Wait for lock acquisition
+    barrier.wait()
+
+    # Check
+    assert f"count={n}" in repr(udlock)
+
+    # Clean up
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+
+def test_threads_down(udlock):
+    """Test acquiring the lock from multiple threads."""
+
+    # Number of threads to run
+    n = 3
+
+    # Synchronisation barriers
+    barrier = threading.Barrier(1 + n)
+
+    def thread(udlock, barrier):
+        udlock.down.acquire()
+
+        # Wait for check to complete
+        barrier.wait()
+        barrier.wait()
+
+        # Now release
+        udlock.down.release()
+
+    # Create threads
+    threads = list()
+    for _ in range(n):
+        threads.append(
+            threading.Thread(target=thread, args=(udlock, barrier), daemon=True)
+        )
+
+    # Start threads
+    for thread in threads:
+        thread.start()
+
+    # Wait for lock acquisition
+    barrier.wait()
+
+    # Check
+    assert f"count={n}" in repr(udlock)
+
+    # Clean up
+    barrier.wait()
+    for thread in threads:
+        thread.join()
+
+
+def test_nonblocking(udlock):
+    """Test a non-blocking acquire."""
+
+    barrier = threading.Barrier(2)
+
+    def thread(udlock, barrier):
+        # Lock up
+        udlock.up.acquire()
+
+        # Wait for main to test
+        barrier.wait()
+        barrier.wait()
+
+        udlock.up.release()
+
+    t = threading.Thread(target=thread, args=(udlock, barrier), daemon=True)
+    t.start()
+
+    # Wait for lock
+    barrier.wait()
+
+    # Try locking
+    assert not udlock.down.acquire(blocking=False)
+
+    # Test done
+    barrier.wait()
+    t.join()
+
+
+def test_waiting(udlock):
+    """Test waiting for a lock."""
+
+    # Synchronisation barrier between main and one test thread
+    barrier2 = threading.Barrier(2)
+
+    # Synchronisation barrier between all threads
+    barrier3 = threading.Barrier(3)
+
+    def upthread(udlock, barrier2, barrier3):
+        udlock.up.acquire()
+
+        # Signal we have the up lock
+        barrier3.wait()  # Sync point 1
+
+        # Wait for main to detect downthread waiting
+        barrier2.wait()  # Sync point 2
+
+        # Release the lock
+        udlock.up.release()
+
+        # Wait for downthread to acquire down lock
+        barrier3.wait()  # Sync point 3
+
+        # Attempt to acquire uplock (this blocks now)
+        assert udlock.up.acquire()
+
+        # Signal we have the up lock
+        barrier3.wait()  # Sync point 5
+
+        # Wait for main thread to check lock state
+        barrier2.wait()  # Sync point 6
+
+        # Release the lock again
+        udlock.up.release()
+
+    def downthread(udlock, barrier2, barrier3):
+        # Wait for upthread to lock up
+        barrier3.wait()  # Sync point 1
+
+        # Acquire the down lock (this blocks)
+        assert udlock.down.acquire()
+
+        # Signal we have the down lock
+        barrier3.wait()  # Sync point 3
+
+        # Wait for main to detect upthread waiting
+        barrier2.wait()  # Sync point 4
+
+        # Release the lock
+        udlock.down.release()
+
+        # Wait for upthread to re-acquire
+        barrier3.wait()  # Sync point 5
+
+    up = threading.Thread(
+        target=upthread, args=(udlock, barrier2, barrier3), daemon=True
+    )
+    down = threading.Thread(
+        target=downthread, args=(udlock, barrier2, barrier3), daemon=True
+    )
+
+    # Start
+    up.start()
+    down.start()
+
+    # Wait for lock up
+    barrier3.wait()  # Sync point 1
+
+    assert "locked up" in repr(udlock)
+
+    # Wait for a bit to give downthread a chance to block
+    sleep(0.05)
+
+    # It's probably fine now
+    barrier2.wait()  # Sync point 2
+
+    # Wait for lock change
+    barrier3.wait()  # Sync point 3
+
+    assert "locked down" in repr(udlock)
+
+    # Wait for a bit to give upthread a chance to block
+    sleep(0.05)
+    barrier2.wait()  # Sync point 4
+
+    # Wait for lock up
+    barrier3.wait()  # Sync point 5
+
+    assert "locked up" in repr(udlock)
+    # We're done
+    barrier2.wait()  # Sync point 6
+
+    # Clean up
+    up.join()
+    down.join()

--- a/tests/test_update_group.py
+++ b/tests/test_update_group.py
@@ -1,4 +1,223 @@
 """Tests for UpdateableGroup."""
+import pytest
+from unittest.mock import patch, call
+
+from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
+
+
+def make_afcr(
+    name,
+    acq,
+    srcnode,
+    srcstate,
+    dstgroup,
+    dstnode,
+    dststate,
+    archivefile,
+    archivefilecopy,
+    archivefilecopyrequest,
+):
+    """Create an ArchiveFileCopyRequest with ArchiveFileCopies on src and dest.
+
+    Returns a 4-tuple: ArchiveFile, source-ArchiveFileCopy, dest-ArchiveFileCopy, Request
+    """
+    file = archivefile(name=name, acq=acq)
+    srccopy = archivefilecopy(node=srcnode, file=file, has_file=srcstate)
+    if dststate is None:
+        dstcopy = None
+    else:
+        dstcopy = archivefilecopy(node=dstnode, file=file, has_file=dststate)
+    afcr = archivefilecopyrequest(node_from=srcnode, group_to=dstgroup, file=file)
+
+    return file, srccopy, dstcopy, afcr
+
+
+@pytest.fixture
+def pull(
+    mockgroupandnode,
+    simpleacq,
+    simplenode,
+    archivefile,
+    archivefilecopy,
+    archivefilecopyrequest,
+):
+    """A simple ArchiveFileCopyRequest for update_group.
+
+    The group and node form `mockedgroupandnode` are the
+    destination.  `simplenode` is the source.
+    """
+
+    # Make source active
+    simplenode.active = True
+    simplenode.save()
+
+    mockio, group, node = mockgroupandnode
+
+    mockio.group.before_update.return_value = True
+    # File doesn't exist on dest
+    mockio.group.exists.return_value = None
+
+    result = make_afcr(
+        "file",
+        simpleacq,
+        simplenode,
+        "Y",
+        group.db,
+        node.db,
+        None,
+        archivefile,
+        archivefilecopy,
+        archivefilecopyrequest,
+    )
+
+    # Don't bother returning the dstcopy, which is None
+    return result[0], result[1], result[3]
+
+
+def test_update_group_inactive(mockgroupandnode, hostname, queue, pull, simplenode):
+    """Test running update.update_group with source node inactive."""
+
+    mockio, group, node = mockgroupandnode
+    file, copy, afcr = pull
+
+    # Source not active
+    simplenode.active = False
+    simplenode.save()
+
+    # run update
+    group.update()
+
+    # afcr is not handled
+    assert not ArchiveFileCopyRequest.get(file=file).completed
+    assert not ArchiveFileCopyRequest.get(file=file).cancelled
+    assert call.pull(file) not in mockio.group.mock_calls
+
+
+def test_update_group_nosrc(mockgroupandnode, hostname, queue, pull):
+    """Test running update.update_group with source file missing."""
+
+    mockio, group, node = mockgroupandnode
+    file, copy, afcr = pull
+
+    # Source not present
+    copy.has_file = "N"
+    copy.save()
+
+    # run update
+    group.update()
+
+    # afcr is not handled
+    assert not ArchiveFileCopyRequest.get(file=afcr.file).completed
+    assert not ArchiveFileCopyRequest.get(file=afcr.file).cancelled
+    assert call.pull(afcr) not in mockio.group.mock_calls
+
+
+def test_update_group_notready(mockgroupandnode, hostname, queue, pull):
+    """Test running update.update_group with source file not ready."""
+
+    mockio, group, node = mockgroupandnode
+    file, copy, afcr = pull
+
+    # Force source not ready
+    with patch(
+        "alpenhorn.io.default.DefaultNodeRemote.pull_ready", lambda self, file: False
+    ):
+        # run update
+        group.update()
+
+    # afcr is not handled
+    assert not ArchiveFileCopyRequest.get(file=file).completed
+    assert not ArchiveFileCopyRequest.get(file=file).cancelled
+    assert call.pull(afcr) not in mockio.group.mock_calls
+
+
+def test_update_group_path_exists(mockgroupandnode, hostname, queue, pull):
+    """Test running update.update_group with unexpected existing dest."""
+
+    mockio, group, node = mockgroupandnode
+    file, copy, afcr = pull
+
+    # File exists on dest
+    mockio.group.exists.return_value = node
+
+    # This runs twice, to test two possibilities:
+    # - no destination ArchiveFileCopy record
+    # - desitination ArchiveFileCopy present with has_file='N'
+    # It should behave the same both times
+    for missing in [True, False]:
+        # run update
+        group.update()
+
+        # Dest file copy needs checking
+        dst = ArchiveFileCopy.get(file=file, node=node.db)
+        assert dst.has_file == "M"
+
+        # Request is still pending
+        assert not ArchiveFileCopyRequest.get(file=file).completed
+        assert not ArchiveFileCopyRequest.get(file=file).cancelled
+
+        # Pull was not executed
+        assert call.pull(afcr) not in mockio.group.mock_calls
+
+        # Only need to do this the first time
+        if missing:
+            # "Delete" dest
+            dst.has_file = "N"
+            dst.save()
+
+
+def test_update_group_copy_state(
+    mockgroupandnode,
+    hostname,
+    queue,
+    simplenode,
+    simpleacq,
+    archivefile,
+    archivefilecopy,
+    archivefilecopyrequest,
+):
+    """Test running update.update_group with different copy states."""
+
+    mockio, group, node = mockgroupandnode
+
+    mockio.group.before_update.return_value = True
+    # Files don't exist on dest
+    mockio.group.exists.return_value = None
+
+    # Source is active
+    simplenode.active = True
+    simplenode.save()
+
+    # Make some pull requests
+    commonargs = (simpleacq, simplenode, "Y", group.db, node.db)
+    factories = (archivefile, archivefilecopy, archivefilecopyrequest)
+    fileY, srcY, dstY, afcrY = make_afcr("fileY", *commonargs, "Y", *factories)
+    fileM, srcM, dstM, afcrM = make_afcr("fileM", *commonargs, "M", *factories)
+    fileX, srcX, dstX, afcrX = make_afcr("fileX", *commonargs, "X", *factories)
+    fileN, srcN, dstN, afcrN = make_afcr("fileN", *commonargs, "N", *factories)
+
+    # run update
+    group.update()
+
+    # afcrY is cancelled
+    assert not ArchiveFileCopyRequest.get(file=fileY).completed
+    assert ArchiveFileCopyRequest.get(file=fileY).cancelled
+    assert call.pull(afcrY) not in mockio.group.mock_calls
+
+    # afcrM is ongoing, but not handled
+    assert not ArchiveFileCopyRequest.get(file=fileM).completed
+    assert not ArchiveFileCopyRequest.get(file=fileM).cancelled
+    assert call.pull(afcrM) not in mockio.group.mock_calls
+
+    # afcrX was executed
+    assert not ArchiveFileCopyRequest.get(file=fileX).completed
+    assert not ArchiveFileCopyRequest.get(file=fileX).cancelled
+    assert call.pull(afcrX) in mockio.group.mock_calls
+
+    # afcrN was executed
+    assert not ArchiveFileCopyRequest.get(file=fileX).completed
+    assert not ArchiveFileCopyRequest.get(file=fileX).cancelled
+    assert call.pull(afcrN) in mockio.group.mock_calls
 
 
 def test_group_idle(queue, mockgroupandnode):


### PR DESCRIPTION
This PR completes the re-write of `update.py` to transition to the new I/O framework by re-implementing support for pull requests.

## The UpDownLock
This is a fairly simple thread synchronization primitive that I'm a little surprised it doesn't already exist.

It's used to prevent race conditions during the modifications of a node directory tree by only allowing either creation or deletion to happen at any given time.  It's needed to prevent the following (starting from a node with only one file on it, `/node/acq/file1`:
```
    worker1 (pulling)                       worker2 (deleting)
    -----------------------                 -----------------------
    wants to create:                        wants to delete:
       /node/acq/file2                        /node/acq/file1
    -----------------------                 -----------------------
1.  verifies that /node/acq exists          deletes /node/acq/file1

2.  skips directory creation                deletes /node/acq (empty dir)

3.  tries to create /node/acq/file2                  ...

4.  catches on fire because /node/acq                ...
      is now missing after verifying
      it existed
```

Any number of threads may hold the lock in a particular state ("lock up" or "lock down") at any given time, but switching from one state to the other forces threads to wait for the lock to become unlocked first.

## Group I/O
Finally, the reason for having an I/O class for StorageGroups:  pull requests, because they target a group are now handled by the group I/O class. The job of the group I/O class is to:
* figure out if the file already exists in this group (`DefaultGroupIO.exists`) and, if it does, cancel the request
* otherwise, figure out which node in the group (if any) will receive the pull request (`DefaultGroupIO.pull`)

If the group selects a node for the request, the rest of the pull is then handed off to the node's I/O layer.

## Node I/O
The guts of the pull request haven't changed and live in the `pull_async`, which is just a cleaned-up version of what used to be in `update_node_requests`.

One wrinkle:
* because all the pull requests now (potentially) happen simultaneously, there needs to be a mechanism for avoiding pulling too much data to the node at once.  This is done via the `reserve_bytes` mechanism in DefaultIO which synchronously (i.e. in the main thread) tries to "reserve" a certain amount of the free space on the node before creating a pull task.  If the reservation fails, the request is skipped (node too full), until the next time through the loop when there might be space.
* There's a "reservation factor" which I've set to 2 (though the correct factor might be something else), meaning twice as much space is reserved than is needed.  This guarantees we'll never overfill a node as a result of actual-apparent size differences, but does mean a node will never get to 100% full.  Not sure if there's a better way to do this.

## Remote I/O
This PR also introduces a somewhat-awkward "Remote I/O" module which is used by alpenhorn to learn things about a non-local node (Technically, it's any node that's the source-side of a pull request, which may in fact be local).  The reason for this is knowledge about a remote node needs to be laundered through the I/O layer because the I/O class and I/O config may affect the information.

There's only two bits of information that alpenhorn needs from a remote node:
* what is the path to the remote file (`file_addr` or `file_path`) that can be given to bbcp/rsync
* is the remote file ready to be pulled (`pull_ready`)

This information could definitely just be part of the Node I/O class, but making it a separate object prevents trying to perform I/O operations on the source node of a pull request.

## Changes to pulls
I've made a few, hopefully minor, changes to the details of how a pull request happens:
* hard links are now never made between archive nodes and non-archive nodes.  I think this is a good idea for the purposes of data integrity of the archived data.  It prevents the accidental corruption of archived files which are accessed via a different node (where you might otherwise think corruption isn't a big deal because you can always just re-sync from the archive copy).
* I'm more explicit about what to do when there's a copy of a file on the pull destination (which may or may not be registered in the database).  Alpenhorn-1 would just fall over and complain when this happened.  Alpenhorn-2 before this rewrite was better about things: it just explicitly clobbered a destination file.  But now the response is more nuanced:
   * If there's an `ArchiveFileCopy` on the destination node with `has_file=='Y'`, then alpenhorn says "Job's a good'un" and cancels the request it was working on
   * If there's an `ArchiveFileCopy` with `has_file=='X'`, then the pull goes ahead and the corrupt file is overwritten.
   * If there's an `ArchiveFileCopy` with `has_file=='M'`, then alpenhorn figures the destination file is going to be checked for corruption soon, and just abandons the request without resolving it (reasoning that next time round, when we handle the request again, the check will have completed and changed `has_file` to "Y" or "X" as appropriate.)
   * Otherwise (`ArchiveFileCopy.has_file=='N'` or no copy record at all), then it looks for a file with the destination path.  If it finds one, it creates/updates an `ArchiveFileCopy` for the existing file and sets `has_file='M'` so that the unexpected file on the destination gets checked.  The request is in this case abandonned without resolution and, like the other `has_file=='M'` case above, it will come back to finish the request after the check is completed.
   * Ultimately, if none of the above happens, then the pull is clear to proceed.

## Broken by this PR
This PR deletes all the special casing previously in `update.py` for transport nodes.  A replacement, in the form of a Transport Group I/O class, will be implemented to fix this in the next PR.

## Resolved by this PR
I think this closes #48 in that a NULL `address` is only going to be a problem in cases when a pull request actually needs it now.