### PR TITLE
Rewrite 13/14: Lustre I/O

### DIFF
--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -160,7 +160,7 @@ def _import_file(task: Task, node: StorageNode, path: pathlib.PurePath) -> None:
             copy.has_file = "M"
             copy.wants_file = "Y"
             copy.ready = True
-            copy.last_upate = datetime.now()
+            copy.last_update = datetime.now()
             copy.save()
             log.warning(
                 f'Imported file "{path}" formerly present on node {node.name}!  Marking suspect.'

--- a/alpenhorn/io/lfs.py
+++ b/alpenhorn/io/lfs.py
@@ -1,0 +1,356 @@
+"""lfs(1) wrapper.
+
+This module provides the `LFS` class which wraps invocations of
+`lfs(1)` to interact with a Lustre filesystem.
+
+It is not a complete wrapper for that command and is only able to
+run these commands:
+
+* `lfs quota`
+    to retrieve the group quota for a path.  The user group used
+    must be provided to the constructor.  Can also handle a
+    fixed max quota, for cases where "lfs quota" doesn't correctly
+    report the max.
+* `lfs hsm_state`
+    to retrieve the HSM state for a file.  The state itself is
+    represented with the `HSMState` enum and is one of:
+        * `MISSING`:    file is not present on disk or external storage
+        * `UNARCHIVED`: file exists on disk, but not on external storage
+        * `RESTORED`:   file exists on both disk and external storage
+        * `RELEASED`:   file exists in external storage only
+* `lfs hsm_restore`
+    requests the state change `RELEASED -> RESTORED`
+* `lfs hsm_release`
+    requests the state change `RESTORED -> RELEASED`
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import shutil
+import logging
+import pathlib
+from enum import Enum
+
+from alpenhorn import util
+
+if TYPE_CHECKING:
+    import os
+
+
+log = logging.getLogger(__name__)
+
+
+class HSMState(Enum):
+    """HSM States.
+
+    Indicates the state of a file in HSM (the external storage).
+
+    Four states are possible:
+    HSMState.MISSING:
+        The file is not on the system (disk or external storage) at all
+    HSMState.UNARCHIVED:
+        This file is on the Lustre disk but not in external storage.  This
+        is the state of newly created files until they are archived.
+    HSMState.RELEASED:
+        The file is in external storage but not on disk.
+    HSMState.RESTORED:
+        The file is both in external storage and on disk.
+
+    A new file starts off in state UNARCHIVED.  Initial archiving is beyond
+    our control, but once the file has been archived, it moves from state
+    UNARCHIVED to state RESTORED.
+
+    A `lfs.hsm_restore()` changes a file's state from RELEASED to RESTORED.
+    A `lfs.hsm_release()` changes a file's state from RESTORED to RELEASED.
+    """
+
+    MISSING = 0
+    UNARCHIVED = 1
+    RESTORED = 2
+    RELEASED = 3
+
+
+class LFS:
+    """A class that wraps invocations of the lfs(1) command for use on Lustre
+    filesystems.
+
+    If the lfs(1) command can't be found in the PATH, attempting to instantiate
+    this class will fail with RuntimeError.
+
+    Parameters:
+    -----------
+    quota_group : str
+        The name of the group to use when running quota queries
+    fixed_quota : integer, optional
+        If not None, a quota size in kiB which will override the
+        maximum quota reported by "lfs quota".
+    lfs : string, optional
+        The name of the lfs(1) command; may include a path.
+        Defaults to "lfs".
+    path : string, optional
+        If not None, the search path to use to look for the lfs(1)
+        commnad.  If None, the "PATH" environmental variable is used.
+    """
+
+    # Conveniences for clients
+    HSM_MISSING = HSMState.MISSING
+    HSM_UNARCHIVED = HSMState.UNARCHIVED
+    HSM_RESTORED = HSMState.RESTORED
+    HSM_RELEASED = HSMState.RELEASED
+
+    def __init__(
+        self,
+        quota_group: str,
+        fixed_quota: int | None = None,
+        lfs: str = "lfs",
+        path: str | None = None,
+    ) -> None:
+        self._quota_group = quota_group
+        self._fixed_quota = fixed_quota
+
+        self._lfs = shutil.which(lfs, path=path)
+        if self._lfs is None:
+            raise RuntimeError("lfs command not found.")
+
+    def run_lfs(self, *args: str) -> str | None:
+        """Run the lfs command with the `args` provided.
+
+        Parameters
+        ----------
+        *args : strings
+            The list of command-line arguments to pass to the
+            lfs command.
+
+        Retunrs
+        -------
+        output : str or None
+            If the command succeeded, returns standard output of
+            the command.  If the command failed, returns None and
+            logs the failure.
+        """
+        ret, stdout, stderr = util.run_command([self._lfs] + list(args))
+
+        if ret != 0:
+            log.warning(f"LFS command failed (ret={ret}): " + " ".join(args))
+            if stderr:
+                log.debug(f"LFS stderr: {stderr}")
+            if stdout:
+                log.debug(f"LFS stdout: {stdout}")
+            return None
+
+        return stdout
+
+    def quota_remaining(self, path: str) -> int | None:
+        """Retrieve the remaining quota for `path`.
+
+        Parameters
+        ----------
+        path : str
+            The path to get the quota for
+
+        Returns
+        -------
+        quota_remaining : int or None
+            The remaining quota for `path`, or None if running
+            "lfs quota" failed.
+
+        Raises
+        ------
+        ValueError
+            The quota group is using the default block quota setting,
+            but no fixed_quota was specified.
+        """
+
+        # If possible, "lfs quota -q -g <group> <path>" will output quota
+        # information on the first line.  But, if the path is too long
+        # (more than 15 characters), the path will be printed by itelf
+        # on the first line and then the quota information will end up on
+        # the second line.
+        #
+        # After the path, there are eight fields:
+        #  - blocks used
+        #  - block quota
+        #  - block limit
+        #  - block grace
+        #  - files used
+        #  - file quota
+        #  - file limit
+        #  - file grace
+        #
+        # Sometimes there are trailing lines.  If one of these contains
+        # "using default block quota setting", then we know that the
+        # default quota is in use.  We (non-root) don't have permission
+        # to fetch the default quota, so we need to fall back on the fixed
+        # quota in that case.
+
+        stdout = self.run_lfs("quota", "-q", "-g", self._quota_group, path)
+        if stdout is None:
+            return None  # Command returned error
+
+        # Split lines
+        lines = stdout.splitlines()
+        if len(lines) < 1:
+            log.warning(f'Error parsing "lfs quota" output: {stdout}')
+            return None
+
+        # Remove the path, wherever it ended up
+        if lines[0] == path:  # Did the line wrap because path was too long?
+            lines.pop(0)  # Remove by discarding the whole line
+            if len(lines) < 1:
+                # Ran out of output
+                log.warning(f'Error parsing "lfs quota" output: {stdout}')
+                return None
+        elif stdout.startswith(path):
+            lines[0] = lines[0][len(path) :]  # Trim path
+        else:
+            log.warning(f'Error parsing "lfs quota" output: {stdout}')
+            return None
+
+        # Split the (potentially newly promoted) first line into the eight values
+        lfs_quota = lines[0].split()
+        if len(lfs_quota) != 8:
+            log.warning(f'Error parsing "lfs quota" output: {stdout}')
+            return None
+
+        # Check the rest of the lines to see if we're using default block quota
+        for line in lines[1:]:
+            if "using default block quota setting" in line:
+                if self._fixed_quota is None:
+                    log.error(f"ERROR: Unable to fetch default block quota for {path}")
+                    return None
+
+        quota_limit = (
+            self._fixed_quota if self._fixed_quota is not None else int(lfs_quota[1])
+        )
+
+        # If we're over quota, the quota value has a '*' appended to it
+        quota = int(lfs_quota[0].rstrip("*"))
+
+        # lfs quota reports values in kiByte blocks
+        return (quota_limit - quota) * 2**10
+
+    def hsm_state(self, path: os.PathLike | str) -> HSMState:
+        """Returns the HSM state of path.
+
+        Parameters
+        ----------
+        path : path-like
+            The path to determine the state for.
+
+        Returns
+        -------
+        state : HSMState or None
+            The state of the file, or None, if running "lfs hsm_state"
+            failed.  If `path` doesn't exist, this will be `HSMState.MISSING`.
+        """
+
+        # No need to check with HSM if the path isn't present
+        if not pathlib.Path(path).exists():
+            return HSMState.MISSING
+
+        stdout = self.run_lfs("hsm_state", path)
+        if stdout is None:
+            return None  # Command returned error
+
+        # The output of hsm_state looks like this:
+        #
+        # <path>: (<hus-states-bits>) [hus-states-words][, archive_id:<archive-id>]
+        #
+        # where:
+        #  - "path" is the path verbatim from the command line
+        #  - "hus-states-bits" is a "0x%08x"-formatted hex representation of the
+        #                      hus_states bitfield
+        #  - "hus-states-words" are specific words, separated by spaces
+        #                      one per hus_states bit set.  There may be none
+        #                      of these if none of the bits are set
+        #  - "archive-id" is the archive ID (i.e. HSM backend index) for this
+        #                      file.  If the file is unarchived, this whole
+        #                      part, starting with the comma, is omitted.
+
+        # Strip path from the output to handle the corner case where, say,
+        # "archived" is part of the filename.
+        if stdout.startswith(path + ":"):
+            stdout = stdout[len(path) :]
+        else:
+            log.warning(f"Error parsing hsm_state output: {stdout}")
+            return None  # Parsing failed
+
+        # Check some hus-states-words to figure out the state.  There are more
+        # bits providing information, but I don't know if we care about them.
+        #
+        # See llapi_hsm_state_get(3) for full details about these.
+        if "archived" not in stdout:
+            return HSMState.UNARCHIVED
+        if "released" in stdout:
+            return HSMState.RELEASED
+        return HSMState.RESTORED
+
+    def hsm_archived(self, path: os.PathLike) -> bool:
+        """Is `path` archived by HSM?"""
+        state = self.hsm_state(path)
+        return state == HSMState.RESTORED or state == HSMState.RELEASED
+
+    def hsm_released(self, path: os.PathLike) -> bool:
+        """Is `path` released to external storage?"""
+        return self.hsm_state(path) == HSMState.RELEASED
+
+    def hsm_restore(self, path: os.PathLike) -> bool:
+        """Trigger restore of `path` from external storage.
+
+        If `path` is already restored or is missing, this does nothing.
+
+        Parameters
+        ----------
+        path : path-like
+            The path to restore.
+
+        Returns
+        -------
+        restored : bool
+            True if a successful restore request was made, or if
+            `path` was already restored.  False otherwise.
+        """
+        state = self.hsm_state(path)
+
+        # If the file doesn't exist, fail
+        if state == HSMState.MISSING:
+            log.debug(f"Attempt to restore non-existent file: {path}")
+            return False
+
+        # If there's nothing to do, do nothing
+        if state != HSMState.RELEASED:
+            return True
+
+        return self.run_lfs("hsm_restore", path) is not None
+
+    def hsm_release(self, path: os.PathLike) -> bool:
+        """Trigger release of `path` from disk.
+
+        If `path` is already released, or can't be released
+        because it's either unarchived or missing, does nothing.
+
+        Parameters
+        ----------
+        path : path-like
+            The path to release.
+
+        Returns
+        -------
+        released : bool
+            True if a successful release request was made, or if
+            `path` was already released.  False otherwise.
+        """
+
+        state = self.hsm_state(path)
+
+        # If there's nothing to do, do nothing
+        if state == HSMState.RELEASED:
+            return True
+
+        # If the file can't be released, fail
+        if state != HSMState.RESTORED:
+            log.debug(f'Unable to release "{path}" [state={state}]')
+            return False
+
+        # Otherwise send the request
+        return self.run_lfs("hsm_release", path) is not None

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -1,0 +1,423 @@
+"""Lustre Hierarchical Storage Management (HSM) I/O.
+
+These I/O classes provide support for using external storage (typically
+a tape system) as a StorageNode via Lustre's Hierarchical Storage
+Management (HSM) framework.
+
+This module provides:
+* LustreHSMNodeIO and LustreHSMNodeRemote, representing a StorageNode on the
+    HSM-managed external storage
+* LustreHSMGroupIO, which allows pairing a `LustreHSMNodeIO` HSM StorageNode
+    with a secondary StorageNode of a different class meant to store files
+    too small for the external system.
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING, IO
+
+import logging
+import pathlib
+import peewee as pw
+
+from ..archive import ArchiveFileCopy
+from ..task import Task
+from ..util import pretty_bytes
+from .base import BaseGroupIO, BaseNodeRemote
+from .lustrequota import LustreQuotaNodeIO
+
+if TYPE_CHECKING:
+    import os
+    from ..acquisition import ArchiveFile
+    from ..archive import ArchiveFileCopyRequest
+    from ..queue import FairMultiFIFOQueue
+    from ..storage import StorageNode, StorageGroup
+    from ..update import UpdateableNode
+
+log = logging.getLogger(__name__)
+
+
+class LustreHSMNodeRemote(BaseNodeRemote):
+    """LustreHSMNodeRemote: information about a LustreHSM remote node."""
+
+    def pull_ready(self, file: ArchiveFile) -> bool:
+        """Is `file` ready for pulling from this remote node?
+
+        Parameters
+        ----------
+        file : ArchiveFile
+            the file being checked
+
+        Returns
+        -------
+        ready : bool
+            True if `file` is ready on the node; False otherwise.
+        """
+        try:
+            copy = ArchiveFileCopy.get(file=file, node=self.node)
+        except pw.DoesNotExist:
+            return False
+
+        return copy.ready
+
+
+class LustreHSMNodeIO(LustreQuotaNodeIO):
+    """LustreHSM node I/O.
+
+    Required io_config keys:
+        * quota_group : string
+            the user group to query quota for
+        * headroom: float
+            the amount of space in kiB to keep empty on the disk.
+
+    Optional io_config keys:
+        * lfs : string
+            the lfs(1) executable.  Defaults to "lfs"; may be a full path.
+        * fixed_quota : integer
+            the quota, in kiB, on the Lustre disk backing the HSM system
+    """
+
+    remote_class = LustreHSMNodeRemote
+
+    def __init__(
+        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue
+    ) -> None:
+        super().__init__(node, config, queue)
+
+        self._headroom = config["headroom"] * 2**10  # convert from kiB
+
+    def release_files(self) -> None:
+        """Release files from the HSM disk to keep the headroom clear.
+
+        This is called at the start of a node update (from
+        `before_update`), but only if the update is going
+        to happen (i.e. the node is currently idle).
+        """
+
+        headroom_needed = self._headroom - self._lfs.quota_remaining(self.node.root)
+
+        # Nothing to do
+        if headroom_needed <= 0:
+            return
+
+        def _async(task, node, lfs, headroom_needed):
+            total_files = 0
+            total_bytes = 0
+
+            # loop through file copies until we've released enough
+            # (or we run out of files)
+            for copy in (
+                ArchiveFileCopy.select()
+                .where(
+                    ArchiveFileCopy.node == node,
+                    ArchiveFileCopy.has_file == "Y",
+                    ArchiveFileCopy.ready == True,
+                )
+                .order_by(ArchiveFileCopy.last_update)
+            ):
+                # Skip unarchived files
+                if not lfs.hsm_archived(copy.path):
+                    continue
+
+                log.debug(
+                    f"releasing file copy {copy.path} "
+                    f"[={pretty_bytes(copy.file.size_b)}] on node {self.node.name}"
+                )
+                lfs.hsm_release(copy.path)
+                # Update copy record immediately
+                ArchiveFileCopy.update(ready=False).where(
+                    ArchiveFileCopy.id == copy.id
+                ).execute()
+                total_files += 1
+                total_bytes += copy.file.size_b
+                if total_bytes >= headroom_needed:
+                    break
+            log.info(
+                f"released {pretty_bytes(total_bytes)} in "
+                f"{total_files} files on node {self.node.name}"
+            )
+            return
+
+        # Do the rest asynchronously
+        Task(
+            func=_async,
+            queue=self._queue,
+            key=self.node.name,
+            args=(self.node, self._lfs, headroom_needed),
+            name=f"Node {self.node.name}: HSM release {pretty_bytes(headroom_needed)}",
+        )
+
+    def before_update(self, idle: bool) -> bool:
+        """Pre-update hook.
+
+        If the node is idle (i.e. the update will happen), then
+        call `self.release_files to potentially free up space.
+
+        Parameters
+        ----------
+        idle : bool
+            Is the node currently idle?
+
+        Returns
+        -------
+        True
+        """
+        # Clear up headroom, if necessary
+        if idle:
+            self.release_files()
+
+        # Continue with the update
+        return True
+
+    # I/O METHODS
+
+    def check(self, copy: ArchiveFileCopy) -> None:
+        """Check whether ArchiveFileCopy `copy` is corrupt.
+
+        If the file is not restored, this function calls lfs(1) to
+        start restoration and then returns without doing anything else
+        (assuming a subsequent call to this function is going to resolve
+        the issue).
+
+        Parameters
+        ----------
+        copy : ArchiveFileCopy
+            the file copy to check
+        """
+        # If the file is released, restore it and do nothing
+        # further (assuming the update loop will re-call this
+        # method next time through the loop).
+        if self._lfs.hsm_released(copy.path):
+            self._lfs.hsm_restore(copy.path)
+            return
+
+        # Otherwise, use the DefaultIO method to do the check
+        super().check(copy)
+
+    def check_active(self) -> bool:
+        """Check that this is an active node.
+
+        There's no ALPENHORN_NODE file on HSM,
+        so this just returns `self.node.active`.
+        """
+        return self.node.active
+
+    def filesize(self, path: pathlib.Path, actual: bool = False) -> int:
+        """Return size in bytes of the file given by `path`.
+
+        This _always_ returns the apprent size, since the size on tape is
+        not known (or important), and the size on disk is usually that of the
+        the file stub.
+
+        Parameters
+        ----------
+        path: path-like
+            The filepath to check the size of.  May be absolute or relative
+            to `node.root`.
+        actual: bool, optional
+            Ignored.
+        """
+        path = pathlib.Path(path)
+        if not path.is_absolute():
+            path = pathlib.Path(self.node.root, path)
+        return path.stat().st_size
+
+    def fits(self, size_b: int) -> bool:
+        """Does `size_b` bytes fit on this node?
+
+        Returns True: everything fits in HSM.
+        """
+        return True
+
+    def open(self, path: os.PathLike | str, binary: bool = True) -> IO:
+        """Open the file specified by `path` for reading.
+
+        Parameters:
+        -----------
+        path : pathlike
+            Relative to `node.root`
+        binary : bool, optional
+            If True, open the file in binary mode, otherwise open the file in
+            text mode.
+
+        Returns
+        -------
+        file : file-like
+            An open, read-only file.
+
+        Raises
+        ------
+        ValueError:
+            `path` was absolute.
+        OSError:
+            The file is not recalled.
+        """
+        if pathlib.PurePath(path).is_absolute():
+            raise ValueError("path must be relative to node.root")
+
+        # Make abs path
+        p = pathlib.Path(self.node.root, path)
+
+        if self._lfs.hsm_released(p):
+            raise OSError(f"{path} is not restored.")
+        return open(p, mode="rb" if binary else "rt")
+
+    def ready_path(self, path: os.PathLike) -> bool:
+        """Recall the specified path so it can be read.
+
+        Parameters
+        ----------
+        path : path-like
+            The path that we want to perform I/O on.
+
+        Returns
+        -------
+        ready : bool
+            True if `path` is ready for I/O.  False otherwise.
+        """
+        fullpath = pathlib.Path(self.node.root, path)
+        state = self._lfs.hsm_state(fullpath)
+
+        # If it's restorable, restore it
+        if state == self._lfs.HSM_RELEASED:
+            self._lfs.hsm_restore(fullpath)
+
+        # Returns True if file is readable.
+        return state == self._lfs.HSM_RESTORED or state == self._lfs.HSM_UNARCHIVED
+
+    def ready_pull(self, req: ArchiveFileCopyRequest) -> None:
+        """Ready a file to be pulled as specified by `req`.
+
+        Parameters
+        ----------
+        req : ArchiveFileCopyRequest
+            the copy request to ready.  We are the source node (i.e.
+            `req.node_from == self.node`).
+        """
+        ready = self.ready_path(req.file.path)
+
+        # Update DB based on HSM state
+        ArchiveFileCopy.update(ready=ready).where(
+            ArchiveFileCopy.file == req.file, ArchiveFileCopy.node == self.node
+        ).execute()
+
+    def release_bytes(self, size: int) -> None:
+        """Does nothing."""
+        pass
+
+    def reserve_bytes(self, size: int, check_only: bool = False) -> bool:
+        """Returns True."""
+        return True
+
+
+class LustreHSMGroupIO(BaseGroupIO):
+    """LustreHSM Group I/O
+
+    The LustreHSM Group contains two nodes:
+     - a primary node pointing to the HSM storage itself.
+     - a secondary node on a regular disk used for storing files too small for HSM.
+
+    The primary node must have `io_class=="LustreHSM"`.  The secondary node must
+    _not_ have `io_class=="LustreHSM`.
+
+    Optional io_config keys:
+     - threshold : integer
+            The smallfile threshold, in bytes.  Files above this size are sent to
+            HSM and put on tape.  The small files are sent to the secondary
+            node.  Default is 1000000000 bytes (1 GB).
+    """
+
+    # SETUP
+
+    def __init__(self, group: StorageGroup, config: dict) -> None:
+        super().__init__(group, config)
+
+        self._threshold = self.config.get("threshold", 1000000000)  # bytes
+
+    # HOOKS
+
+    def set_nodes(self, nodes: list[UpdateableNode]) -> list[UpdateableNode]:
+        """Set nodes used during update.
+
+        Identify primary and secondary nodes.  If that can't be accomplished,
+        `ValueError` is raised.
+
+        Parameters
+        ----------
+        nodes : list of UpdateableNodes
+                The local active nodes in this group.  Will never be
+                empty.
+        idle : boolean
+                True if all the `nodes` were idle when the current
+                update loop started.
+
+        Returns
+        -------
+        nodes : list of UpdateableNodes
+                This is always just the `nodes` list passed-in.
+
+        Raises
+        ------
+        ValueError
+            At least one node couldn't be identified, or more than
+            two nodes were provided.
+        """
+        if len(nodes) != 2:
+            raise ValueError(
+                f"need exactly two nodes in StorageGroup group {self.group.name} (have {len(nodes)})"
+            )
+
+        if nodes[0].db.io_class == "LustreHSM":
+            # If both nodes are LustreHSM, we have a problem
+            if nodes[1].db.io_class == "LustreHSM":
+                raise ValueError(
+                    f"Can't use two LustreHSM nodes in StorageGroup {self.group.name}"
+                )
+
+            self._hsm = nodes[0]
+            self._smallfile = nodes[1]
+        elif nodes[1].db.io_class == "LustreHSM":
+            self._hsm = nodes[1]
+            self._smallfile = nodes[0]
+        else:
+            raise ValueError(f"no LustreHSM node in StorageGroup {self.group.name}")
+
+        return nodes
+
+    # I/O METHODS
+
+    def exists(self, path: pathlib.PurePath) -> UpdateableNode | None:
+        """Check whether the file `path` exists in this group.
+
+        Parameters
+        ----------
+        path : pathlib.PurePath
+            the path, relative to a node `root` of the file to
+            search for.
+
+        Returns
+        -------
+        node : UpdateableNode or None
+            If the file exists, the UpdateableNode on which it is.
+            If the file doesn't exist in the group, this is None.
+        """
+        if self._smallfile.io.exists(path):
+            return self._smallfile
+        if self._hsm.io.exists(path):
+            return self._hsm
+        return None
+
+    def pull(self, req: ArchiveFileCopyRequest) -> None:
+        """Handle ArchiveFileCopyRequest `req` by pulling to this group.
+
+        This takes care of directing pulls to the correct node
+        based on the threshold.
+
+        Parameters
+        ----------
+        req : ArchiveFileCopyRequest
+            the request to fulfill.  We are the destination group (i.e.
+            `req.group_to == self.group`).
+        """
+        if req.file.size_b <= self._threshold:
+            self._smallfile.io.pull(req)
+        else:
+            self._hsm.io.pull(req)

--- a/alpenhorn/io/lustrequota.py
+++ b/alpenhorn/io/lustrequota.py
@@ -1,0 +1,85 @@
+"""Alpenhorn LustreQuota Node I/O class.
+
+This I/O class extends the DefaultNodeIO.  The primary change is that it
+uses the "lfs quota" command to determine free space on a quota-tracking
+Lustre filesystem.
+
+This module only queries group quota.  The group used must be provided in
+the `io_config`.
+
+The quota target can either be the one reported by "lfs quota" directly
+or else set to a fixed value via the `io_config`.
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import logging
+
+from .default import DefaultNodeIO
+from .lfs import LFS
+
+if TYPE_CHECKING:
+    from ..queue import FairMultiFIFOQueue
+    from ..storage import StorageNode
+
+log = logging.getLogger(__name__)
+
+
+class LustreQuotaNodeIO(DefaultNodeIO):
+    """An extension to DefaultNodeIO which uses the "lfs quota" to determine
+    free space, rather than stat.
+
+    Required io_config keys:
+        * quota_group: the user group to query quota for
+
+    Optional io_config keys:
+        * fixed_quota: a fixed number of kiB to use to override the max quota
+            reported by the "lfs quota" command.
+        * lfs: the lfs(1) executable.  Defaults to "lfs"; may be a full path.
+
+    Notes
+    -----
+    If the provided `quota_group` is using the default block quota on the
+    filesystem, then block quota max cannot be determined from the lfs(1)
+    output.  In this case, `fixed_quota` _must_ be used to specify the default
+    quota for any meaninful free space value to be returned.
+    """
+
+    def __init__(
+        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue
+    ) -> None:
+        super().__init__(node, config, queue)
+
+        # Make alpenhornd crash if the io_config is incomplete.
+        if "quota_group" not in config:
+            raise KeyError(
+                f'"quota_group" missing from StorageNode {node.name} io_config'
+            )
+
+        # Initialise the lfs(1) wrapper
+        self._lfs = LFS(
+            quota_group=config["quota_group"],
+            fixed_quota=config.get("fixed_quota", None),
+            lfs=config.get("lfs", "lfs"),
+        )
+
+    # I/O METHODS
+
+    def bytes_avail(self, fast: bool = False) -> int | None:
+        """Use "lfs quota" get the amount of free quota.
+
+        Parameters
+        ----------
+        fast : bool
+            If True, then this is a fast call and we simply return None.
+            Otherwise (slow call) we do th "lfs quota" query.
+
+        Returns
+        -------
+        bytes_avail : int or None
+            None if `fast is True` otherwise, the available quota.
+        """
+        if fast:
+            return None
+
+        return self._lfs.quota_remaining(self.node.root)

--- a/tests/io/test_lfs.py
+++ b/tests/io/test_lfs.py
@@ -1,0 +1,281 @@
+"""Test alpenhorn.io.lfs LFS wrapper."""
+
+import pytest
+
+from alpenhorn.io.lfs import LFS
+
+
+@pytest.mark.run_command_result(0, "lfs_out", "lfs_err")
+def test_run_lfs_success(have_lfs, mock_run_command):
+    """Test successful invocation of lfs.run_lfs."""
+
+    lfs = LFS(None)
+
+    assert lfs.run_lfs("arg1", "arg2") == "lfs_out"
+    assert mock_run_command() == {
+        "cmd": ["LFS", "arg1", "arg2"],
+        "kwargs": dict(),
+        "timeout": None,
+    }
+
+
+@pytest.mark.run_command_result(1, "lfs_out", "lfs_err")
+def test_run_lfs_fail(have_lfs, mock_run_command):
+    """Test failed invocation of lfs.run_lfs."""
+
+    lfs = LFS(None)
+
+    assert lfs.run_lfs("arg1", "arg2") is None
+    assert mock_run_command() == {
+        "cmd": ["LFS", "arg1", "arg2"],
+        "kwargs": dict(),
+        "timeout": None,
+    }
+
+
+@pytest.mark.run_command_result(0, "/path", None)
+def test_quota_auto_syntax_short(have_lfs, mock_run_command):
+    """Test quota syntax error: too few lines."""
+
+    lfs = LFS("qgroup")
+
+    assert lfs.quota_remaining("/path") is None
+
+
+@pytest.mark.run_command_result(
+    0,
+    "/path           1234 0 0 - 100 0 0 -\n"
+    "gid 345678 is using default block quota setting\n"
+    "gid 345678 is using default file quota setting",
+    None,
+)
+def test_quota_auto_with_default(have_lfs, mock_run_command):
+    """Test getting quota with default settings."""
+
+    lfs = LFS("qgroup", fixed_quota=2500)
+
+    assert lfs.quota_remaining("/path") == (2500 - 1234) * 2**10
+
+
+@pytest.mark.run_command_result(
+    0,
+    "/path           1234 0 0 - 100 0 0 -\n"
+    "gid 345678 is using default block quota setting\n"
+    "gid 345678 is using default file quota setting",
+    None,
+)
+def test_quota_auto_default_no_fixed(have_lfs, mock_run_command):
+    """Test getting quota with default settings without a fixed quota."""
+
+    lfs = LFS("qgroup")
+
+    assert lfs.quota_remaining("/path") is None
+
+
+@pytest.mark.run_command_result(0, "/path           1234", None)
+def test_quota_auto_syntax_quota(have_lfs, mock_run_command):
+    """Test quota syntax error: bad second line"""
+
+    lfs = LFS("qgroup")
+
+    assert lfs.quota_remaining("/path") is None
+
+
+@pytest.mark.run_command_result(
+    0, "/path           1234* 1000 3000 - 100 200 300 -", None
+)
+def test_quota_over(have_lfs, mock_run_command):
+    """Test getting quota from lfs.quota_remaining() when over quota."""
+
+    lfs = LFS("qgroup")
+
+    assert lfs.quota_remaining("/path") == (1000 - 1234) * 2**10
+    assert "qgroup" in mock_run_command()["cmd"]
+
+
+@pytest.mark.run_command_result(
+    0, "/path           1234 2000 3000 - 100 200 300 -", None
+)
+def test_quota_auto(have_lfs, mock_run_command):
+    """Test getting quota from lfs.quota_remaining() with no fixed_quota."""
+
+    lfs = LFS("qgroup")
+
+    assert lfs.quota_remaining("/path") == (2000 - 1234) * 2**10
+    assert "qgroup" in mock_run_command()["cmd"]
+
+
+@pytest.mark.run_command_result(
+    0, "/path-so-long-it-wraps\n                1234 2000 3000 - 100 200 300 -", None
+)
+def test_quota_longpath(have_lfs, mock_run_command):
+    """Test getting quota from lfs.quota_remaining() with a long path."""
+
+    lfs = LFS("qgroup")
+
+    assert lfs.quota_remaining("/path-so-long-it-wraps") == (2000 - 1234) * 2**10
+    assert "qgroup" in mock_run_command()["cmd"]
+
+
+@pytest.mark.run_command_result(
+    0, "/path           1234 2000 3000 - 100 200 300 -", None
+)
+def test_quota_fixed(have_lfs, mock_run_command):
+    """Test getting quota_remaining from lfs.quota() with fixed quota."""
+
+    lfs = LFS("qgroup", fixed_quota=2500)
+
+    assert lfs.quota_remaining("/path") == (2500 - 1234) * 2**10
+
+
+@pytest.mark.run_command_result(1, None, None)
+def test_hsm_state_missing(xfs, have_lfs, mock_run_command):
+    """Test hsm_state on a missing file."""
+
+    lfs = LFS("qgroup")
+
+    assert lfs.hsm_state("/path") == lfs.HSM_MISSING
+
+
+@pytest.mark.run_command_result(0, "/poth: (0x00000000)", None)
+def test_hsm_state_syntax(xfs, have_lfs, mock_run_command):
+    """Test syntax error in hsm_state output."""
+
+    xfs.create_file("/path")
+
+    lfs = LFS("qgroup")
+
+    assert lfs.hsm_state("/path") is None
+
+
+@pytest.mark.run_command_result(0, "/path: (0x00000000)", None)
+def test_hsm_state_unarchived(xfs, have_lfs, mock_run_command):
+    """Test hsm_state on an unarchived file."""
+
+    xfs.create_file("/path")
+
+    lfs = LFS("qgroup")
+
+    assert lfs.hsm_state("/path") == lfs.HSM_UNARCHIVED
+
+
+@pytest.mark.run_command_result(
+    0, "/path: (0x00000009) exists archived, archive_id:2", None
+)
+def test_hsm_state_restored(xfs, have_lfs, mock_run_command):
+    """Test hsm_state on a restored file."""
+
+    xfs.create_file("/path")
+
+    lfs = LFS("qgroup")
+
+    assert lfs.hsm_state("/path") == lfs.HSM_RESTORED
+
+
+@pytest.mark.run_command_result(
+    0, "/path: (0x0000000d) released exists archived, archive_id:2", None
+)
+def test_hsm_state_released(xfs, have_lfs, mock_run_command):
+    """Test hsm_state on a released file."""
+
+    xfs.create_file("/path")
+
+    lfs = LFS("qgroup")
+
+    assert lfs.hsm_state("/path") == lfs.HSM_RELEASED
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/missing": "missing",
+        "/unarchived": "unarchived",
+        "/restored": "restored",
+        "/released": "released",
+    }
+)
+def test_hsm_archived(mock_lfs):
+    """Test hsm_archived()."""
+
+    lfs = LFS("qgroup")
+
+    assert not lfs.hsm_archived("/missing")
+    assert not lfs.hsm_archived("/unarchived")
+    assert lfs.hsm_archived("/restored")
+    assert lfs.hsm_archived("/released")
+    assert not lfs.hsm_released("/other")
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/missing": "missing",
+        "/unarchived": "unarchived",
+        "/restored": "restored",
+        "/released": "released",
+    }
+)
+def test_hsm_released(mock_lfs):
+    """Test hsm_released()."""
+
+    lfs = LFS("qgroup")
+
+    assert not lfs.hsm_released("/missing")
+    assert not lfs.hsm_released("/unarchived")
+    assert not lfs.hsm_released("/restored")
+    assert lfs.hsm_released("/released")
+    assert not lfs.hsm_released("/other")
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/missing": "missing",
+        "/unarchived": "unarchived",
+        "/restored": "restored",
+        "/released": "released",
+    }
+)
+@pytest.mark.run_command_result(0, "", None)
+@pytest.mark.lfs_dont_mock("hsm_restore")
+def test_hsm_restore(mock_lfs, mock_run_command):
+    """Test hsm_restore()."""
+
+    lfs = LFS("qgroup")
+
+    assert not lfs.hsm_restore("/missing")
+    assert lfs.hsm_restore("/unarchived")
+    assert lfs.hsm_restore("/restored")
+
+    # None of these should have called run_lfs
+    assert "cmd" not in mock_run_command()
+
+    # Restore is run here
+    assert lfs.hsm_restore("/released")
+    assert "hsm_restore" in mock_run_command()["cmd"]
+    assert "/released" in mock_run_command()["cmd"]
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/missing": "missing",
+        "/unarchived": "unarchived",
+        "/restored": "restored",
+        "/released": "released",
+    }
+)
+@pytest.mark.run_command_result(0, "", None)
+@pytest.mark.lfs_dont_mock("hsm_release")
+def test_hsm_release(mock_lfs, mock_run_command):
+    """Test hsm_restore()."""
+
+    lfs = LFS("qgroup")
+
+    assert not lfs.hsm_release("/missing")
+    assert not lfs.hsm_release("/unarchived")
+    assert lfs.hsm_release("/released")
+
+    # None of these should have called run_lfs
+    assert "cmd" not in mock_run_command()
+
+    # Release is run here
+    assert lfs.hsm_release("/restored")
+    assert "hsm_release" in mock_run_command()["cmd"]
+    assert "/restored" in mock_run_command()["cmd"]

--- a/tests/io/test_lustrehsmgroup.py
+++ b/tests/io/test_lustrehsmgroup.py
@@ -1,0 +1,161 @@
+"""Test LustreHSMGroupIO."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from alpenhorn.update import UpdateableGroup, UpdateableNode
+
+
+@pytest.fixture
+def group(xfs, mock_lfs, hostname, queue, storagegroup, storagenode):
+    """Create a hsm group for testing."""
+
+    stgroup = storagegroup(name="group", io_class="LustreHSM")
+
+    hsm = UpdateableNode(
+        queue,
+        storagenode(
+            name="hsm",
+            io_class="LustreHSM",
+            group=stgroup,
+            storage_type="A",
+            root="/hsm",
+            host=hostname,
+            io_config='{"quota_group": "qgroup", "headroom": 10250}',
+        ),
+    )
+    smallfile = UpdateableNode(
+        queue,
+        storagenode(
+            name="smallfile",
+            group=stgroup,
+            storage_type="A",
+            root="/smallfile",
+            host=hostname,
+        ),
+    )
+
+    group = UpdateableGroup(group=stgroup, nodes=[hsm, smallfile], idle=True)
+
+    # All the node pull methods are mocked to avoid running them.
+    hsm.io.pull = MagicMock(return_value=None)
+    smallfile.io.pull = MagicMock(return_value=None)
+
+    xfs.create_dir(hsm.db.root)
+    xfs.create_dir(smallfile.db.root)
+
+    return group, hsm, smallfile
+
+
+@pytest.fixture
+def req(
+    group,
+    simplegroup,
+    storagenode,
+    simplefile,
+    archivefilecopyrequest,
+):
+    """Create an ArchiveFileCopyRequest targetting the hsm group."""
+    group_to = group[0].db
+    node_from = storagenode(name="src", group=simplegroup)
+    req = archivefilecopyrequest(
+        file=simplefile, node_from=node_from, group_to=group_to
+    )
+
+    return req
+
+
+def test_init(storagegroup, storagenode, mock_lfs):
+    stgroup = storagegroup(name="group", io_class="LustreHSM")
+
+    hsm = UpdateableNode(
+        None,
+        storagenode(
+            name="hsm",
+            group=stgroup,
+            io_class="LustreHSM",
+            io_config='{"quota_group": "qgroup", "headroom": 10250}',
+        ),
+    )
+    smallfile = UpdateableNode(
+        None, storagenode(name="smallfile", group=stgroup, io_class="Default")
+    )
+
+    # These should work
+    group = UpdateableGroup(group=stgroup, nodes=[hsm, smallfile], idle=True)
+    assert group._nodes is not None
+    assert group.io._hsm is hsm
+    assert group.io._smallfile is smallfile
+
+    group = UpdateableGroup(group=stgroup, nodes=[smallfile, hsm], idle=True)
+    assert group._nodes is not None
+    assert group.io._hsm is hsm
+    assert group.io._smallfile is smallfile
+
+    # But not these
+    group = UpdateableGroup(group=stgroup, nodes=[smallfile], idle=True)
+    assert group._nodes is None
+    group = UpdateableGroup(group=stgroup, nodes=[hsm], idle=True)
+    assert group._nodes is None
+    group = UpdateableGroup(group=stgroup, nodes=[smallfile, smallfile], idle=True)
+    assert group._nodes is None
+
+
+def test_idle(queue, group):
+    """Test TransportGroupIO.idle."""
+    group, hsm, smallfile = group
+
+    # Currently idle
+    assert group.idle is True
+
+    for node in hsm, smallfile:
+        # Enqueue something into the node's queue
+        queue.put(None, node.name)
+
+        # Now not idle
+        assert group.idle is False
+
+        # Dequeue it
+        task, key = queue.get()
+        queue.task_done(node.name)
+
+        # Now idle again
+        assert group.idle is True
+
+
+def test_exists(xfs, group):
+    """Test TransportGroupIO.exists()."""
+    group, hsm, smallfile = group
+
+    # make some files
+    xfs.create_file("/hsm/test/one")
+    xfs.create_file("/hsm/test/two")
+    xfs.create_file("/smallfile/test/two")
+
+    # Check
+    assert group.io.exists("test/one") == hsm
+    assert group.io.exists("test/two") == smallfile
+    assert group.io.exists("test/three") is None
+
+
+def test_pull_small(req, group):
+    """Test TransportGroupIO.pull() hands off a small file to the smallfile node."""
+    group, hsm, smallfile = group
+
+    req.file.size_b = 1  # A very small file
+    group.io.pull(req)
+
+    # Sent to smallfile
+    smallfile.io.pull.assert_called_once_with(req)
+    hsm.io.pull.assert_not_called()
+
+
+def test_pull_big(req, group):
+    """Test TransportGroupIO.pull() hands off a large file to the hsm node."""
+    group, hsm, smallfile = group
+
+    req.file.size_b = 1e10
+    group.io.pull(req)
+
+    hsm.io.pull.assert_called_once_with(req)
+    smallfile.io.pull.assert_not_called()

--- a/tests/io/test_lustrehsmnode.py
+++ b/tests/io/test_lustrehsmnode.py
@@ -1,0 +1,277 @@
+"""Test LustreHSMNodeIO."""
+
+import pytest
+
+from alpenhorn.archive import ArchiveFileCopy
+from alpenhorn.update import UpdateableNode
+
+
+@pytest.fixture
+def node(
+    mock_lfs,
+    queue,
+    simplenode,
+    simpleacq,
+    archivefile,
+    archivefilecopy,
+):
+    """A LustreHSM node for testing with some stuff on it"""
+    simplenode.io_class = "LustreHSM"
+
+    simplenode.io_config = (
+        '{"quota_group": "qgroup", "headroom": 10250, "release_check_count": 6}'
+    )
+
+    # Some files
+    files = [
+        archivefile(name="file1", acq=simpleacq, size_b=100000),
+        archivefile(name="file2", acq=simpleacq, size_b=300000),
+        archivefile(name="file3", acq=simpleacq, size_b=400000),
+        archivefile(name="file4", acq=simpleacq, size_b=800000),
+        archivefile(name="file5", acq=simpleacq, size_b=50000),
+        archivefile(name="file6", acq=simpleacq, size_b=300000),
+    ]
+
+    # Some copies
+    last_updates = [3, 1, 5, 6, 2, 4]
+    for num, file in enumerate(files):
+        archivefilecopy(file=file, node=simplenode, has_file="Y", size_b=10, ready=True)
+        # We need to do it this way to set last_update
+        ArchiveFileCopy.update(last_update=last_updates[num]).where(
+            ArchiveFileCopy.id == num + 1
+        ).execute()
+
+    return UpdateableNode(queue, simplenode)
+
+
+def test_init_no_headroom(have_lfs, simplenode):
+    """No headroom is an error"""
+
+    simplenode.io_class = "LustreHSM"
+    simplenode.io_config = '{"quota_group": "qgroup"}'
+
+    with pytest.raises(KeyError):
+        UpdateableNode(None, simplenode)
+
+
+@pytest.mark.lfs_quota_remaining(20000000)
+def test_release_files_okay(queue, node):
+    """Test running release_files when we're under headroom"""
+
+    node.io.release_files()
+
+    # Shouldn't be anything in the queue
+    assert queue.qsize == 0
+
+
+@pytest.mark.lfs_quota_remaining(10000000)
+@pytest.mark.lfs_hsm_state(
+    {
+        "/node/simpleacq/file1": "restored",
+        "/node/simpleacq/file2": "restored",
+        "/node/simpleacq/file3": "restored",
+        "/node/simpleacq/file4": "restored",
+        "/node/simpleacq/file5": "restored",
+        "/node/simpleacq/file6": "unarchived",
+    }
+)
+def test_release_files(queue, mock_lfs, node):
+    """Test running release_files."""
+
+    node.io.release_files()
+
+    # Job in queue
+    assert queue.qsize == 1
+
+    # Run the task
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Headroom is about 10.5MB, slightly more than the 10MB we report for quota
+    # remaining.  As a result, we have released 4 files, ordered by last_update:
+    #  - file2: 300 kB  [ last_update = 1 ]
+    #  - file5:  50 kB  [ last_update = 2 ]
+    #  - file1: 100 kB  [ last_update = 3 ]
+    #  - file6 is skipped because it's not archived [last_update = 4]
+    #  - file3: 400 kB  [ last_update = 5 ]
+    # file4 remains restored
+    assert not ArchiveFileCopy.get(id=1).ready
+    assert not ArchiveFileCopy.get(id=2).ready
+    assert not ArchiveFileCopy.get(id=3).ready
+    assert ArchiveFileCopy.get(id=4).ready
+    assert not ArchiveFileCopy.get(id=5).ready
+    assert ArchiveFileCopy.get(id=6).ready
+
+    # Check hsm_relase was actually called
+    lfs = mock_lfs("")
+    assert lfs.hsm_state("/node/simpleacq/file1") == lfs.HSM_RELEASED
+    assert lfs.hsm_state("/node/simpleacq/file2") == lfs.HSM_RELEASED
+    assert lfs.hsm_state("/node/simpleacq/file3") == lfs.HSM_RELEASED
+    assert lfs.hsm_state("/node/simpleacq/file4") == lfs.HSM_RESTORED
+    assert lfs.hsm_state("/node/simpleacq/file5") == lfs.HSM_RELEASED
+    assert lfs.hsm_state("/node/simpleacq/file6") == lfs.HSM_UNARCHIVED
+
+
+@pytest.mark.lfs_quota_remaining(10000000)
+def test_before_update(queue, node):
+    """Test LustreHSMNodeIO.before_update()"""
+
+    # When not idle, the release_files task is not run
+    node.io.before_update(idle=False)
+
+    assert queue.qsize == 0
+
+    # But when idle it should run
+    node.io.before_update(idle=True)
+
+    assert queue.qsize == 1
+
+
+def test_filesize(xfs, node):
+    """Test LustreHSMNodeIO.filesize(), which always returns st_size"""
+
+    xfs.create_file("/node/simpleacq/file1", st_size=100000)
+    assert node.io.filesize("simpleacq/file1") == 100000
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/node/dir/file1": "released",
+        "/node/dir/file2": "restored",
+    }
+)
+def test_open_binary(xfs, node):
+    """Test binary LustreHSMNodeIO.open()"""
+
+    xfs.create_file("/node/dir/file2", contents="file contents")
+
+    with pytest.raises(OSError):
+        node.io.open("dir/file1", binary=True)
+
+    with node.io.open("dir/file2", binary=True) as f:
+        assert f.read() == b"file contents"
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/node/dir/file1": "released",
+        "/node/dir/file2": "restored",
+    }
+)
+def test_open_text(xfs, node):
+    """Test text LustreHSMNodeIO.open()"""
+
+    xfs.create_file("/node/dir/file2", contents="file contents")
+
+    with pytest.raises(OSError):
+        node.io.open("dir/file1", binary=False)
+
+    with node.io.open("dir/file2", binary=False) as f:
+        assert f.read() == "file contents"
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/node/simpleacq/file1": "released",
+    }
+)
+def test_check_released(queue, mock_lfs, node):
+    """Test LustreHSMNodeIO.check() on a released file."""
+
+    copy = ArchiveFileCopy.get(id=1)
+    copy.ready = False
+
+    node.io.check(copy)
+
+    # Queue is empty
+    assert queue.qsize == 0
+
+    # File has been restored
+    assert not mock_lfs("").hsm_released(copy.path)
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/node/simpleacq/file1": "restored",
+    }
+)
+def test_check_restored(queue, mock_lfs, node):
+    """Test LustreHSMNodeIO.check() on a restored file."""
+    node.io.check(ArchiveFileCopy.get(id=1))
+
+    # Task has been created
+    assert queue.qsize == 1
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/node/simpleacq/file1": "restored",
+        "/node/simpleacq/file2": "released",
+        "/node/simpleacq/file3": "unarchived",
+        "/node/simpleacq/file4": "missing",
+    }
+)
+def test_ready_path(mock_lfs, node):
+    """Test LustreHSMNodeIO.ready_path."""
+
+    # Return indicates readiness before recall
+    assert node.io.ready_path("/node/simpleacq/file1")
+    assert not node.io.ready_path("/node/simpleacq/file2")
+    assert node.io.ready_path("/node/simpleacq/file3")
+    assert not node.io.ready_path("/node/simpleacq/file4")
+
+    # But now released file is recalled.
+    lfs = mock_lfs("")
+    assert lfs.hsm_state("/node/simpleacq/file1") == lfs.HSM_RESTORED
+    assert lfs.hsm_state("/node/simpleacq/file2") == lfs.HSM_RESTORED
+    assert lfs.hsm_state("/node/simpleacq/file3") == lfs.HSM_UNARCHIVED
+    assert lfs.hsm_state("/node/simpleacq/file4") == lfs.HSM_MISSING
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/node/simpleacq/file1": "restored",
+    }
+)
+def test_ready_pull_restored(mock_lfs, node, archivefilecopyrequest):
+    """Test LustreHSMNodeIO.ready_pull on a restored file that isn't ready."""
+
+    copy = ArchiveFileCopy.get(id=1)
+    copy.ready = False
+    copy.save()
+    afcr = archivefilecopyrequest(
+        file=copy.file, node_from=node.db, group_to=node.db.group
+    )
+
+    node.io.ready_pull(afcr)
+
+    # File is ready
+    assert ArchiveFileCopy.get(id=1).ready
+
+    # File is restored
+    lfs = mock_lfs("")
+    assert lfs.hsm_state(copy.path) == lfs.HSM_RESTORED
+
+
+@pytest.mark.lfs_hsm_state(
+    {
+        "/node/simpleacq/file1": "released",
+    }
+)
+def test_ready_pull_released(mock_lfs, node, archivefilecopyrequest):
+    """Test LustreHSMNodeIO.ready on a released file that isn't ready."""
+
+    copy = ArchiveFileCopy.get(id=1)
+    afcr = archivefilecopyrequest(
+        file=copy.file, node_from=node.db, group_to=node.db.group
+    )
+
+    node.io.ready_pull(afcr)
+
+    # File is not ready (because ready is set before hsm_restore is called)
+    assert not ArchiveFileCopy.get(id=1).ready
+
+    # File is restored
+    lfs = mock_lfs("")
+    assert lfs.hsm_state(copy.path) == lfs.HSM_RESTORED

--- a/tests/io/test_lustrequota.py
+++ b/tests/io/test_lustrequota.py
@@ -1,0 +1,47 @@
+"""Test LustreQuotaNodeIO."""
+
+import pytest
+
+from alpenhorn.io.lustrequota import LustreQuotaNodeIO
+from alpenhorn.update import UpdateableNode
+
+
+@pytest.fixture
+def node(simplenode, mock_lfs):
+    """A LustreQuota node for testing"""
+    simplenode.io_class = "LustreQuota"
+    simplenode.io_config = '{"quota_group": "qgroup"}'
+
+    return UpdateableNode(None, simplenode)
+
+
+def test_no_quota_group(simplenode):
+    """Test instantiating I/O without specifying quota_group."""
+
+    simplenode.io_class = "LustreQuota"
+
+    with pytest.raises(KeyError):
+        UpdateableNode(None, simplenode)
+
+
+def test_no_lfs(simplenode):
+    """Test crashing if lfs(1) can't be found."""
+
+    simplenode.io_class = "LustreQuota"
+    simplenode.io_config = '{"quota_group": "qgroup"}'
+
+    with pytest.raises(RuntimeError):
+        UpdateableNode(None, simplenode)
+
+
+def test_quota_group(node):
+    """Test instantiating I/O."""
+
+    assert isinstance(node.io, LustreQuotaNodeIO)
+
+
+@pytest.mark.lfs_quota_remaining(1234)
+def test_bytes_avail(node):
+    """Test LustreQuotaNodeIO.bytes_avail"""
+
+    assert node.io.bytes_avail() == 1234

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -168,10 +168,10 @@ def test_serial_io(fastqueue, set_config):
     assert task_count == 3
 
 
-def test_ioload(storagegroup, storagenode):
+def test_ioload(storagegroup, storagenode, mock_lfs):
     """Test instantiation of the I/O classes"""
 
-    for ioclass in ["Default", "Transport", None]:
+    for ioclass in ["Default", "Transport", "LustreHSM", None]:
         group = storagegroup(
             name="none" if ioclass is None else ioclass, io_class=ioclass
         )
@@ -179,6 +179,8 @@ def test_ioload(storagegroup, storagenode):
     for ioclass, ioconfig in [
         ("Default", None),
         ("Polling", None),
+        ("LustreQuota", '{"quota_group": "qgroup"}'),
+        ("LustreHSM", '{"quota_group": "qgroup", "headroom": 100000}'),
         (None, None),
     ]:
         storagenode(


### PR DESCRIPTION
This PR add the Lustre I/O classes.

## LFS wrapper
I've made a wrapper around calls to the `lfs(1)` binary in `alpenhorn.io.lfs.py`.  It is not a complete wrapper for that command and only able to run these commands:
* "lfs quota" to retrieve the group quota for a path.  The user group used must be specified in the I/O config.  Can also handle the quota max override needed for cedar's `/nearline`.
* "lfs hsm_state" to retrieve the HSM state for a file.  The state itself is represented with the `HSMState` enum and is one of:
  * `MISSING`: file is not present on disk or tape
  * `UNARCHIVED`: file exists on disk, but not on tape
  * `RESTORED`: file exists on both disk and tape
  * `RELEASED`: file exists on tape only
* "lfs hsm_restore" changes state `RELEASED -> RESTORED`
* "lfs hsm_release" changes state `RESTORED -> RELEASED`

## LustreQuota I/O

This is a very simple stepping-stone I/O module to Lustre HSM I/O.  It's exactly the same as DefaultIO, except is uses "lfs quota" to determine free space.  This behaviour re-creates the special casing we have in place in alpenhorn-1 for the "cedar_online" node.

## Lustre HSM I/O
The LustreHSM I/O is where all the HSM management occurs.  In general this is via updated versions of I/O methods from Default I/O. It also will automatically release files from disk (see `release_files`) as needed to keep enough headroom available on the HSM disk so that I/O can continue to happen.

The LustreHSM Group needs two nodes in it.  One of them must be a "LustreHSM" node, used as the "primary node", and another node, of any non-LustreHSM type, used as a "secondary node" for small files.  The group I/O config may specify the threshold for small files.