### PR TITLE
fix(run_command): fix subprocess timeout recovery

### DIFF
--- a/alpenhorn/util.py
+++ b/alpenhorn/util.py
@@ -30,6 +30,7 @@ def run_command(
     -------
     retval : int or None
         Return code, or None if the process was killed after timing out.
+        Integer zero indicates success.
     stdout : string
         Value of stdout.
     stderr : string
@@ -48,8 +49,10 @@ def run_command(
         stdout_val, stderr_val = proc.communicate(timeout=timeout)
         retval = proc.returncode
     except subprocess.TimeoutExpired:
+        log.warning(f"Process overrun [timeout={timeout}]: " + " ".join(cmd))
         proc.kill()
-        stdout_val, stderr_val = proc.communicate()
+        stdout_val = "";
+        stderr_val = "";
         retval = None
 
     return (

--- a/alpenhorn/util.py
+++ b/alpenhorn/util.py
@@ -51,8 +51,8 @@ def run_command(
     except subprocess.TimeoutExpired:
         log.warning(f"Process overrun [timeout={timeout}]: " + " ".join(cmd))
         proc.kill()
-        stdout_val = "";
-        stderr_val = "";
+        stdout_val = ""
+        stderr_val = ""
         retval = None
 
     return (


### PR DESCRIPTION
Normally, when a transfer times out, it's because it's stuck deep down in I/O wait, meaning SIGKILL
is not going to be handled in a timely manner, and, so, trying to `.communicate()` with it again is just futile.

With the current code, after a timeout, the worker just gets stuck in the same wait it tried to get out of with the kill, as if there were no timeout given.

So, let's just send it a kill and then abandon it.

Related to #175 (abandonning subprocesses may lead to zombies), but this doesn't really address the items brought up in that issue, which are higher-level ideas.

I have deployed this to cedar.