### PR TITLE
Drop globre from test requirements

### DIFF
--- a/examples/pattern_importer.py
+++ b/examples/pattern_importer.py
@@ -35,7 +35,6 @@ if TYPE_CHECKING:
 import re
 import os
 import json
-import globre
 import peewee as pw
 from functools import partial
 
@@ -52,11 +51,8 @@ class TypeBase(base_model):
     ----------
     name : string
         The name of this file type.
-    glob : bool
-        If True, the `patterns` will be interpreted by `globre.match`.
-        If False, the `patterns` will be interpreted by `re.match`.
     patterns : string
-        A JSON array literal of patterns.  Patterns are tried in order
+        A JSON array literal of regular expressions.  Patterns are tried in order
         listed.
     notes : string or None
         Any notes or comments about this file type.
@@ -102,15 +98,9 @@ class TypeBase(base_model):
                     f'(Got "{self.patterns}")'
                 )
 
-        # Get the match function to use depending on whether globbing is enabled.
-        if self.glob:
-            matchfn = globre.match
-        else:
-            matchfn = re.match
-
         # Loop over patterns and check for matches
         for pattern in self._pattern_list:
-            if matchfn(pattern, name):
+            if re.match(pattern, name):
                 return True
 
         return False

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 chimedb @ git+https://github.com/chime-experiment/chimedb.git
 docker >= 3.0
-globre
 pyfakefs >= 5.0
 pytest >= 7.0

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -32,10 +32,9 @@ from alpenhorn.storage import StorageGroup, StorageNode, StorageTransferAction
 from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
 from alpenhorn.acquisition import ArchiveAcq, ArchiveFile
 
-from examples import pattern_importer
-
-# Make it easy for alpenhornd to find the extension
-sys.modules["pattern_importer"] = pattern_importer
+# Import pattern_importer from the examples directory
+sys.path.append(str(pathlib.Path(__file__).parent.joinpath("..", "examples")))
+import pattern_importer
 
 # database URI for a shared in-memory database
 DB_URI = "file:e2edb?mode=memory&cache=shared"
@@ -141,17 +140,13 @@ def e2e_db(xfs, hostname):
     xfs.create_file("/sf2/ALPENHORN_NODE", contents="sf2")
 
     # The only acqtype
-    pattern_importer.AcqType.create(name="acqtype", glob=True, patterns='["acq?"]')
+    pattern_importer.AcqType.create(name="acqtype", patterns='["acq."]')
 
     # The only (existing) acq
     acq1 = ArchiveAcq.create(name="acq1")
 
     # The only filetype
-    pattern_importer.FileType.create(
-        name="filetype",
-        glob=True,
-        patterns='["*.me"]',
-    )
+    pattern_importer.FileType.create(name="filetype", patterns=r'[".*\\.me"]')
 
     # A file that needs to be pulled onto the Transport group
     pullme = ArchiveFile.create(name="pull.me", acq=acq1, size_b=0)


### PR DESCRIPTION
Back in #163 I was content to solve #160 by demoting `globre` from a requirement to a test requirement, but I think even here it's an unnecessary complication for something we're not using in production.

This rewrites the `pattern_importer` example extension to accept only regular expressions and updates the patterns in `tests/test_service.py` to follow.

Also updated how the `pattern_importer` is imported in the `test_service` test to handle cases where the current directory is not in the import path or the test suite isn't run from the top-level alpenhorn directory.

Closes #131