### PR TITLE
fix(LustreHSM): Move ready_pull I/O out of main thread

### DIFF
--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -158,8 +158,9 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         # Add this copy to the list of copies we're waiting on.  Other tasks
         # can use this to see if the file they're interested in is already
         # "in use".
-        self._restoring.add(copy.file.id)
-        self._restore_start[copy.file.id] = time.monotonic()
+        if copy.file.id not in self._restoring:
+            self._restoring.add(copy.file.id)
+            self._restore_start[copy.file.id] = time.monotonic()
 
         # Restore it.  We deliberately do this every time, to hedge against
         # our initial request being forgotten/ignored by HSM.


### PR DESCRIPTION
This is the second part of the fix for #183 which fixes how the `ready_pull` function works.  All I/O for `ready_pull` is now in a task and out of the main thread.

In the previous PR I added some slap-dash "race condition insurance" which I've removed here and replaced with a more robust system to restore-and-wait for a file which provides a way to track files already being waited on for restore.  (Which was otherwise impossible to do because yielded tasks are essentially hidden from the system while they're deferred.)

Now `check`s and `ready_pull`s won't be re-queued if they're already waiting for a file to be restored.

Closes #183