### PR TITLE
Rewrite 11/14: Transport Group I/O

### DIFF
--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -282,6 +282,21 @@ class BaseNodeIO:
         """
         raise NotImplementedError("method must be re-implemented in subclass.")
 
+    def fits(self, size_b: int) -> bool:
+        """Does `size_b` bytes fit on this node?
+
+        Parameters
+        ----------
+        size_b : int
+            The size of the file we're trying to fit
+
+        Returns
+        -------
+        fits : bool
+            True if `size_b` fits on the node.  False otherwise.
+        """
+        raise NotImplementedError("method must be re-implemented in subclass.")
+
     def md5(self, path: str | pathlib.Path, *segments) -> str:
         """Compute the MD5 hash of the file at the specified path.
 

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -198,6 +198,23 @@ class DefaultNodeIO(BaseNodeIO):
         # Apparent size
         return path.stat().st_size
 
+    def fits(self, size_b: int) -> bool:
+        """Does `size_b` bytes fit on this node?
+
+        Takes into account reserved space.
+
+        Parameters
+        ----------
+        size_b : int
+            The size of the file we're trying to fit
+
+        Returns
+        -------
+        fits : bool
+            True if `size_b` fits on the node.  False otherwise.
+        """
+        return self.reserve_bytes(size_b, check_only=True)
+
     def md5(self, path: str | pathlib.Path, *segments) -> str:
         """Compute the MD5 hash of the file at the specified path.
 

--- a/alpenhorn/io/transport.py
+++ b/alpenhorn/io/transport.py
@@ -1,0 +1,165 @@
+"""Transport Group I/O."""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import logging
+
+from .base import BaseGroupIO
+
+if TYPE_CHECKING:
+    import pathlib
+    from ..archive import ArchiveFileCopyRequest
+    from ..update import UpdateableNode
+
+log = logging.getLogger(__name__)
+
+
+class TransportGroupIO(BaseGroupIO):
+    """Transport Group I/O.
+
+    This implements (the formerly special-cased) transport disk logic.
+
+    A Transport StorageGroup is used to transfer data onto transiting
+    storage.
+
+    Features of a Transport StorageGroup:
+        - it may have any number of nodes.  All node must have
+            node.db.storage_type == 'T', but no restrictions are put on the
+            io_class of nodes
+        - all pulls to the StorageGroup must be local: non-local pull
+            requests will be ignored
+        - when handling pull requests, transport nodes are prioritised by
+            increasing free space: the group will attempt to pull a file
+            to the fullest node that it thinks it will fit on.
+    """
+
+    def set_nodes(self, nodes: list[UpdateableNode]) -> list[UpdateableNode]:
+        """Check that nodes in group are transit nodes.
+
+        Parameters
+        ----------
+        nodes : list of UpdateableNodes
+            local active nodes in this group
+
+        Returns
+        -------
+        nodes : list of UpdateableNodes
+            subset of `nodes` which are Transport nodes.
+
+        Raises
+        ------
+        ValueError
+            none of the supplied `nodes` were Transport nodes.
+        """
+        self._nodes = list()
+        for node in nodes:
+            if node.db.storage_type != "T":
+                log.warning(
+                    f'Ignoring non-transport node "{node.name}" '
+                    f'in Transport Group "{self.group.name}"'
+                )
+            else:
+                self._nodes.append(node)
+
+        if not len(self._nodes):
+            raise ValueError(
+                f"no usable nodes ({len(nodes)} unusable) in "
+                f"Transport group {self.group.name}"
+            )
+
+        return self._nodes
+
+    def exists(self, path: pathlib.PurePath) -> UpdateableNode | None:
+        """Checks whether a file at `path` exists in this group.
+
+        Parameters
+        ----------
+        path : pathlib.PurePath
+            the path to search for; relative to node root
+
+        Returns
+        -------
+        exists : UpdateableNode or None
+            If `path` is found on a node in the group, this is the node.
+            If `path` was not found, this is None.
+
+        Notes
+        -----
+        If `path` exists on multiple nodes in the group, then one of the
+        nodes where it exists is returned.  The caller should _not_ assume
+        this is stable: multiple calls to this method with the same `path`
+        may return different nodes.
+        """
+        for node in self._nodes:
+            if node.io.exists(path):
+                return node
+
+        return None
+
+    def pull(self, req: ArchiveFileCopyRequest) -> None:
+        """Handle a pull request.
+
+        Only local pulls are only fulfilled.  Remote pulls are ignored.
+
+        The request will be handed off to the fullest node that can fit the
+        file to be pulled.
+
+        Parameters
+        ----------
+        req : ArchiveFileCopyRequest
+            the request to fulfill.  We are the destination group (i.e.
+            `req.group_to == self.group`).
+        """
+
+        # If this is a non-local transfer, skip it.
+        if not req.node_from.local:
+            log.info(
+                f"Skipping pull of {req.file.path} from node "
+                f"{req.node_from.name} to group {req.group_to.name}: "
+                f"non-local transfer request."
+            )
+            return
+
+        # Sort the nodes; this has to be done for every request because
+        # available space (hopefully) changes as requests are submitted and
+        # completed.
+
+        # Our node-sorting function
+        def _node_key(node):
+            """Sort key function for Transport nodes.
+
+            Returns `node.db.avail_gb`, if that's numeric, or else a very
+            large float if it's `None`."""
+            n = node.db.avail_gb
+            if n is not None:
+                return n
+
+            # Using node.db.id here makes ordering stable.  1e9 GB = 1EB, so we'll
+            # be fine for a while until disks get too big.
+            return node.db.id * 1e9
+
+        # loop through sorted nodes and pick a node
+        for node in sorted(self._nodes, key=_node_key):
+            # Skip node out of space
+            if node.db.under_min:
+                log.debug(f"Ignoring transport node {node.name}: hit min_avail_gb")
+                continue
+
+            # Skip full node
+            if node.db.check_over_max():
+                log.debug(f"Ignoring transport node {node.name}: hit max_total_gb")
+                continue
+
+            # Skip this node if the file won't fit
+            if not node.io.fits(req.file.size_b):
+                log.debug(f"Ignoring transport node {node.name}: not enough space")
+                continue
+
+            # If we got here, I guess we're going to use this disk
+            # Hand the pull request off to the node
+            node.io.pull(req)
+            return
+
+        # If we got here, we couldn't find a disk
+        log.debug(f'Unable to find a transport node for "{req.file.path}"')
+        return

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -707,7 +707,7 @@ def update_loop(
             else:
                 new_groups[group_name]["nodes"].append(node)
                 new_groups[group_name]["idle"] = (
-                    new_groups[group_name]["idle"] and node.io.idle
+                    new_groups[group_name]["idle"] and node.idle
                 )
 
         # Drop groups that are no longer available

--- a/tests/io/test_defaultnode.py
+++ b/tests/io/test_defaultnode.py
@@ -45,6 +45,16 @@ def test_filesize(unode, xfs):
     assert unode.io.filesize("dir/file1", actual=True) == 1024
 
 
+def test_fits(unode, xfs):
+    """test DefaultNodeIO.fits()."""
+
+    xfs.create_dir("/node")
+    xfs.set_disk_usage(10000)
+
+    assert unode.io.fits(3000) is True
+    assert unode.io.fits(30000) is False
+
+
 def test_md5(unode, xfs):
     """test DefaultNodeIO.md5()"""
     xfs.create_file("/node/dir/file1")

--- a/tests/io/test_transport.py
+++ b/tests/io/test_transport.py
@@ -1,0 +1,274 @@
+"""Test TransportGroupIO."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from alpenhorn.archive import ArchiveFileCopyRequest
+from alpenhorn.update import UpdateableGroup, UpdateableNode
+
+
+@pytest.fixture
+def transport_fleet(transport_fleet_no_init):
+    """Create a Transport group for testing.
+
+    Returns a tuple:
+        - the Tranport StorageGroup
+        - a list of the StorageNodes
+    """
+
+    # Do init
+    stgroup, nodes = transport_fleet_no_init
+    group = UpdateableGroup(group=stgroup, nodes=nodes, idle=True)
+
+    return group, nodes
+
+
+@pytest.fixture
+def transport_fleet_no_init(xfs, hostname, queue, storagegroup, storagenode):
+    """Like transport_fleet, but initialisation of the group
+    is not done (so it can be tested)."""
+
+    stgroup = storagegroup(name="group", io_class="Transport")
+
+    nodes = [
+        UpdateableNode(
+            queue,
+            storagenode(
+                name="node1",
+                group=stgroup,
+                storage_type="T",
+                avail_gb=10,
+                root="/node1",
+                host=hostname,
+            ),
+        ),
+        UpdateableNode(
+            queue,
+            storagenode(
+                name="node2",
+                group=stgroup,
+                storage_type="T",
+                avail_gb=20,
+                root="/node2",
+                host=hostname,
+            ),
+        ),
+        UpdateableNode(
+            queue,
+            storagenode(
+                name="node3",
+                group=stgroup,
+                storage_type="T",
+                avail_gb=40,
+                root="/node3",
+                host=hostname,
+            ),
+        ),
+        UpdateableNode(
+            queue,
+            storagenode(
+                name="node4",
+                group=stgroup,
+                storage_type="T",
+                avail_gb=None,
+                root="/node4",
+                host=hostname,
+            ),
+        ),
+    ]
+
+    for index, node in enumerate(nodes):
+        # All the node pull methods are mocked to avoid running them.
+        node.io.pull = MagicMock(return_value=None)
+        # mock bytes_avail to simply return avail_gb to avoid having to mess about with pyfakefs
+        node.io.bytes_avail = MagicMock(
+            return_value=None
+            if node.db.avail_gb is None
+            else node.db.avail_gb * 2**30
+        )
+        xfs.create_dir(node.db.root)
+
+    return stgroup, nodes
+
+
+@pytest.fixture
+def remote_req(
+    transport_fleet,
+    simplegroup,
+    storagenode,
+    simplefile,
+    archivefilecopyrequest,
+):
+    """Create a non-local ArchiveFileCopyRequest targetting the transport group."""
+    group_to, _ = transport_fleet
+    node_from = storagenode(name="src", group=simplegroup, host="other-host")
+    req = archivefilecopyrequest(
+        file=simplefile, node_from=node_from, group_to=group_to.db
+    )
+
+    return req
+
+
+@pytest.fixture
+def req(hostname, remote_req):
+    """Create a local ArchiveFileCopyRequest targetting the transport group."""
+
+    # Fix src node to be local
+    remote_req.node_from.host = hostname
+
+    return remote_req
+
+
+def test_group_init(transport_fleet_no_init):
+    """Test initialisation of TranportGroupIO with good nodes."""
+    stgroup, nodes = transport_fleet_no_init
+
+    group = UpdateableGroup(group=stgroup, nodes=nodes, idle=True)
+    assert group._nodes == nodes
+
+
+def test_group_init_bad(transport_fleet_no_init):
+    """Test initialisation of TranportGroupIO with bad nodes."""
+    stgroup, nodes = transport_fleet_no_init
+
+    # Change all the nodes to not be transport nodes.
+    for node in nodes:
+        node.db.storage_type = "F"
+
+    group = UpdateableGroup(group=stgroup, nodes=nodes, idle=True)
+    assert group._nodes is None
+
+
+def test_group_init_mixed(transport_fleet_no_init):
+    """Test initialisation of TranportGroupIO with some bad nodes."""
+    stgroup, nodes = transport_fleet_no_init
+
+    # Change _some_ of the nodes to non-transport
+    nodes[0].db.storage_type = "A"
+    nodes[3].db.storage_type = "F"
+
+    group = UpdateableGroup(group=stgroup, nodes=nodes, idle=True)
+    assert group._nodes == nodes[1:3]
+
+
+def test_idle(queue, transport_fleet):
+    """Test TransportGroupIO.idle."""
+    group, nodes = transport_fleet
+
+    # Currently idle
+    assert group.idle is True
+
+    # Enqueue something into a node's queue
+    queue.put(None, nodes[2].name)
+
+    # Now not idle
+    assert group.idle is False
+
+    # Dequeue it
+    task, key = queue.get()
+    queue.task_done(nodes[2].name)
+
+    # Now idle again
+    assert group.idle is True
+
+
+def test_exists(xfs, transport_fleet):
+    """Test TransportGroupIO.exists()."""
+    group, nodes = transport_fleet
+
+    # make some files
+    xfs.create_file("/node1/test/one")
+    xfs.create_file("/node3/test/two")
+    xfs.create_file("/node5/test/two")
+
+    # Check
+    assert group.io.exists("test/one") == nodes[0]
+    assert group.io.exists("test/two") == nodes[2]
+    assert group.io.exists("test/three") is None
+
+
+def test_pull_remote_skip(remote_req, transport_fleet):
+    """Test TransportGroupIO.pull() skips non-local requests."""
+    group, nodes = transport_fleet
+
+    group.io.pull(remote_req)
+
+    # Request is not resolved
+    afcr = ArchiveFileCopyRequest.get(id=remote_req.id)
+    assert not afcr.completed
+    assert not afcr.cancelled
+
+    # Request did not get handed off
+    for node in nodes:
+        node.io.pull.assert_not_called()
+
+
+def test_pull_local(req, transport_fleet):
+    """Test TransportGroupIO.pull() hands off local requests."""
+    group, nodes = transport_fleet
+
+    group.io.pull(req)
+
+    # Since the copy has no size, it will be put onto the first (smallest) node
+    nodes[0].io.pull.assert_called_once_with(req)
+    nodes[1].io.pull.assert_not_called()
+    nodes[2].io.pull.assert_not_called()
+    nodes[3].io.pull.assert_not_called()
+
+
+def test_pull_size(req, transport_fleet):
+    """Test TransportGroupIO.pull() finds the correct disk to fit the request."""
+    group, nodes = transport_fleet
+
+    # Set file size.  The node sizes in the transport fleet are (in GiB):
+    # [10, 20, 40, None].  A file of size 6000 GiB will be sent to
+    # nodes[1] due to the fudge factor of two in DefaultIO's reserve_bytes()
+    req.file.size_b = 6 * 2**30
+
+    group.io.pull(req)
+
+    nodes[0].io.pull.assert_not_called()
+    nodes[1].io.pull.assert_called_once_with(req)
+    nodes[2].io.pull.assert_not_called()
+    nodes[3].io.pull.assert_not_called()
+
+
+def test_pull_minmax(req, archivefilecopy, transport_fleet):
+    """Test TransportGroupIO.pull() correctly rejecting under-min and over-max nodes."""
+    group, nodes = transport_fleet
+
+    # Make nodes[0] under-min
+    nodes[0].db.min_avail_gb = nodes[0].db.avail_gb * 2
+
+    # Make nodes[1] over-max
+    req.file.size_b = 10000
+    archivefilecopy(file=req.file, node=nodes[1].db, has_file="Y")
+    nodes[1].db.max_total_gb = 1e-3
+
+    # Check
+    group.io.pull(req)
+
+    # Node 2 is the first node that can take the file
+    nodes[0].io.pull.assert_not_called()
+    nodes[1].io.pull.assert_not_called()
+    nodes[2].io.pull.assert_called_once_with(req)
+    nodes[3].io.pull.assert_not_called()
+
+
+def test_pull_nonode(req, archivefilecopy, transport_fleet):
+    """Test TransportGroupIO.pull() being okay with no node available."""
+    group, nodes = transport_fleet
+
+    # Give node[3] a size
+    nodes[3].db.avail_gb = 3
+    # Make all nodes under-min
+    for node in nodes:
+        node.db.min_avail_gb = node.db.avail_gb * 2
+
+    # Check
+    group.io.pull(req)
+
+    nodes[0].io.pull.assert_not_called()
+    nodes[1].io.pull.assert_not_called()
+    nodes[2].io.pull.assert_not_called()
+    nodes[3].io.pull.assert_not_called()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,7 +1,7 @@
 """An end-to-end test of the alpenhorn daemon.
 
 Things that this end-to-end test does:
-    - pulls a file
+    - pulls a file onto the Transport group
     - checks a corrupt file
     - deletes a file
 
@@ -74,8 +74,8 @@ def e2e_db(xfs, hostname):
     )
     xfs.create_file("/dft/ALPENHORN_NODE", contents="dftnode")
 
-    # Future PR will turn this into a transport fleet
-    fleet = StorageGroup.create(name="fleet")
+    # A transport fleet
+    fleet = StorageGroup.create(name="fleet", io_class="Transport")
     tp1 = StorageNode.create(
         name="tp1",
         storage_type="T",
@@ -84,7 +84,17 @@ def e2e_db(xfs, hostname):
         host=hostname,
         active=True,
     )
+    StorageNode.create(
+        name="tp2",
+        storage_type="T",
+        group=fleet,
+        root="/tp/two",
+        host=hostname,
+        active=True,
+        auto_verify=1,
+    )
     xfs.create_file("/tp/one/ALPENHORN_NODE", contents="tp1")
+    xfs.create_file("/tp/two/ALPENHORN_NODE", contents="tp2")
 
     # A future PR will turn this into a Nearline group
     nlgrp = StorageGroup.create(name="nl1")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -171,7 +171,7 @@ def test_serial_io(fastqueue, set_config):
 def test_ioload(storagegroup, storagenode):
     """Test instantiation of the I/O classes"""
 
-    for ioclass in ["Default", None]:
+    for ioclass in ["Default", "Transport", None]:
         group = storagegroup(
             name="none" if ioclass is None else ioclass, io_class=ioclass
         )


### PR DESCRIPTION
This PR adds a new group I/O class, `TransportGroupIO` suitable for use with a transport group to fix the removal of transport group logic from `update.py` in the previous PR.

Features of a Transport StorageGroup:
* it may have any number of nodes.  All node must have `node.storage_type == 'T'`, but no restrictions are put on the I/O class of nodes.  Nodes in the group which have a different `storage_type` are ignored.
* all pulls to the StorageGroup must be local: non-local pull requests will be ignored
* when handling pull requests, transport nodes are prioritised by increasing free space: the group will attempt to pull a file to the fullest node that it thinks it will fit on.

The name of the group is no longer special (previously, the group had to be named "transport") and more than one independent transport group can be made now, though I don't know how useful that would be.