### PR TITLE
fix(setup): Move globre requirement to test-requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-peewee ~= 3.0
 Click >= 6.0
-globre
-watchdog
-tabulate
+peewee ~= 3.0
 PyYAML
+tabulate
+watchdog

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
-pytest >= 7.0
-pyfakefs >= 5.0
-docker >= 3.0
 chimedb @ git+https://github.com/chime-experiment/chimedb.git
+docker >= 3.0
+globre
+pyfakefs >= 5.0
+pytest >= 7.0


### PR DESCRIPTION
Might be better just to drop the requirement, which would require rewriting examples/pattern_imorter.py

Closes #160 