### PR TITLE
fix(io.default): Handle PermissionError during check

### DIFF
--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -1,4 +1,5 @@
 """Routines for the importing of new files on a node."""
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/alpenhorn/client/__init__.py
+++ b/alpenhorn/client/__init__.py
@@ -250,9 +250,11 @@ def sync(
         click.echo(
             "Adding {} new requests{}.\n".format(
                 len(files_out) or "no",
-                ", keeping {} already existing".format(len(files_in))
-                if len(files_in)
-                else "",
+                (
+                    ", keeping {} already existing".format(len(files_in))
+                    if len(files_in)
+                    else ""
+                ),
             )
         )
 

--- a/alpenhorn/db.py
+++ b/alpenhorn/db.py
@@ -35,6 +35,7 @@ After `init()` has been called, database access is possible.  Each thread
 needing database access must separately call `connect()` to initialise the
 database proxy.
 """
+
 from __future__ import annotations
 from typing import Any
 

--- a/alpenhorn/extensions.py
+++ b/alpenhorn/extensions.py
@@ -66,6 +66,7 @@ functionality they provide. There are currently three supported keys:
 If other keys are present in the dictionary returned by `register_extension`, they
 are ignored.
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, Tuple
 

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -1,4 +1,5 @@
 """DefaultIO asyncs (functions that run asynchronously in tasks)."""
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -6,6 +6,7 @@ These are very low-level classes.  Any module implementing the I/O class for
 something even remotely resembling a POSIX filesystem may be better served
 by subclassing from DefaultIO instead of from here directly.
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, IO
 

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -7,6 +7,7 @@ These I/O classes are used by StorageNodes and StorageGroups which do not
 explicitly specify `io_class` (as well as being used explicitly when `io_class`
 has the value "Default").
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, IO
 

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -268,7 +268,7 @@ class DefaultNodeIO(BaseNodeIO):
 
         return path.with_name("." + path.name + ".lock").exists()
 
-    def md5(self, path: str | pathlib.Path, *segments) -> str:
+    def md5(self, path: str | pathlib.Path, *segments) -> str | None:
         """Compute the MD5 hash of the file at the specified path.
 
         This can take a long time: call it from an async.
@@ -283,10 +283,17 @@ class DefaultNodeIO(BaseNodeIO):
 
         Returns
         -------
-        md5sum : str
-            the base64-encoded MD5 hash value
+        md5sum : str | None
+            the base64-encoded MD5 hash value or None on error
         """
-        return util.md5sum_file(pathlib.Path(self.node.root, path, *segments))
+        path = pathlib.Path(self.node.root, path, *segments)
+        try:
+            return util.md5sum_file(pathlib.Path(path))
+        except FileNotFoundError:
+            log.warning(f"MD5 sum check for {path} failed: file not found.")
+        except PermissionError:
+            log.warning(f"MD5 sum check for {path} failed: permission error.")
+        return None
 
     def open(self, path: os.PathLike | str, binary: bool = True) -> IO:
         """Open the file specified by `path` for reading.

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -289,7 +289,7 @@ class DefaultNodeIO(BaseNodeIO):
         """
         path = pathlib.Path(self.node.root, path, *segments)
         try:
-            return util.md5sum_file(pathlib.Path(path))
+            return util.md5sum_file(path)
         except FileNotFoundError:
             log.warning(f"MD5 sum check for {path} failed: file not found.")
         except PermissionError:

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -1,4 +1,5 @@
 """I/O utility functions."""
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/alpenhorn/io/lfs.py
+++ b/alpenhorn/io/lfs.py
@@ -23,6 +23,7 @@ run these commands:
 * `lfs hsm_release`
     requests the state change `RESTORED -> RELEASED`
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -11,6 +11,7 @@ This module provides:
     with a secondary StorageNode of a different class meant to store files
     too small for the external system.
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, IO
 

--- a/alpenhorn/io/lustrequota.py
+++ b/alpenhorn/io/lustrequota.py
@@ -10,6 +10,7 @@ the `io_config`.
 The quota target can either be the one reported by "lfs quota" directly
 or else set to a fixed value via the `io_config`.
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/alpenhorn/io/polling.py
+++ b/alpenhorn/io/polling.py
@@ -4,6 +4,7 @@ The same as DefaultNodeIO but uses the PollingObserver for auto-import.
 
 Use in situations where inotify won't work (like NFS mounts).
 """
+
 from watchdog.observers.polling import PollingObserver
 
 from .default import DefaultNodeIO

--- a/alpenhorn/io/transport.py
+++ b/alpenhorn/io/transport.py
@@ -1,4 +1,5 @@
 """Transport Group I/O."""
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/alpenhorn/storage.py
+++ b/alpenhorn/storage.py
@@ -1,4 +1,5 @@
 """StorageNode and StorageGroup table models."""
+
 # Type annotation shennanigans
 from __future__ import annotations
 from typing import TYPE_CHECKING

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -1,5 +1,6 @@
 """Routines for updating the state of a node.
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING
 

--- a/alpenhorn/util.py
+++ b/alpenhorn/util.py
@@ -1,4 +1,5 @@
 """Utility functions."""
+
 from __future__ import annotations
 
 import socket

--- a/examples/pattern_importer.py
+++ b/examples/pattern_importer.py
@@ -21,6 +21,7 @@ will be called by alpenhorn, which then stores the matched AcqType
 in an extended ArchiveAcq table and the matched FileType in an
 extended ArchiveFile table.
 """
+
 from __future__ import annotations
 from typing import TYPE_CHECKING, Tuple
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,7 +314,7 @@ def mock_stat(fs):
 
         from math import ceil
 
-        file = fs.get_object(path)
+        file = fs.get_object(path, check_read_perm=False)
         size = file.size
 
         # Anything with a __dict__ works here.
@@ -331,6 +331,44 @@ def mock_stat(fs):
 
 
 @pytest.fixture
+def mock_exists(fs):
+    """Mocks pathlib.PosixPath.exists to work with pyfakefs."""
+
+    def _mocked_exists(path):
+        """Mock of pathlib.PosixPath.exists to work better with pyfakefs.
+
+        The problem here is if there's an unreadable file in a readable
+        directory, pyfakefs raises PermissionError in pathlib.Path.exists,
+        even though it should return True (since only the directory needs to
+        be read for an existence check.)
+        """
+        nonlocal fs
+
+        from math import ceil
+
+        try:
+            dir_ = fs.get_object(path.parent)
+            # Parent directory not readable
+            if not dir_.st_mode & 0o222:
+                raise PermissionError("Permission denied")
+        except FileNotFoundError:
+            return False
+
+        # Directory is readable
+        try:
+            file = fs.get_object(path)
+        except PermissionError:
+            pass
+        except FileNotFoundError:
+            return False
+
+        return True
+
+    with patch("pathlib.PosixPath.exists", _mocked_exists):
+        yield
+
+
+@pytest.fixture
 def mock_observer():
     """Mocks the DefaultIO observer so its always the PollingObserver"""
     from watchdog.observers.polling import PollingObserver
@@ -340,7 +378,7 @@ def mock_observer():
 
 
 @pytest.fixture
-def xfs(fs, mock_observer, mock_statvfs, mock_stat):
+def xfs(fs, mock_observer, mock_statvfs, mock_stat, mock_exists):
     """An extended pyfakefs.
 
     Patches more stuff for proper behaviour with alpenhorn unittests"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures"""
+
 import os
 import pytest
 import shutil

--- a/tests/io/test_defaultnode.py
+++ b/tests/io/test_defaultnode.py
@@ -1,4 +1,5 @@
 """Test DefaultNodeIO."""
+
 import pytest
 import pathlib
 

--- a/tests/io/test_defaultnode.py
+++ b/tests/io/test_defaultnode.py
@@ -111,6 +111,18 @@ def test_md5(unode, xfs):
     assert unode.io.md5("dir/file2") == "9e107d9d372bb6826bd81d3542a419d6"
 
 
+def test_md5_bad(unode, xfs):
+    """test DefaultNodeIO.md5() with bad files"""
+
+    # Try a missing file
+    xfs.create_dir("/node/dir/")
+    assert unode.io.md5("dir", "file1") is None
+
+    # Try an unreadable file
+    xfs.create_file("/node/dir/file", st_mode=0)
+    assert unode.io.md5("dir/file") == None
+
+
 def test_open_absolute(unode, xfs):
     """Test DefaultNodeIO.open() on an absolute path."""
 

--- a/tests/io/test_transport.py
+++ b/tests/io/test_transport.py
@@ -82,9 +82,7 @@ def transport_fleet_no_init(xfs, hostname, queue, storagegroup, storagenode):
         node.io.pull = MagicMock(return_value=None)
         # mock bytes_avail to simply return avail_gb to avoid having to mess about with pyfakefs
         node.io.bytes_avail = MagicMock(
-            return_value=None
-            if node.db.avail_gb is None
-            else node.db.avail_gb * 2**30
+            return_value=None if node.db.avail_gb is None else node.db.avail_gb * 2**30
         )
         xfs.create_dir(node.db.root)
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,4 +1,5 @@
 """test alpenhorn.extensions."""
+
 import pytest
 
 from unittest.mock import patch, MagicMock

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,4 +1,5 @@
 """Test alpenhorn.logger"""
+
 import pytest
 import socket
 import logging

--- a/tests/test_update_group.py
+++ b/tests/test_update_group.py
@@ -1,4 +1,5 @@
 """Tests for UpdateableGroup."""
+
 import pytest
 import datetime
 from unittest.mock import patch, call

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,5 @@
 """alpenhorn.util tests."""
+
 import pytest
 
 from alpenhorn import util


### PR DESCRIPTION
A `PermissionError` while checking a file will now result in it being considered corrupt.

_Bonus_: fixed some ham-fisted mocking in `tests/io/test_lustrehsmnode.py` which was not being properly cleaned up after the test finished.

Closes #176