### PR TITLE
feat: Edge table and transfer race condition fixes

### DIFF
--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -11,6 +11,7 @@ from watchdog.events import FileSystemEventHandler
 from . import config, db, extensions
 from .acquisition import ArchiveAcq, ArchiveFile
 from .archive import ArchiveFileCopy
+from .io import ioutil
 from .task import Task
 
 if TYPE_CHECKING:
@@ -177,6 +178,9 @@ def _import_file(task: Task, node: StorageNode, path: pathlib.PurePath) -> None:
                 last_update=datetime.utcnow(),
             )
             log.info(f'Registered file copy "{path}" on node "{node.name}".')
+
+    # Run post-add actions, if any
+    ioutil.post_add(node.db, file_)
 
     # Run the extension module's callback, if necessary
     if callable(callback):

--- a/alpenhorn/storage.py
+++ b/alpenhorn/storage.py
@@ -376,7 +376,7 @@ class StorageNode(base_model):
             log.info(f'Unable to determine available space for "{self.name}".')
 
 
-class StorageTransfer(base_model):
+class StorageTransferAction(base_model):
     """Storage transfer rules for the archive.
 
     This provides configuration for the edges in the storage node/group directed
@@ -397,9 +397,9 @@ class StorageTransfer(base_model):
     Notes
     -----
     If `NODE_A` is in `GROUP_A` and `NODE_B` in `GROUP_B`, then
-    `StorageTransfer(node_from=NODE_A, group_to=NODE_B)` and
-    `StorageTransfer(node_from=NODE_B, group_to=NODE_A)` are distinct.  (i.e.
-    all edges are directed).
+    `StorageTransferAction(node_from=NODE_A, group_to=NODE_B)` and
+    `StorageTransferAction(node_from=NODE_B, group_to=NODE_A)` are distinct.
+    (i.e. all edges are directed).
 
     Alpenhorn ignores records where `group_to == node_from.group` (self-loops).
 

--- a/alpenhorn/storage.py
+++ b/alpenhorn/storage.py
@@ -374,3 +374,60 @@ class StorageNode(base_model):
 
         if new_avail is None:
             log.info(f'Unable to determine available space for "{self.name}".')
+
+
+class StorageTransfer(base_model):
+    """Storage transfer rules for the archive.
+
+    This provides configuration for the edges in the storage node/group directed
+    graph.
+
+    Attributes
+    ----------
+    node_from : foreign key
+        The source node for the transfer.
+    group_to : foreign key
+        The destination group for the transfer.
+    autosync : boolean
+        If True, automatically copy files from `node_from` to `group_to`.
+    autoclean : boolean
+        If True, automatically delete file copies from `node_from` after they
+        end up in `group_to`.
+
+    Notes
+    -----
+    If `NODE_A` is in `GROUP_A` and `NODE_B` in `GROUP_B`, then
+    `StorageTransfer(node_from=NODE_A, group_to=NODE_B)` and
+    `StorageTransfer(node_from=NODE_B, group_to=NODE_A)` are distinct.  (i.e.
+    all edges are directed).
+
+    Alpenhorn ignores records where `group_to == node_from.group` (self-loops).
+
+    Autosyncing:
+        If `autosync` between a NODE and a GROUP is enabled, then whenever a
+        new file copy is added to NODE (i.e. after a successful import or pull),
+        then a new `ArchiveFileCopyRequest` will be created to transfer the file
+        from NODE to GROUP, so long as the file doesn't already exist in GROUP.
+
+    Autocleaning:
+        If `autoclean` between a NODE and a GROUP is enabled, then whenever a
+        new file copy is added to GROUP (i.e. after a successful import or pull,
+        regardless of the origin of the file), then the file will be scheduled
+        for deletion from NODE (by setting `ArchiveFileCopy.wants_file` to "N"
+        for the file copy on NONE).
+    """
+
+    node_from = pw.ForeignKeyField(StorageNode, backref="transfers_from")
+    group_to = pw.ForeignKeyField(StorageGroup, backref="transfers_to")
+    autosync = pw.BooleanField(default=False)
+    autoclean = pw.BooleanField(default=False)
+
+    @property
+    def self_loop(self) -> bool:
+        """True if this is a self-loop (i.e. node_from.group == group_to)."""
+        return self.node_from.group == self.group_to
+
+    class Meta:
+        indexes = (
+            (("node_from", "group_to"), True),
+        )  # (node_from, group_to) is unique

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, MagicMock
 import alpenhorn.logger
 from alpenhorn import config, db, extensions
 from alpenhorn.queue import FairMultiFIFOQueue
-from alpenhorn.storage import StorageGroup, StorageNode
+from alpenhorn.storage import StorageGroup, StorageNode, StorageTransfer
 from alpenhorn.acquisition import ArchiveAcq, ArchiveFile
 from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
 from alpenhorn.update import UpdateableNode, UpdateableGroup
@@ -413,6 +413,7 @@ def dbtables(dbproxy):
         [
             StorageGroup,
             StorageNode,
+            StorageTransfer,
             ArchiveAcq,
             ArchiveFile,
             ArchiveFileCopy,
@@ -445,7 +446,7 @@ def loop_once(dbtables):
 
 
 @pytest.fixture
-def unode(simplenode, queue):
+def unode(dbtables, simplenode, queue):
     """Returns an UpdateableNode."""
     return UpdateableNode(queue, simplenode)
 
@@ -544,6 +545,11 @@ def storagegroup(factory_factory):
 @pytest.fixture
 def storagenode(factory_factory):
     return factory_factory(StorageNode)
+
+
+@pytest.fixture
+def storagetransfer(factory_factory):
+    return factory_factory(StorageTransfer)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import patch, MagicMock
 import alpenhorn.logger
 from alpenhorn import config, db, extensions
 from alpenhorn.queue import FairMultiFIFOQueue
-from alpenhorn.storage import StorageGroup, StorageNode, StorageTransfer
+from alpenhorn.storage import StorageGroup, StorageNode, StorageTransferAction
 from alpenhorn.acquisition import ArchiveAcq, ArchiveFile
 from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
 from alpenhorn.update import UpdateableNode, UpdateableGroup
@@ -413,7 +413,7 @@ def dbtables(dbproxy):
         [
             StorageGroup,
             StorageNode,
-            StorageTransfer,
+            StorageTransferAction,
             ArchiveAcq,
             ArchiveFile,
             ArchiveFileCopy,
@@ -548,8 +548,8 @@ def storagenode(factory_factory):
 
 
 @pytest.fixture
-def storagetransfer(factory_factory):
-    return factory_factory(StorageTransfer)
+def storagetransferaction(factory_factory):
+    return factory_factory(StorageTransferAction)
 
 
 @pytest.fixture

--- a/tests/io/test_defaultnode_pull.py
+++ b/tests/io/test_defaultnode_pull.py
@@ -92,7 +92,7 @@ def test_req(
 
 
 @pytest.fixture
-def pull_async(test_req):
+def pull_async(dbtables, test_req):
     """Put a pull_async Task on the queue.
 
     Returns a two-element tuple: (node_to, copy_request)"""

--- a/tests/io/test_ioutil.py
+++ b/tests/io/test_ioutil.py
@@ -2,8 +2,11 @@
 
 import pytest
 import pathlib
+import datetime
+import peewee as pw
 
 from alpenhorn.io import ioutil
+from alpenhorn.archive import ArchiveFileCopyRequest, ArchiveFileCopy
 
 
 @pytest.mark.run_command_result(0, "", "md5 d41d8cd98f00b204e9800998ecf8427e")
@@ -227,3 +230,156 @@ def test_hardlink_fail(tmp_path):
     assert ioutil.hardlink(file, dstdir, "file") is None
     with pytest.raises(PermissionError):
         destfile.read_text()
+
+
+def test_autosync(dbtables, simplefile, simplenode, simplegroup, storagetransfer):
+    """Test post_add running autosync."""
+
+    storagetransfer(node_from=simplenode, group_to=simplegroup, autosync=True)
+
+    ioutil.post_add(simplenode, simplefile)
+
+    assert ArchiveFileCopyRequest.get(
+        file=simplefile,
+        node_from=simplenode,
+        group_to=simplegroup,
+        completed=0,
+        cancelled=0,
+    )
+
+
+def test_autosync_state(
+    dbtables,
+    archivefilecopy,
+    archivefile,
+    simpleacq,
+    storagenode,
+    simplenode,
+    simplegroup,
+    storagetransfer,
+):
+    """post_add autosync only copies if dest copy doesn't exist."""
+
+    destnode = storagenode(name="dest", group=simplegroup)
+    storagetransfer(node_from=simplenode, group_to=simplegroup, autosync=True)
+
+    # Copies with different states
+    fileY = archivefile(name="fileY", acq=simpleacq)
+    archivefilecopy(file=fileY, node=destnode, has_file="Y")
+
+    fileX = archivefile(name="fileX", acq=simpleacq)
+    archivefilecopy(file=fileX, node=destnode, has_file="X")
+
+    fileM = archivefile(name="fileM", acq=simpleacq)
+    archivefilecopy(file=fileM, node=destnode, has_file="M")
+
+    fileN = archivefile(name="fileN", acq=simpleacq)
+    archivefilecopy(file=fileN, node=destnode, has_file="N")
+
+    # None of these should add a new copy request
+    for f in [fileY, fileX, fileM]:
+        ioutil.post_add(simplenode, f)
+
+        with pytest.raises(pw.DoesNotExist):
+            ArchiveFileCopyRequest.get(file=f)
+
+    # But this one should
+    ioutil.post_add(simplenode, fileN)
+    assert ArchiveFileCopyRequest.get(
+        file=fileN, node_from=simplenode, group_to=simplegroup, completed=0, cancelled=0
+    )
+
+
+def test_autosync_loop(dbtables, simplefile, simplenode, storagetransfer):
+    """post_add autosync ignores graph loops."""
+
+    storagetransfer(node_from=simplenode, group_to=simplenode.group, autosync=True)
+
+    ioutil.post_add(simplenode, simplefile)
+
+    with pytest.raises(pw.DoesNotExist):
+        ArchiveFileCopyRequest.get(file=simplefile)
+
+
+def test_autoclean(
+    archivefilecopy, simplefile, simplenode, storagenode, simplegroup, storagetransfer
+):
+    """Test post_add running autoclean."""
+
+    before = datetime.datetime.utcnow() - datetime.timedelta(seconds=2)
+
+    destnode = storagenode(name="dest", group=simplegroup)
+
+    storagetransfer(node_from=simplenode, group_to=simplegroup, autoclean=True)
+    archivefilecopy(file=simplefile, node=simplenode, wants_file="Y", has_file="Y")
+
+    ioutil.post_add(destnode, simplefile)
+
+    copy = ArchiveFileCopy.get(file=simplefile, node=simplenode)
+    assert copy.wants_file == "N"
+    assert copy.last_update >= before
+
+
+def test_autoclean_state(
+    archivefile,
+    archivefilecopy,
+    simpleacq,
+    storagenode,
+    simplenode,
+    simplegroup,
+    storagetransfer,
+):
+    """post_add autoclean only deletes copies with has_file=='Y'."""
+
+    then = datetime.datetime.utcnow() - datetime.timedelta(seconds=200)
+
+    srcnode = storagenode(name="src", group=simplegroup)
+    storagetransfer(node_from=srcnode, group_to=simplenode.group, autoclean=True)
+
+    # Copies with different states
+    fileY = archivefile(name="fileY", acq=simpleacq)
+    archivefilecopy(
+        file=fileY, node=srcnode, has_file="Y", wants_file="Y", last_update=then
+    )
+
+    fileX = archivefile(name="fileX", acq=simpleacq)
+    archivefilecopy(
+        file=fileX, node=srcnode, has_file="X", wants_file="Y", last_update=then
+    )
+
+    fileM = archivefile(name="fileM", acq=simpleacq)
+    archivefilecopy(
+        file=fileM, node=srcnode, has_file="M", wants_file="Y", last_update=then
+    )
+
+    fileN = archivefile(name="fileN", acq=simpleacq)
+    archivefilecopy(
+        file=fileN, node=srcnode, has_file="N", wants_file="Y", last_update=then
+    )
+
+    # None of these should be deleted
+    for f in [fileN, fileX, fileM]:
+        ioutil.post_add(simplenode, f)
+
+        copy = ArchiveFileCopy.get(file=f, node=srcnode)
+        assert copy.last_update == then
+        assert copy.wants_file == "Y"
+
+    # But this one should
+    ioutil.post_add(simplenode, fileY)
+
+    copy = ArchiveFileCopy.get(file=fileY, node=srcnode)
+    assert copy.last_update > then
+    assert copy.wants_file == "N"
+
+
+def test_autoclean_loop(archivefilecopy, simplefile, simplenode, storagetransfer):
+    """post_add autoclean ignores graph loops."""
+
+    storagetransfer(node_from=simplenode, group_to=simplenode.group, autoclean=True)
+    archivefilecopy(file=simplefile, node=simplenode, wants_file="Y", has_file="Y")
+
+    ioutil.post_add(simplenode, simplefile)
+
+    copy = ArchiveFileCopy.get(file=simplefile, node=simplenode)
+    assert copy.wants_file == "Y"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -28,7 +28,7 @@ from urllib.parse import quote as urlquote
 
 from alpenhorn.service import cli
 from alpenhorn.db import database_proxy, EnumField
-from alpenhorn.storage import StorageGroup, StorageNode, StorageTransfer
+from alpenhorn.storage import StorageGroup, StorageNode, StorageTransferAction
 from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
 from alpenhorn.acquisition import ArchiveAcq, ArchiveFile
 
@@ -58,7 +58,7 @@ def e2e_db(xfs, hostname):
             ArchiveFileCopyRequest,
             StorageGroup,
             StorageNode,
-            StorageTransfer,
+            StorageTransferAction,
             pattern_importer.AcqType,
             pattern_importer.FileType,
             pattern_importer.ExtendedAcq,
@@ -253,7 +253,7 @@ def e2e_db(xfs, hostname):
     # Auto-actions:
     # * copy find.me to the transport fleet after import
     # * delete pull.me from the transport fleet after pull
-    StorageTransfer.create(
+    StorageTransferAction.create(
         node_from=dftnode, group_to=fleet, autoclean=True, autosync=True
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,13 +1,14 @@
 """An end-to-end test of the alpenhorn daemon.
 
 Things that this end-to-end test does:
-    - auto-imports a file
+    - auto-imports a file and then autosyncs it onwards
     - auto-verifies a file
     - recalls a released file out of LustreHSM
-    - pulls a file onto the Transport group
+    - pulls a file onto the Transport group and then autodeletes the source
     - releases a file on HSM to free space
     - checks a corrupt file
     - deletes a file
+    - doesn't delete a file with a pending transfer
 
 The purpose of this test isn't to exhaustively exercise all parts
 of the daemon, but to check the connectivity of the high-level blocks
@@ -27,7 +28,7 @@ from urllib.parse import quote as urlquote
 
 from alpenhorn.service import cli
 from alpenhorn.db import database_proxy, EnumField
-from alpenhorn.storage import StorageGroup, StorageNode
+from alpenhorn.storage import StorageGroup, StorageNode, StorageTransfer
 from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
 from alpenhorn.acquisition import ArchiveAcq, ArchiveFile
 
@@ -57,6 +58,7 @@ def e2e_db(xfs, hostname):
             ArchiveFileCopyRequest,
             StorageGroup,
             StorageNode,
+            StorageTransfer,
             pattern_importer.AcqType,
             pattern_importer.FileType,
             pattern_importer.ExtendedAcq,
@@ -78,6 +80,9 @@ def e2e_db(xfs, hostname):
         auto_import=True,
     )
     xfs.create_file("/dft/ALPENHORN_NODE", contents="dftnode")
+
+    # An empty group
+    emptygrp = StorageGroup.create(name="emptygrp")
 
     # A transport fleet
     fleet = StorageGroup.create(name="fleet", io_class="Transport")
@@ -214,6 +219,22 @@ def e2e_db(xfs, hostname):
     xfs.create_file("/sf/acq1/delete.me")
     xfs.create_file("/tp/one/acq1/delete.me")
 
+    # A file to _not_ delete (because it's the source for a copy request)
+    keepme = ArchiveFile.create(name="keep.me", acq=acq1, size_b=0)
+    ArchiveFileCopy.create(
+        file=keepme, node=dftnode, has_file="Y", wants_file="Y", ready=True
+    )
+    ArchiveFileCopy.create(
+        file=keepme, node=sf1, has_file="Y", wants_file="Y", ready=True
+    )
+    ArchiveFileCopy.create(
+        file=keepme, node=tp1, has_file="Y", wants_file="N", ready=True
+    )
+    xfs.create_file("/tp/one/acq1/keep.me")
+
+    # The target of this request has no nodes, so it can't be fulfilled
+    ArchiveFileCopyRequest.create(file=keepme, node_from=tp1, group_to=emptygrp)
+
     # A file to auto-verify
     verifyme = ArchiveFile.create(
         name="verify.me",
@@ -228,6 +249,13 @@ def e2e_db(xfs, hostname):
 
     # A file to auto-import
     xfs.create_file("/dft/acq2/find.me", contents="")
+
+    # Auto-actions:
+    # * copy find.me to the transport fleet after import
+    # * delete pull.me from the transport fleet after pull
+    StorageTransfer.create(
+        node_from=dftnode, group_to=fleet, autoclean=True, autosync=True
+    )
 
     yield
 
@@ -281,6 +309,7 @@ def e2e_config(xfs, hostname):
             "pattern_importer",
         ],
         "database": {"url": "sqlite:///?database=" + urlquote(DB_URI) + "&uri=true"},
+        "logging": {"level": "debug"},
         "service": {"num_workers": 0},
     }
 
@@ -313,7 +342,13 @@ def test_cli(e2e_db, e2e_config, mock_lfs, mock_rsync, loop_once):
 
     # find.me has been imported
     assert ArchiveAcq.get(name="acq2")
-    assert ArchiveFile.get(name="find.me")
+    findme = ArchiveFile.get(name="find.me")
+    assert findme
+
+    # ... and is scheduled for transfer to the fleet
+    dftnode = StorageNode.get(name="dftnode")
+    fleet = StorageGroup.get(name="fleet")
+    assert ArchiveFileCopyRequest.get(file=findme, node_from=dftnode, group_to=fleet)
 
     # correct.me has been marked ready
     correctme = ArchiveFile.get(name="correct.me")
@@ -332,6 +367,10 @@ def test_cli(e2e_db, e2e_config, mock_lfs, mock_rsync, loop_once):
     copy = ArchiveFileCopy(file=pullme, node=tp1)
     assert copy.path.exists()
 
+    # ... and now the source file is marked for deletion
+    copy = ArchiveFileCopy.get(file=pullme, node=dftnode)
+    assert copy.wants_file == "N"
+
     # release.me is not ready
     releaseme = ArchiveFile.get(name="release.me")
     assert not ArchiveFileCopy.get(file=releaseme).ready
@@ -349,3 +388,9 @@ def test_cli(e2e_db, e2e_config, mock_lfs, mock_rsync, loop_once):
     copy = ArchiveFileCopy.get(file=deleteme, node=tp1)
     assert copy.has_file == "N"
     assert not copy.path.exists()
+
+    # keep.me is _not_ gone from tp1
+    deleteme = ArchiveFile.get(name="keep.me")
+    copy = ArchiveFileCopy.get(file=deleteme, node=tp1)
+    assert copy.has_file != "N"
+    assert copy.path.exists()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -5,17 +5,17 @@ import pathlib
 import datetime
 import peewee as pw
 
-from alpenhorn.storage import StorageGroup, StorageNode, StorageTransfer
+from alpenhorn.storage import StorageGroup, StorageNode, StorageTransferAction
 
 
-def test_schema(dbproxy, simplenode, storagetransfer):
+def test_schema(dbproxy, simplenode, storagetransferaction):
     # Force table creation
-    storagetransfer(node_from=simplenode, group_to=simplenode.group)
+    storagetransferaction(node_from=simplenode, group_to=simplenode.group)
 
     assert set(dbproxy.get_tables()) == {
         "storagegroup",
         "storagenode",
-        "storagetransfer",
+        "storagetransferaction",
     }
 
 
@@ -370,23 +370,26 @@ def test_update_avail_gb(simplenode):
     assert StorageNode.get(id=simplenode.id).avail_gb is None
 
 
-def test_edge_model(storagetransfer, storagenode, storagegroup):
+def test_edge_model(storagetransferaction, storagenode, storagegroup):
     group1 = storagegroup(name="group1")
     node1 = storagenode(name="node1", group=group1)
 
     group2 = storagegroup(name="group2")
     node2 = storagenode(name="node2", group=group2)
 
-    storagetransfer(node_from=node1, group_to=group2)
-    storagetransfer(node_from=node2, group_to=group1, autosync=True, autoclean=True)
+    storagetransferaction(node_from=node1, group_to=group2)
+    storagetransferaction(
+        node_from=node2, group_to=group1, autosync=True, autoclean=True
+    )
 
     # (node_from, group_to) is unique
     with pytest.raises(pw.IntegrityError):
-        storagetransfer(node_from=node1, group_to=group2)
+        storagetransferaction(node_from=node1, group_to=group2)
 
     # Check records in DB
-    assert StorageTransfer.select().where(
-        StorageTransfer.node_from == node1, StorageTransfer.group_to == group2
+    assert StorageTransferAction.select().where(
+        StorageTransferAction.node_from == node1,
+        StorageTransferAction.group_to == group2,
     ).dicts().get() == {
         "id": 1,
         "node_from": node1.id,
@@ -394,8 +397,9 @@ def test_edge_model(storagetransfer, storagenode, storagegroup):
         "autosync": False,
         "autoclean": False,
     }
-    assert StorageTransfer.select().where(
-        StorageTransfer.node_from == node2, StorageTransfer.group_to == group1
+    assert StorageTransferAction.select().where(
+        StorageTransferAction.node_from == node2,
+        StorageTransferAction.group_to == group1,
     ).dicts().get() == {
         "id": 2,
         "node_from": node2.id,
@@ -405,8 +409,8 @@ def test_edge_model(storagetransfer, storagenode, storagegroup):
     }
 
 
-def test_edge_self_loop(storagetransfer, storagenode, storagegroup):
-    """StorageTransfer.self_loop is True when node_from.group == group_to"""
+def test_edge_self_loop(storagetransferaction, storagenode, storagegroup):
+    """StorageTransferAction.self_loop is True when node_from.group == group_to"""
 
     group1 = storagegroup(name="group1")
     node1 = storagenode(name="node1", group=group1)
@@ -415,10 +419,10 @@ def test_edge_self_loop(storagetransfer, storagenode, storagegroup):
     storagenode(name="node2", group=group2)
 
     # Not a loop
-    storagetransfer(node_from=node1, group_to=group2)
+    storagetransferaction(node_from=node1, group_to=group2)
 
     # Loop
-    storagetransfer(node_from=node1, group_to=group1)
+    storagetransferaction(node_from=node1, group_to=group1)
 
-    assert not StorageTransfer.get(id=1).self_loop
-    assert StorageTransfer.get(id=2).self_loop
+    assert not StorageTransferAction.get(id=1).self_loop
+    assert StorageTransferAction.get(id=2).self_loop

--- a/tests/test_update_node.py
+++ b/tests/test_update_node.py
@@ -359,7 +359,7 @@ def test_update_idle(unode, queue):
 
 
 def test_update_delete_under_min(unode, simpleacq, archivefile, archivefilecopy):
-    """Test UpdateableNode.update_delete() when not under min"""
+    """Test UpdateableNode.update_delete() when under min"""
 
     archivefilecopy(
         node=unode.db,
@@ -419,6 +419,24 @@ def test_update_delete_over_min(unode, simpleacq, archivefile, archivefilecopy):
     with patch.object(unode.io, "delete", mock_delete):
         unode.update_delete()
     mock_delete.assert_called_once_with([copyN])
+
+
+def test_update_delete_transfer_pending(
+    unode, simplegroup, simplefile, archivefilecopy, archivefilecopyrequest
+):
+    """update_delete() should skip files that have pending transfers."""
+
+    archivefilecopy(file=simplefile, node=unode.db, has_file="Y", wants_file="N")
+
+    # The blocking AFCR
+    archivefilecopyrequest(file=simplefile, node_from=unode.db, group_to=simplegroup)
+
+    mock_delete = MagicMock()
+    with patch.object(unode.io, "delete", mock_delete):
+        unode.update_delete()
+
+    # A call is always made, even though in this case it's empty.
+    mock_delete.assert_called_once_with([])
 
 
 def test_update_node_run(


### PR DESCRIPTION
This PR handles a few potential race conditions in the way CHIME moves data around its Storage graph.  There are two parts.

# Change to deletion

The easier part is a change to the way alpenhorn collects files for deletion.  It now skips deleting a file copy which is needed to fulfill a copy request.  It doesn't cancel the deletion, so it will consider deleting it again next time, but deletion won't actually occur until the blocking copy request is handled (completed or cancelled), avoiding a potential race condition in file management.

# Edge table

The bigger change here is the addition of a table providing metadata for the edges in the Storage directed graph (edges in a directed graph are usually called "arrows").   This is the table `StorageTransfer` defined in `storage.py`.

We've talked about edge tables for a long time, and the PR implements almost nothing of what we've talked about, though there is potential to add more stuff later.

A `StorageTransfer` edge is defined by a `node_from` (source) and a `group_to` (destination).  Any `ArchiveFileCopyRequest` with the same `node_from` and `group_to` is transferring data along that edge, and there's the _potential_ to use the `StorageTransfer` to provide finer-grained configuration for specific routes.  But, as I alluded to above, none of that is implemented here.

What _is_ implemented is two post-file-adding actions which I've previously mentioned in #158 :
* **Autosync:** when a file is added to a node, autosync tells alpenhorn to immediately queue a new `ArchiveFileCopyRequest` to transfer it from this node to a destination group.  This allows us to define automatic transfer routes.  For example, we can turn on autosync on the `cedar_staging->scinet_staging` to automatically copy files to niagara when they arrive on cedar.  This feature is needed to avoid a race condition distributing files to `cedar_staging` and `cedar_offload` after transfer from gong.
* **Autoclean:** when a file is added to a node, autoclean tells alpenhorn to immediately mark the file copy on an "upstream" node for deletion (by setting `wants_file` to "N").  This feature isn't really needed to fix any problems, but, along with autosync it allows us to completely specify in the alpenhorn database our routine data movement using the following edge definitions (obviously, some of these won't work until we deploy alpenhorn2 to the other hosts):

| node_from | group_to | auto-sync | auto-clean | explanation
|-------|-------|-------|-------|-------|
| gong | cedar_staging | Y | N | files appearing on gong are automatically transferred to cedar_staging
| cedar_staging | cedar_offload | Y | N | files arriving on cedar_staging are automatically transferred to cedar_offload
| cedar_staging | scinet_staging | Y | N | files arriving on cedar_staging are automatically transferred to scinet_staging
| cedar_staging | scinet_hpss | N | Y | files are deleted from cedar_staging after being archived in HPSS on scinet
| cedar_offload | cedar_nearline | Y | Y | files arriving on cedar_offload are automatically transferred to nearline, and then deleted once they're in nearline
| scinet_staging | scinet_hpss | Y | Y | files arriving on scinet_staging are automatically transferred to HPSS, and then deleted once they're in HPSS

The post-add actions (autosync and autoclean) are triggered whenever a file appears on a node (i.e. both via import and also pull requests).

_Subtlety!_ The route a file takes **_does not matter_** when performing autosync and autoclean.  So, e.g., in the example table above, autocleaning of  `cedar_staging` will happen after files appear on HPSS, even though the `cedar_staging->scinet_hpss` edge is not used to transfer files into HPSS.

alpenhorn ignores all `StorageTransfer` records where `node_from.group == group_to` (i.e. edges pointing back to their origin, what are known as "self-loops" or 1-cycles).

Also: autoclean and autosync aren't complete replacments for cron-based `alpenhorn clean/sync` invocations.  These actions only ever trigger once, when a file first appears on a node.  It can't do a full sync/clean of a node.

Closes #158