### PR TITLE
fix(_default_asyncs): fix race condition when making new directories

### DIFF
--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -77,7 +77,7 @@ def pull_async(
     with tree_lock.up:
         if not to_dir.exists():
             log.info(f'Creating directory "{to_dir}".')
-            to_dir.mkdir(parents=True)
+            to_dir.mkdir(parents=True, exist_ok=True)
 
         # If the file doesn't exist, create a placeholder so we can release
         # the tree lock without having to wait for the transfer to complete


### PR DESCRIPTION
Multiple threads can try to create the same directory, which created a race condition between checking for the existance of a directory and actually trying to make it