### PR TITLE
fix: Store/read (naive) UTC datetimes to/from DB.

### DIFF
--- a/alpenhorn/acquisition.py
+++ b/alpenhorn/acquisition.py
@@ -40,7 +40,7 @@ class ArchiveFile(base_model):
     md5sum : string
         md5 checksum of file. Used for verifying integrity.
     registered : datetime
-        The time the file was registered in the database.
+        The UTC time when the file was registered in the database.
     """
 
     acq = pw.ForeignKeyField(ArchiveAcq, backref="files")
@@ -49,7 +49,7 @@ class ArchiveFile(base_model):
     md5sum = pw.CharField(null=True, max_length=32)
     # Note: default here is the now method itself (i.e. "now", not "now()").
     #       Will be evaulated by peewee at row-creation time.
-    registered = pw.DateTimeField(default=datetime.datetime.now)
+    registered = pw.DateTimeField(default=datetime.datetime.utcnow)
 
     class Meta:
         # (acq,name) is unique

--- a/alpenhorn/archive.py
+++ b/alpenhorn/archive.py
@@ -49,7 +49,7 @@ class ArchiveFileCopy(base_model):
     wants_file = EnumField(["Y", "M", "N"], default="Y")
     ready = pw.BooleanField(default=False)
     size_b = pw.BigIntegerField(null=True)
-    last_update = pw.DateTimeField(default=datetime.datetime.now)
+    last_update = pw.DateTimeField(default=datetime.datetime.utcnow)
 
     @property
     def path(self) -> pathlib.Path:
@@ -80,11 +80,11 @@ class ArchiveFileCopyRequest(base_model):
     cancelled : bool
         Set to true if the copy is no longer wanted.
     timestamp : datetime
-        The time the request was made.
+        The UTC time when the request was made.
     transfer_started : datetime
-        The time the transfer was started.
+        The UTC time when the transfer was started.
     transfer_completed : datetime
-        The time the transfer was completed.
+        The UTC time when the transfer was completed.
     """
 
     file = pw.ForeignKeyField(ArchiveFile, backref="requests")
@@ -92,7 +92,7 @@ class ArchiveFileCopyRequest(base_model):
     node_from = pw.ForeignKeyField(StorageNode, backref="requests_from")
     completed = pw.BooleanField(default=False)
     cancelled = pw.BooleanField(default=False)
-    timestamp = pw.DateTimeField(default=datetime.datetime.now, null=True)
+    timestamp = pw.DateTimeField(default=datetime.datetime.utcnow, null=True)
     transfer_started = pw.DateTimeField(null=True)
     transfer_completed = pw.DateTimeField(null=True)
 

--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -160,7 +160,7 @@ def _import_file(task: Task, node: StorageNode, path: pathlib.PurePath) -> None:
             copy.has_file = "M"
             copy.wants_file = "Y"
             copy.ready = True
-            copy.last_update = datetime.now()
+            copy.last_update = datetime.utcnow()
             copy.save()
             log.warning(
                 f'Imported file "{path}" formerly present on node {node.name}!  Marking suspect.'
@@ -174,7 +174,7 @@ def _import_file(task: Task, node: StorageNode, path: pathlib.PurePath) -> None:
                 wants_file="Y",
                 ready=True,
                 size_b=node.io.filesize(path, actual=True),
-                last_update=datetime.now(),
+                last_update=datetime.utcnow(),
             )
             log.info(f'Registered file copy "{path}" on node "{node.name}".')
 

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -218,7 +218,7 @@ def check_async(task: Task, io: BaseNodeIO, copy: ArchiveFileCopy) -> None:
     log.info(
         f"Updating file copy #{copy.id} for file {copyname} on node {io.node.name}."
     )
-    copy.last_update = datetime.now()
+    copy.last_update = datetime.utcnow()
     copy.save()
 
 
@@ -303,5 +303,5 @@ def delete_async(
 
         # Update the DB
         ArchiveFileCopy.update(
-            has_file="N", wants_file="N", last_update=datetime.now()
+            has_file="N", wants_file="N", last_update=datetime.utcnow()
         ).where(ArchiveFileCopy.id == copy.id).execute()

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -355,7 +355,7 @@ def copy_request_done(
         if check_src:
             # If the copy didn't work, then the remote file may be corrupted.
             log.error(f"Copy failed: {stderr};  Marking source file suspect.")
-            ArchiveFileCopy.update(has_file="M", last_update=datetime.now()).where(
+            ArchiveFileCopy.update(has_file="M", last_update=datetime.utcnow()).where(
                 ArchiveFileCopy.file == req.file,
                 ArchiveFileCopy.node == req.node_from,
             ).execute()
@@ -376,7 +376,7 @@ def copy_request_done(
             f"MD5 mismatch on node {io.node.name}; "
             f"Marking source file {req.file.name} on node {req.node_from} suspect."
         )
-        ArchiveFileCopy.update(has_file="M", last_update=datetime.now()).where(
+        ArchiveFileCopy.update(has_file="M", last_update=datetime.utcnow()).where(
             ArchiveFileCopy.file == req.file,
             ArchiveFileCopy.node == req.node_from,
         ).execute()
@@ -402,7 +402,7 @@ def copy_request_done(
                 wants_file="Y",
                 ready=True,
                 size_b=size,
-                last_update=datetime.now(),
+                last_update=datetime.utcnow(),
             ).execute()
         except pw.IntegrityError:
             ArchiveFileCopy.update(
@@ -410,7 +410,7 @@ def copy_request_done(
                 wants_file="Y",
                 ready=True,
                 size_b=size,
-                last_update=datetime.now(),
+                last_update=datetime.utcnow(),
             ).where(
                 ArchiveFileCopy.file == req.file, ArchiveFileCopy.node == io.node
             ).execute()
@@ -418,8 +418,8 @@ def copy_request_done(
         # Mark AFCR as completed
         ArchiveFileCopyRequest.update(
             completed=True,
-            transfer_started=datetime.fromtimestamp(start_time),
-            transfer_completed=datetime.fromtimestamp(end_time),
+            transfer_started=datetime.utcfromtimestamp(start_time),
+            transfer_completed=datetime.utcfromtimestamp(end_time),
         ).where(ArchiveFileCopyRequest.id == req.id).execute()
 
     return True

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -320,7 +320,7 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         # Update last_updated for the copy.  This ensures another
         # copy of auto-verify won't be enqueued while the job is yielded
         # waiting for restore
-        copy.last_update = datetime.now()
+        copy.last_update = datetime.utcnow()
         copy.save()
 
         def _async(

--- a/alpenhorn/storage.py
+++ b/alpenhorn/storage.py
@@ -131,7 +131,7 @@ class StorageNode(base_model):
     avail_gb : float
         How much free space is there on this node?
     avail_gb_last_checked : datetime
-        When was the amount of free space last checked?
+        The UTC time when `avail_gb` was last updated.
     notes : string
         Any notes or comments about this node.
     io_config : string
@@ -366,7 +366,7 @@ class StorageNode(base_model):
             self.avail_gb = None
         else:
             self.avail_gb = new_avail / 2**30
-        self.avail_gb_last_checked = datetime.datetime.now()
+        self.avail_gb_last_checked = datetime.datetime.utcnow()
 
         # Update the DB with the free space but don't clobber changes made
         # manually to the database

--- a/tests/io/test_ioutil_crd.py
+++ b/tests/io/test_ioutil_crd.py
@@ -154,7 +154,7 @@ def test_md5ok_true(db_setup):
 
     io, copy, req, start_time = db_setup
 
-    before = datetime.datetime.now() - datetime.timedelta(seconds=2)
+    before = datetime.datetime.utcnow() - datetime.timedelta(seconds=2)
     assert (
         copy_request_done(
             req,
@@ -165,13 +165,13 @@ def test_md5ok_true(db_setup):
         )
         is True
     )
-    after = datetime.datetime.now()
+    after = datetime.datetime.utcnow()
 
     # request is resolved
     afcr = ArchiveFileCopyRequest.get(id=req.id)
     assert afcr.completed
     assert not afcr.cancelled
-    assert afcr.transfer_started == datetime.datetime.fromtimestamp(start_time)
+    assert afcr.transfer_started == datetime.datetime.utcfromtimestamp(start_time)
     assert afcr.transfer_completed >= before
     assert afcr.transfer_completed <= after
 

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -39,9 +39,9 @@ def test_acq_model(archiveacq):
 
 def test_file_model(archiveacq, archivefile):
     acq1 = archiveacq(name="acq1")
-    before = datetime.datetime.now().replace(microsecond=0)
+    before = datetime.datetime.utcnow().replace(microsecond=0)
     archivefile(name="min", acq=acq1)
-    after = datetime.datetime.now()
+    after = datetime.datetime.utcnow()
     archivefile(
         name="max",
         acq=acq1,

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -79,11 +79,11 @@ def test_archivefilecopyrequest_model(
     """Test ArchiveFileCopyRequest model"""
     minnode = storagenode(name="min", group=simplegroup)
     maxnode = storagenode(name="max", group=simplegroup)
-    before = (datetime.datetime.now() - datetime.timedelta(seconds=1)).replace(
+    before = (datetime.datetime.utcnow() - datetime.timedelta(seconds=1)).replace(
         microsecond=0
     )
     archivefilecopyrequest(file=simplefile, node_from=minnode, group_to=simplegroup)
-    after = datetime.datetime.now() + datetime.timedelta(seconds=1)
+    after = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
     archivefilecopyrequest(
         file=simplefile,
         node_from=maxnode,

--- a/tests/test_auto_import.py
+++ b/tests/test_auto_import.py
@@ -105,7 +105,7 @@ def test_import_file_create(xfs, dbtables, unode):
 
     xfs.create_file("/node/simplefile_acq/simplefile")
 
-    before = (datetime.datetime.now() - datetime.timedelta(seconds=1)).replace(
+    before = (datetime.datetime.utcnow() - datetime.timedelta(seconds=1)).replace(
         microsecond=0
     )
 
@@ -119,7 +119,7 @@ def test_import_file_create(xfs, dbtables, unode):
                 )
             )
 
-    after = datetime.datetime.now() + datetime.timedelta(seconds=1)
+    after = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
 
     # Check DB
     acq = ArchiveAcq.get(name="simplefile_acq")
@@ -209,7 +209,7 @@ def test_import_file_exists(xfs, dbtables, unode, simplefile, archivefilecopy):
     )
     xfs.create_file("/node/simplefile_acq/simplefile")
 
-    before = (datetime.datetime.now() - datetime.timedelta(seconds=1)).replace(
+    before = (datetime.datetime.utcnow() - datetime.timedelta(seconds=1)).replace(
         microsecond=0
     )
 
@@ -223,7 +223,7 @@ def test_import_file_exists(xfs, dbtables, unode, simplefile, archivefilecopy):
                 )
             )
 
-    after = datetime.datetime.now() + datetime.timedelta(seconds=1)
+    after = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
 
     # Check DB
     acq = ArchiveAcq.get(name="simplefile_acq")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -348,13 +348,15 @@ def test_update_avail_gb(simplenode):
     assert simplenode.avail_gb is None
 
     # Test a number
-    start = datetime.datetime.now()
+    before = datetime.datetime.utcnow()
     simplenode.update_avail_gb(10000)
     # Now the value is set
     node = StorageNode.get(id=simplenode.id)
+    after = datetime.datetime.utcnow()
 
     assert node.avail_gb == 10000.0 / 2.0**30
-    assert node.avail_gb_last_checked >= start
+    assert node.avail_gb_last_checked >= before
+    assert node.avail_gb_last_checked <= after
 
     # Test None
     simplenode.update_avail_gb(None)

--- a/tests/test_update_node.py
+++ b/tests/test_update_node.py
@@ -146,7 +146,7 @@ def test_update_free_space(unode):
     unode.db.avail_gb = 3
     unode.db.save()
 
-    now = datetime.datetime.now()
+    now = datetime.datetime.utcnow()
     # 2 ** 32 bytes is 4 GiB
     with patch.object(unode.io, "bytes_avail", lambda fast: 2**32):
         unode.update_free_space()
@@ -164,7 +164,7 @@ def test_auto_verify(unode, simpleacq, archivefile, archivefilecopy):
     unode.db.auto_verify = 4
 
     # Last Update time to permit auto verification
-    last_update = datetime.datetime.now() - datetime.timedelta(days=10)
+    last_update = datetime.datetime.utcnow() - datetime.timedelta(days=10)
 
     # Make some files to verify
     copyY = archivefilecopy(
@@ -211,7 +211,7 @@ def test_auto_verify_dups(unode, simpleacq, archivefile, archivefilecopy):
     unode.db.auto_verify = 4
 
     # Last Update time to permit auto verification
-    last_update = datetime.datetime.now() - datetime.timedelta(days=10)
+    last_update = datetime.datetime.utcnow() - datetime.timedelta(days=10)
 
     # Only one file
     copyY = archivefilecopy(
@@ -235,33 +235,30 @@ def test_auto_verify_time(unode, simpleacq, archivefile, archivefilecopy):
     # Enable auto_verify
     unode.db.auto_verify = 4
 
-    # Last Update time to permit auto verification
-    last_update = datetime.datetime.now() - datetime.timedelta(days=10)
-
     # Files with different last update times
     copy9 = archivefilecopy(
         node=unode.db,
         file=archivefile(name="file9", acq=simpleacq),
         has_file="Y",
-        last_update=datetime.datetime.now() - datetime.timedelta(days=9),
+        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=9),
     )
     copy8 = archivefilecopy(
         node=unode.db,
         file=archivefile(name="file8", acq=simpleacq),
         has_file="Y",
-        last_update=datetime.datetime.now() - datetime.timedelta(days=8),
+        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=8),
     )
     copy6 = archivefilecopy(
         node=unode.db,
         file=archivefile(name="file6", acq=simpleacq),
         has_file="Y",
-        last_update=datetime.datetime.now() - datetime.timedelta(days=6),
+        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=6),
     )
     copy5 = archivefilecopy(
         node=unode.db,
         file=archivefile(name="file5", acq=simpleacq),
         has_file="Y",
-        last_update=datetime.datetime.now() - datetime.timedelta(days=5),
+        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=5),
     )
 
     mock = MagicMock()
@@ -298,18 +295,18 @@ def test_auto_verify_released(
     # Make the node
     unode = UpdateableNode(queue, simplenode)
 
-    # Files with different last update times
-    copy = archivefilecopy(
+    # This is the only file
+    archivefilecopy(
         node=unode.db,
         file=simplefile,
         has_file="Y",
-        last_update=datetime.datetime.now() - datetime.timedelta(days=10),
+        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=10),
     )
 
     unode.run_auto_verify()
     unode.run_auto_verify()
 
-    # There should be one deferred put
+    # There should be one pending check
     assert queue.qsize == 1
 
 


### PR DESCRIPTION
The `datetime`s are all naive because peewee doesn't work well with TZ-aware ones.

Closes #159 