### PR TITLE
fix(db): Don't initialise peewee DB in every thread

### DIFF
--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -86,7 +86,7 @@ def _capability(key: str) -> Any:
     default_cap = {
         "connect": None,
         "close": None,
-        "reentrant": False,
+        "reentrant": True,
     }
 
     try:
@@ -101,11 +101,11 @@ def _capability(key: str) -> Any:
             raise KeyError(f"unknown database capability: {key}")
 
 
-def init() -> None:
-    """Initiate the database connection framework.
+def connect() -> None:
+    """Connect to the database.
 
-    This must be called once, after extensions are loaded, but
-    before attempting to use connect() to create a database connection.
+    This must be called once, after extensions are loaded, before
+    threads are created.
     """
     # attempt to load a database extension
     global _db_ext
@@ -119,13 +119,6 @@ def init() -> None:
     # Tell everyone whether we're threadsafe
     global threadsafe
     threadsafe = _capability("reentrant")
-
-
-def connect() -> None:
-    """Connect to the database.
-
-    Should be called per-thread before any database operations are attempted.
-    """
 
     # If fetch the database config, if present
     if "database" in config.config:

--- a/alpenhorn/pool.py
+++ b/alpenhorn/pool.py
@@ -6,7 +6,6 @@ import threading
 from types import FrameType
 from peewee import OperationalError
 
-from . import db
 from .queue import FairMultiFIFOQueue
 
 log = logging.getLogger(__name__)
@@ -60,8 +59,6 @@ class Worker(threading.Thread):
         """
 
         log.info("Started.")
-
-        db.connect()
 
         while True:
             # Exit if told to stop

--- a/alpenhorn/service.py
+++ b/alpenhorn/service.py
@@ -42,9 +42,6 @@ def cli():
     # Load alpenhorn extensions
     extensions.load_extensions()
 
-    # Initialise the database framework
-    db.init()
-
     # Connect to the database
     db.connect()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,7 +374,6 @@ def dbproxy(set_config):
     extensions.load_extensions()
 
     # DB start
-    db.init()
     db.connect()
 
     yield db.database_proxy

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -9,12 +9,12 @@ from alpenhorn import db
 
 def test_db(dbproxy):
     """Test starting the default DB."""
-    assert not db.threadsafe
+    assert db.threadsafe
     assert issubclass(dbproxy.obj.__class__, pw.Database)
 
 
 def test_chimedb(use_chimedb, dbproxy):
-    """Test starting the default DB."""
+    """Test starting CHIMEdb."""
     assert db.threadsafe
     assert issubclass(dbproxy.obj.__class__, pw.Database)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -281,7 +281,7 @@ def e2e_config(xfs, hostname):
             "pattern_importer",
         ],
         "database": {"url": "sqlite:///?database=" + urlquote(DB_URI) + "&uri=true"},
-        "service": {"num_workers": 4},
+        "service": {"num_workers": 0},
     }
 
     # Put it in a file


### PR DESCRIPTION
peewee already handles threadsafety of the inherently not threadsafe MySQL connection, so there's no need for us to second guess it.

This changes the way the DB framework is initialised: all initialisation happens in the main thread.  peewee is smart enough to open per-thread connections to the database on demand in the worker threadds.

As a result, the default DB code (which CHIME doesn't use) is now reported to be threadsafe, which is nice.