### PR TITLE
Various small fixes found during the cedar shakedown

### DIFF
--- a/alpenhorn/config.py
+++ b/alpenhorn/config.py
@@ -145,7 +145,7 @@ log = logging.getLogger(__name__)
 config = None
 
 _default_config = {
-    "logging": {"level": "warning", "module_levels": {"alpenhorn": "info"}},
+    "logging": {"level": "info"},
     "service": {
         "auto_import_interval": 30,
         "auto_verify_min_days": 7,

--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -189,7 +189,7 @@ class RetryOperationalError:
     See: https://github.com/coleifer/peewee/issues/1472
     """
 
-    def execute_sql(self, sql, params=None, commit=pw.SENTINEL):
+    def execute_sql(self, sql, params=None, commit=None):
         """Extend default execute_sql to retry.
 
         Retries once on pw.OperationalError, but only if not

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -143,7 +143,7 @@ class BaseNodeIO:
         self._queue = queue
         self.config = config
 
-    def update(self, node: StorageNode) -> None:
+    def set_storage(self, node: StorageNode) -> None:
         """Update the cached StorageNode instance.
 
         Called once per update loop on pre-existing I/O instances to
@@ -455,6 +455,30 @@ class BaseGroupIO:
     def __init__(self, group: StorageGroup, config: dict) -> None:
         self.group = group
         self.config = config
+
+    def set_storage(self, group: StorageGroup) -> None:
+        """Update the cached StorageGroup instance.
+
+        Called once per update loop on pre-existing I/O instances to
+        replace their `self.group` with a new instance fetched from
+        the database.  The new `group` instance reflects changes made
+        to the database record outside of alpenhornd.
+
+        None of `group.id`, `group.name`, `group.io_class`, or `group.io_config`
+        are different than the old `self.group`'s values.  (Changes in these
+        attributes cause alpenhorn to re-create the I/O instance instead of
+        calling this method.)
+
+        If called, this method is called before the `before_update` hook,
+        but it is not called during the main loop iteration that creates
+        the I/O instance.
+
+        Parameters
+        ----------
+        group : StorageGroup
+            the updated group instance read from the database
+        """
+        self.group = group
 
     def set_nodes(self, nodes: list[UpdateableNode]) -> list[UpdateableNode]:
         """Set the list of local active nodes in this group.

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -13,6 +13,7 @@ from ..archive import ArchiveFileCopy, ArchiveFileCopyRequest
 from .. import config, db, util
 
 if TYPE_CHECKING:
+    import os
     from ..base import BaseNodeIO
 
 import logging
@@ -63,16 +64,16 @@ def _pull_timeout(size_b: int) -> float | None:
     return base + size_b / bps
 
 
-def bbcp(from_path: str, to_dir: str, size_b: int) -> dict:
+def bbcp(from_path: str | os.PathLike, to_dir: str | os.PathLike, size_b: int) -> dict:
     """Transfer a file with BBCP.
 
     Command times out after `_pull_timeout(size_b)` seconds have elapsed.
 
     Parameters
     ----------
-    from_path : str
+    from_path : path-like
         Source location
-    to_dir : str
+    to_dir : path-like
         Destination directory
     size_b : int
         Size of the file to transfer.  Only used to
@@ -153,8 +154,8 @@ def bbcp(from_path: str, to_dir: str, size_b: int) -> dict:
             # and https://github.com/chime-experiment/alpenhorn/pull/15
             "-E",
             "%md5=",
-            from_path,
-            to_dir,
+            str(from_path),
+            str(to_dir),
         ],
         timeout=_pull_timeout(size_b),
     )
@@ -178,16 +179,18 @@ def bbcp(from_path: str, to_dir: str, size_b: int) -> dict:
     return ioresult
 
 
-def rsync(from_path: str, to_dir: str, size_b: int, local: bool) -> dict:
+def rsync(
+    from_path: str | os.PathLike, to_dir: str | os.PathLike, size_b: int, local: bool
+) -> dict:
     """Rsync a file (either local or remote).
 
     Command times out after `_pull_timeout(size_b)` seconds have elapsed.
 
     Parameters
     ----------
-    from_path : str
+    from_path : path-like
         Source location
-    to_dir : str
+    to_dir : path-like
         Destination directory
     size_b : int
         Size of the file to transfer.  Only used to
@@ -232,8 +235,8 @@ def rsync(from_path: str, to_dir: str, size_b: int, local: bool) -> dict:
             "--owner",
             "--copy-links",
             "--sparse",
-            from_path,
-            to_dir,
+            str(from_path),
+            str(to_dir),
         ],
         timeout=_pull_timeout(size_b),
     )

--- a/alpenhorn/io/lfs.py
+++ b/alpenhorn/io/lfs.py
@@ -128,7 +128,10 @@ class LFS:
             the command.  If the command failed, returns None and
             logs the failure.
         """
-        ret, stdout, stderr = util.run_command([self._lfs] + list(args))
+        # Stringify args
+        args = [str(arg) for arg in args]
+
+        ret, stdout, stderr = util.run_command([self._lfs] + args)
 
         if ret != 0:
             log.warning(f"LFS command failed (ret={ret}): " + " ".join(args))
@@ -140,7 +143,7 @@ class LFS:
 
         return stdout
 
-    def quota_remaining(self, path: str) -> int | None:
+    def quota_remaining(self, path: str | os.PathLike) -> int | None:
         """Retrieve the remaining quota for `path`.
 
         Parameters
@@ -182,6 +185,9 @@ class LFS:
         # default quota is in use.  We (non-root) don't have permission
         # to fetch the default quota, so we need to fall back on the fixed
         # quota in that case.
+
+        # Stringify path
+        path = str(path)
 
         stdout = self.run_lfs("quota", "-q", "-g", self._quota_group, path)
         if stdout is None:
@@ -247,6 +253,9 @@ class LFS:
         # No need to check with HSM if the path isn't present
         if not pathlib.Path(path).exists():
             return HSMState.MISSING
+
+        # Stringify path
+        path = str(path)
 
         stdout = self.run_lfs("hsm_state", path)
         if stdout is None:

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -229,13 +229,13 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
                     ).execute()
                 elif state == lfs.HSM_RELEASED:
                     if copy.ready:
-                        log.info("Updating file copy {copy.file.path}: ready -> False")
+                        log.info(f"Updating file copy {copy.file.path}: ready -> False")
                         ArchiveFileCopy.update(ready=False).where(
                             ArchiveFileCopy.id == copy.id
                         ).execute()
                 else:  # i.e. RESTORED or UNARCHIVED
                     if not copy.ready:
-                        log.info("Updating file copy {copy.file.path}: ready -> True")
+                        log.info(f"Updating file copy {copy.file.path}: ready -> True")
                         ArchiveFileCopy.update(ready=True).where(
                             ArchiveFileCopy.id == copy.id
                         ).execute()

--- a/alpenhorn/logger.py
+++ b/alpenhorn/logger.py
@@ -36,7 +36,8 @@ except ImportError:
 
 # The log format.  Used by the stderr log and any other log destinations
 log_fmt = logging.Formatter(
-    "%(asctime)s %(levelname)s >> [%(threadName)s] %(message)s", "%b %d %H:%M:%S"
+    "%(asctime)s %(levelname)s >> [%(threadName)s:%(name)s] %(message)s",
+    "%b %d %H:%M:%S",
 )
 
 # initialised by init_logging
@@ -350,12 +351,13 @@ def configure_logging() -> None:
     root_logger.setLevel(level)
 
     # Apply any module specific logging levels
-    for name, level in logger_config["module_levels"].items():
-        logger = logging.getLogger(name)
-        level = level.upper()
+    if "module_levels" in logger_config:
+        for name, level in logger_config["module_levels"].items():
+            logger = logging.getLogger(name)
+            level = level.upper()
 
-        _check_level(level, f"logging.module_levels.{name}")
-        logger.setLevel(level)
+            _check_level(level, f"logging.module_levels.{name}")
+            logger.setLevel(level)
 
     # Configure syslog logging, maybe
     if "syslog" in logger_config:

--- a/alpenhorn/pool.py
+++ b/alpenhorn/pool.py
@@ -268,7 +268,7 @@ class WorkerPool:
                     self._all_workers.remove(worker)
 
                     # Respawn
-                    log.warning("Respawning dead worker #{index}")
+                    log.warning(f"Respawning dead worker #{index}")
                     self._new_worker(index)
 
     def __len__(self) -> int:

--- a/alpenhorn/storage.py
+++ b/alpenhorn/storage.py
@@ -292,7 +292,7 @@ class StorageNode(base_model):
             .where(ArchiveFileCopy.node == self, ArchiveFileCopy.has_file == "Y")
         ).scalar(as_tuple=True)[0]
 
-        return 0.0 if size is None else float(size) / 2**20
+        return 0.0 if size is None else float(size) / 2**30
 
     def get_all_files(
         self,

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -176,7 +176,7 @@ class updateable_base:
 
         # No re-init, update I/O instance's Storage object
         self.db = storage
-        self.io.update(storage)
+        self.io.set_storage(storage)
         return False
 
 
@@ -478,10 +478,10 @@ class UpdateableGroup(updateable_base):
         self.db = None
         self._do_idle_updates = False
 
-        self.reinit(group, nodes, idle)
+        self.reinit(group=group, nodes=nodes, idle=idle)
 
     def reinit(
-        self, group: StorageGroup, nodes: list[UpdateableNode], idle: bool
+        self, *, group: StorageGroup, nodes: list[UpdateableNode], idle: bool
     ) -> None:
         """Re-initialise the UpdateableGroup.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Click >= 6.0
 concurrent-log-handler
-peewee ~= 3.0
+peewee >= 3.16
 PyYAML
 tabulate
 watchdog

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -603,7 +603,7 @@ def simplefile(archiveacq, archivefile):
         name="simplefile",
         acq=acq,
         md5sum="d41d8cd98f00b204e9800998ecf8427e",
-        size_b=2**20,
+        size_b=2**30,
     )
 
 

--- a/tests/io/test_defaultnode_pull.py
+++ b/tests/io/test_defaultnode_pull.py
@@ -128,7 +128,7 @@ def test_pull_sync_overmax(queue, test_req, archivefile, archivefilecopy):
     # set up node to fail over_max check
     file = archivefile(name="file2", acq=req.file.acq, size_b=100000)
     archivefilecopy(file=file, node=node.db, has_file="Y")
-    node.db.max_total_gb = file.size_b / 2**21  # i.e. half of file.size_b
+    node.db.max_total_gb = file.size_b / 2**31  # i.e. half of file.size_b
     node.io.pull(req)
 
     # No job should be queued and req isn't resolved.

--- a/tests/io/test_ioutil.py
+++ b/tests/io/test_ioutil.py
@@ -1,6 +1,7 @@
 """Test alpenhorn.io.ioutil"""
 
 import pytest
+import pathlib
 
 from alpenhorn.io import ioutil
 
@@ -35,6 +36,22 @@ def test_bbcp_no_timeout(mock_run_command, set_config):
 
     args = mock_run_command()
     assert args["timeout"] is None  # pull_bytes_per_second = 0 disables
+
+
+@pytest.mark.run_command_result(0, "", "md5 d41d8cd98f00b204e9800998ecf8427e")
+def test_bbcp_pathlib(mock_run_command):
+    """Test passing pathlib.Path to ioutil.bbcp()."""
+
+    assert ioutil.bbcp(pathlib.Path("from/path"), pathlib.Path("to/dir"), 1e8) == {
+        "check_src": True,
+        "md5sum": "d41d8cd98f00b204e9800998ecf8427e",
+        "ret": 0,
+        "stderr": "md5 d41d8cd98f00b204e9800998ecf8427e",
+    }
+
+    args = mock_run_command()
+    assert "from/path" in args["cmd"]
+    assert "to/dir" in args["cmd"]
 
 
 @pytest.mark.run_command_result(0, "", "md5 d41d8cd98f00b204e9800998ecf8427e")
@@ -101,6 +118,25 @@ def test_rsync_good(mock_run_command):
     args = mock_run_command()
     assert "--compress" in args["cmd"]
     assert args["timeout"] == 305.0
+
+
+@pytest.mark.run_command_result(0, "", "")
+def test_rsync_pathlib(mock_run_command):
+    """Test passing pathlib.Path to ioutil.rsync()."""
+
+    # Local rsync
+    assert ioutil.rsync(
+        pathlib.Path("from/path"), pathlib.Path("to/dir"), 1e8, True
+    ) == {
+        "md5sum": True,
+        "ret": 0,
+        "stderr": "",
+    }
+
+    # Paths should be stringified
+    args = mock_run_command()
+    assert "from/path" in args["cmd"]
+    assert "to/dir" in args["cmd"]
 
 
 @pytest.mark.run_command_result(1, "", "mkstemp")

--- a/tests/io/test_lfs.py
+++ b/tests/io/test_lfs.py
@@ -1,6 +1,7 @@
 """Test alpenhorn.io.lfs LFS wrapper."""
 
 import pytest
+import pathlib
 
 from alpenhorn.io.lfs import LFS
 
@@ -14,6 +15,20 @@ def test_run_lfs_success(have_lfs, mock_run_command):
     assert lfs.run_lfs("arg1", "arg2") == "lfs_out"
     assert mock_run_command() == {
         "cmd": ["LFS", "arg1", "arg2"],
+        "kwargs": dict(),
+        "timeout": None,
+    }
+
+
+@pytest.mark.run_command_result(0, "lfs_out", "lfs_err")
+def test_run_lfs_stringify(have_lfs, mock_run_command):
+    """run_lfs should stringify arguments."""
+
+    lfs = LFS(None)
+
+    assert lfs.run_lfs(pathlib.Path("path"), 2) == "lfs_out"
+    assert mock_run_command() == {
+        "cmd": ["LFS", "path", "2"],
         "kwargs": dict(),
         "timeout": None,
     }


### PR DESCRIPTION
I don't think these are big enough to merit their own PRs:

# [fix(io): Add missing BaseGroupIO.set_storage()](https://github.com/radiocosmology/alpenhorn/commit/f7adfd0882186e9f440b090f1e488b24c04930c2)

Also:
* renamed BaseNodeIO.update() to BaserNodeIO.set_storage().
* enforce keyword arguments in UpdateableGroup.reinit().

The "set_storage" methods are called at the top of every update loop to replace the StorageNode/Group of the I/O classes. "update" was a very poor choice for their name because there are already too many things referred to as "update", and the name was always just going to lead to confusion.

(The erstwhile "update()" method was always called _before_ the "before_update()" method, which is a pretty clear indication there's something wrong with the name.)

# [Require peewee >= 3.16.3 to avoid deprecation warning](https://github.com/radiocosmology/alpenhorn/commit/bcced15248e209f3a092370f339e0cb5328e5a52)

Ported from https://github.com/chime-experiment/chimedb/pull/40

# [ Don't let pathlib.Paths leak into run_command ](https://github.com/radiocosmology/alpenhorn/commit/074f36b674e4b03d7f4ef431b8559f45c4bdd301)

`run_command` only accepts strings.

# [ Make INFO the default log level everywhere](https://github.com/radiocosmology/alpenhorn/commit/5cacc4e9e845d4eb54ad6bfc43d004757c58c6ab)

I get the idea of using `{"level": "warning", "module_levels": {"alpenhorn": "info"}}` as the logging config, but I think it's too confusing from a user point of view.  By default, users are going to expect the top-level `logging.level` to set the logging level of alpenhorn itself.  (Whereas, with the original config, it was setting the logging level of everything _but_ alpenhorn).

# [ Fix f-strings ](https://github.com/radiocosmology/alpenhorn/commit/787596ae3b9123ec9ffeedfeb0ccee39e687409e)

... which were missing their leading-`f`.

# [ Fix calcuation of StorageNode.get_total_gb() ](https://github.com/radiocosmology/alpenhorn/commit/c24045938646d4562b7cb8d023296fdecc121648)

It was returning MiB (`2**20`), instead of GiB (`2**30`).