### PR TITLE
feat(io/default): Try to clean up during idle updates

### DIFF
--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -283,28 +283,7 @@ def delete_async(
 
         # Check if any containing directory is now empty
         # and remove if they are.
-        dirname = fullpath.parent
-
-        # try to delete the directories.  This must be done while locking down the tree lock
-        with tree_lock.down:
-            while dirname != ".":
-                try:
-                    dirname.rmdir()
-                    log.info(f"Removed directory {dirname} on {name}")
-                except OSError as e:
-                    if e.errno == errno.ENOTEMPTY:
-                        # This is fine, but stop trying to rmdir.
-                        break
-                    elif e.errno == errno.ENOENT:
-                        # Already deleted, which is fine.
-                        pass
-                    else:
-                        log.warning(
-                            f"Error deleting directory {dirname} on {name}: {e}"
-                        )
-                        # Otherwise, let's try to soldier on
-
-                dirname = dirname.parent
+        ioutil.remove_filedir(copy.node, fullpath.parent, tree_lock)
 
         # Update the DB
         ArchiveFileCopy.update(

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -190,7 +190,7 @@ class BaseNodeIO:
         # By default, we do nothing and allow the update to continue
         return True
 
-    def idle_update(self) -> None:
+    def idle_update(self, newly_idle: bool) -> None:
         """Idle update hook.
 
         Called after a regular update that wasn't skipped, but only if,
@@ -199,6 +199,12 @@ class BaseNodeIO:
 
         This is the place to put low-priority tasks that should only happen
         if no other I/O is happening on the node.
+
+        Parameters
+        ----------
+        newly_idle : bool
+            True if this is the first time idle_update has been called since
+            some I/O happened.
         """
         # By default do nothing.
         pass

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -84,8 +84,8 @@ class DefaultNodeIO(BaseNodeIO):
         # The directory tree modification lock
         self.tree_lock = UpDownLock()
 
-        # When <= 1, the idle clean-up can is allowed to run; we initialise
-        # to zero # to run it as soon as possible after start-up
+        # When <= 1, the idle clean-up is allowed to run; we initialise
+        # to zero to run it as soon as possible after start-up
         self._skip_idle_cleanup = 0
 
         # Set up a reservation for ourself if necessary

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -17,9 +17,11 @@ import pathlib
 import threading
 from watchdog.observers import Observer
 
+from . import ioutil
 from .base import BaseNodeIO, BaseGroupIO, BaseNodeRemote
 from .updownlock import UpDownLock
 from .. import util
+from ..acquisition import ArchiveAcq, ArchiveFile
 from ..task import Task
 
 # The asyncs are over here:
@@ -27,7 +29,6 @@ from ._default_asyncs import pull_async, check_async, delete_async
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from ..acquisition import ArchiveFile
     from ..archive import ArchiveFileCopy, ArchiveFileCopyRequest
     from ..queue import FairMultiFIFOQueue
     from ..storage import StorageNode
@@ -39,6 +40,10 @@ log = logging.getLogger(__name__)
 # by the mutex
 _mutex = threading.Lock()
 _reserved_bytes = dict()
+
+# This sets how often we run the clean-up idle task.  What
+# we're counting here is number of not-idle -> idle transitions
+_IDLE_CLEANUP_PERIOD = 100  # (i.e. once every 100 opportunities)
 
 
 class DefaultNodeRemote(BaseNodeRemote):
@@ -79,9 +84,66 @@ class DefaultNodeIO(BaseNodeIO):
         # The directory tree modification lock
         self.tree_lock = UpDownLock()
 
+        # When <= 1, the idle clean-up can is allowed to run; we initialise
+        # to zero # to run it as soon as possible after start-up
+        self._skip_idle_cleanup = 0
+
         # Set up a reservation for ourself if necessary
         with _mutex:
             _reserved_bytes.setdefault(node.name, 0)
+
+    # HOOKS
+
+    def idle_update(self, newly_idle: bool) -> None:
+        """Idle update hook.
+
+        Called after a regular update that wasn't skipped, but only if,
+        after the regular update, there were no tasks pending or in
+        progress for this node (i.e. `self.idle` is True).
+
+        This will try to do some tidying-up: look for stale placeholders,
+        and attempt to delete empty acqdirs, whenever newly_idle is True.
+
+        Parameters
+        ----------
+        newly_idle : bool
+            True if this is the first time idle_update has been called since
+            some I/O happened.
+        """
+
+        # Task to do some cleanup
+        def _async(task, node, tree_lock):
+            # Loop over all acqs
+            for acq in ArchiveAcq.select():
+                # Only continue if the directory for this acquisition exists
+                acqpath = pathlib.Path(node.root, acq.name)
+                if acqpath.is_dir():
+                    # Look for placeholders
+                    for file_ in ArchiveFile.select().where(ArchiveFile.acq == acq):
+                        placeholder = acqpath.joinpath(f".{file_.name}.placeholder")
+                        if placeholder.exists():
+                            log.warning(f"Removing stale placeholder {placeholder!s}")
+                            placeholder.unlink()
+                    # Attempt to remove acqpath.  If it isn't empty, this does nothing
+                    ioutil.remove_filedir(
+                        node,
+                        pathlib.Path(node.root, acq.name),
+                        tree_lock,
+                    )
+
+        # Submit the task only after doing some I/O
+        if newly_idle:
+            if self._skip_idle_cleanup <= 1:
+                self._skip_idle_cleanup = _IDLE_CLEANUP_PERIOD
+                Task(
+                    func=_async,
+                    queue=self._queue,
+                    key=self.node.name,
+                    args=(self.node, self.tree_lock),
+                    name=f"Tidy up {self.node.name}",
+                )
+            else:
+                self._skip_idle_cleanup = self._skip_idle_cleanup - 1
 
     # I/O METHODS
 

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -187,7 +187,7 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         # Continue with the update
         return True
 
-    def idle_update(self) -> None:
+    def idle_update(self, newly_idle) -> None:
         """Update HSM state of copies when idle.
 
         If the node is idle after an update, double check the HSM state
@@ -197,6 +197,9 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         data index to reflect changes made in this way outside of alpenhorn so that
         the alpenhornd daemon can properly manage free space.
         """
+
+        # Run DefautlIO idle checks
+        super().idle_update(newly_idle)
 
         # Check the query walker.  Initialised if necessary.
         if self._release_qw is None:

--- a/tests/io/test_ioutil.py
+++ b/tests/io/test_ioutil.py
@@ -6,6 +6,7 @@ import datetime
 import peewee as pw
 
 from alpenhorn.io import ioutil
+from alpenhorn.io.updownlock import UpDownLock
 from alpenhorn.archive import ArchiveFileCopyRequest, ArchiveFileCopy
 
 
@@ -423,3 +424,65 @@ def test_autoclean_loop(archivefilecopy, simplefile, simplenode, storagetransfer
 
     copy = ArchiveFileCopy.get(file=simplefile, node=simplenode)
     assert copy.wants_file == "Y"
+
+
+def test_remove_filedir_patherror(simplenode):
+    """remove_filedir raises ValueErorr if dirname isn't rooted under node.root"""
+
+    with pytest.raises(ValueError):
+        ioutil.remove_filedir(simplenode, pathlib.Path("/some/other/path"), None)
+
+
+def test_remove_filedir_node_root(simplenode, xfs):
+    """remove_filedir must stop removing directories at node.root"""
+
+    udl = UpDownLock()
+
+    # Create something to delete
+    path_to_delete = pathlib.Path(f"{simplenode.root}/a/b/c")
+    xfs.create_dir(path_to_delete)
+
+    ioutil.remove_filedir(simplenode, path_to_delete, udl)
+
+    assert not path_to_delete.exists()
+    assert not pathlib.Path(f"{simplenode.root}/a/b").exists()
+    assert not pathlib.Path(f"{simplenode.root}/a").exists()
+    assert pathlib.Path(simplenode.root).exists()
+
+
+def test_remove_filedir_missing(simplenode, xfs):
+    """remove_filedir should be fine with missing subdirs"""
+
+    udl = UpDownLock()
+
+    # Create something to delete
+    path_to_delete = pathlib.Path(f"{simplenode.root}/a/b/c")
+    xfs.create_dir(path_to_delete)
+
+    ioutil.remove_filedir(simplenode, path_to_delete.joinpath("d/e/f"), udl)
+
+    assert not path_to_delete.exists()
+    assert not pathlib.Path(f"{simplenode.root}/a/b").exists()
+    assert not pathlib.Path(f"{simplenode.root}/a").exists()
+    assert pathlib.Path(simplenode.root).exists()
+
+
+def test_remove_filedir_nonempty(simplenode, xfs):
+    """remove_filedir should be fine with non-empty dirs"""
+
+    udl = UpDownLock()
+
+    # Create something to delete
+    path_to_delete = pathlib.Path(f"{simplenode.root}/a/b/c")
+    xfs.create_dir(path_to_delete)
+
+    # Make a file somewhere to block deletion
+    xfs.create_file(f"{simplenode.root}/a/b/blocker")
+
+    ioutil.remove_filedir(simplenode, path_to_delete, udl)
+
+    # Only has been deleted up to /a/b
+    assert not path_to_delete.exists()
+    assert pathlib.Path(f"{simplenode.root}/a/b").exists()
+    assert pathlib.Path(f"{simplenode.root}/a").exists()
+    assert pathlib.Path(simplenode.root).exists()

--- a/tests/io/test_lustrehsmnode.py
+++ b/tests/io/test_lustrehsmnode.py
@@ -407,7 +407,7 @@ def test_idle_update_empty(queue, mock_lfs, node):
     # Delete all copies
     ArchiveFileCopy.update(has_file="N").execute()
 
-    node.io.idle_update()
+    node.io.idle_update(False)
 
     # QW has not been initialised
     assert node.io._release_qw is None
@@ -429,7 +429,7 @@ def test_idle_update_ready(xfs, queue, mock_lfs, node):
 
     before = datetime.datetime.utcnow().replace(microsecond=0)
 
-    node.io.idle_update()
+    node.io.idle_update(False)
 
     # QW has been initialised
     assert node.io._release_qw is not None
@@ -472,7 +472,7 @@ def test_idle_update_not_ready(xfs, queue, mock_lfs, node):
     # Update all copies
     ArchiveFileCopy.update(ready=False).execute()
 
-    node.io.idle_update()
+    node.io.idle_update(False)
 
     # QW has been initialised
     assert node.io._release_qw is not None

--- a/tests/test_update_node.py
+++ b/tests/test_update_node.py
@@ -357,6 +357,9 @@ def test_update_idle(unode, queue):
             assert len(rav.mock_calls) == 1
             assert len(ioiu.mock_calls) == 3
 
+            # newly_idle should only be true in the first call
+            assert ioiu.mock_calls == [call(True), call(False), call(False)]
+
 
 def test_update_delete_under_min(unode, simpleacq, archivefile, archivefilecopy):
     """Test UpdateableNode.update_delete() when under min"""
@@ -435,8 +438,8 @@ def test_update_delete_transfer_pending(
     with patch.object(unode.io, "delete", mock_delete):
         unode.update_delete()
 
-    # A call is always made, even though in this case it's empty.
-    mock_delete.assert_called_once_with([])
+    # A call is not made in this case
+    mock_delete.assert_not_called()
 
 
 def test_update_node_run(
@@ -476,8 +479,7 @@ def test_update_node_run(
 
     # Check I/O calls
     calls = list(mock.mock_calls)
-    assert len(calls) == 5
+    assert len(calls) == 4
     assert call.bytes_avail(fast=False) in calls
     assert call.check(copy) in calls
-    assert call.delete([]) in calls
     assert call.ready_pull(afcr) in calls


### PR DESCRIPTION
This adds an attempt to clean up a DefaultIONode during an idle update by:
 * looking for `.placeholder` files and deleting them
 * attempting to remove acq directories

Because this routine runs when the node is idle (i.e. only when there's no other I/O occurring), no placeholders should be on the node.  Any which are found are clearly spurious due to prior crashes.

I've also implemented a check to reduce how often it runs. It will always run at start-up (when I suspect most uncleanliness would be found), and then once every 100 times the node transitions from not-idle to idle.  Not really sure how often is appropriate.  It might even be sufficient to only run it on start-up.

While implementing this, I discovered that the code that was deleting acq dirs wasn't stopping at the StorageNode.root, meaning there was a potential to delete the node directory itself (plus anything above that)!

In practice, on DefaultIO nodes, this couldn't happen because all such nodes have a `ALPENHORN_NODE` file at the top level, but that's not necessarily true for other IO classes which still use the DefaultIO's delete function (for example, the LustreHSM I/O class).

I've fixed this bug while moving the directory deletion code from the delete_async into its own function in `ioutil` because the cleanup task is now also using it.

Also, removed submitting an uncessary job which was deleting zero file copies.