### PR TITLE
fix(update): Don't ready missing files for pull

### DIFF
--- a/tests/test_update_group.py
+++ b/tests/test_update_group.py
@@ -110,9 +110,9 @@ def test_update_group_nosrc(mockgroupandnode, hostname, queue, pull):
     # run update
     group.update()
 
-    # afcr is not handled
+    # afcr is cancelled
     assert not ArchiveFileCopyRequest.get(file=afcr.file).completed
-    assert not ArchiveFileCopyRequest.get(file=afcr.file).cancelled
+    assert ArchiveFileCopyRequest.get(file=afcr.file).cancelled
     assert call.pull(afcr) not in mockio.group.mock_calls
 
 

--- a/tests/test_update_node.py
+++ b/tests/test_update_node.py
@@ -440,17 +440,30 @@ def test_update_delete_transfer_pending(
 
 
 def test_update_node_run(
-    unode, queue, simplegroup, simplefile, archivefilecopy, archivefilecopyrequest
+    unode,
+    queue,
+    simpleacq,
+    simplegroup,
+    archivefile,
+    archivefilecopy,
+    archivefilecopyrequest,
 ):
     """Test running UpdateableNode.update_node."""
 
     # Make something to check
-    copy = archivefilecopy(node=unode.db, file=simplefile, has_file="M")
+    badfile = archivefile(name="check_me", acq=simpleacq)
+    copy = archivefilecopy(node=unode.db, file=badfile, has_file="M")
 
-    # And something to pull
+    # And something to ready for a pull
+    goodfile = archivefile(name="ready_me", acq=simpleacq)
+    archivefilecopy(node=unode.db, file=goodfile, has_file="Y")
     afcr = archivefilecopyrequest(
-        node_from=unode.db, group_to=simplegroup, file=simplefile
+        node_from=unode.db, group_to=simplegroup, file=goodfile
     )
+
+    # And something to ignore (i.e. not ready for a pull)
+    missingfile = archivefile(name="ignore_me", acq=simpleacq)
+    archivefilecopyrequest(node_from=unode.db, group_to=simplegroup, file=missingfile)
 
     mock = MagicMock()
     mock.before_update.return_value = True


### PR DESCRIPTION
These files will just be ignored (i.e. no attempt to make them ready).

Also: cancel AFCRs for files which don't exist on the source.