### PR TITLE
fix(update): Don't deactive nodes with I/O issues

### DIFF
--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -274,15 +274,9 @@ class UpdateableNode(updateable_base):
             if self.io.check_active():
                 return True
             else:
-                # Mark the node as inactive in the database
-                self.db.active = False
-                self.db.save(only=[StorageNode.active])
-                log.info(
-                    f'Correcting the database: node "{self.name}" is now set to '
-                    "inactive."
-                )
+                log.warning(f'Ignoring node "{self.name}": not ready for I/O.')
         else:
-            log.warning(f'Attempted to update inactive node "{self.name}"')
+            log.warning(f'Ignoring node "{self.name}": deactivated during update.')
 
         return False
 

--- a/tests/test_update_node.py
+++ b/tests/test_update_node.py
@@ -135,8 +135,8 @@ def test_update_active(unode):
     # Pretend node is actually not active
     with patch.object(unode.io, "check_active", lambda: False):
         assert not unode.update_active()
-    assert not unode.db.active
-    assert not StorageNode.select(StorageNode.active).limit(1).scalar()
+    assert unode.db.active
+    assert StorageNode.select(StorageNode.active).limit(1).scalar()
 
 
 def test_update_free_space(unode):


### PR DESCRIPTION
Instead, they'll just be skipped by the running process, which has the same effect as an inactive node, except that alpenhornd will re-check the node each time through the main loop.

This should mean alpenhorn can recover from intermittant I/O issues on /project space at cedar.