### PR TITLE
fix(lustrehsm): Only call hsm_restore once during restore-wait

### DIFF
--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -538,7 +538,6 @@ def remove_filedir(
                 dirname.rmdir()
                 log.info(f"Removed directory {dirname} on {node.name}")
             except OSError as e:
-                log.debug(f"Failed to remove directory {dirname} on {node.name}: {e}")
                 if e.errno == errno.ENOTEMPTY:
                     # This is fine, but stop trying to rmdir.
                     break

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -162,9 +162,8 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
             self._restoring.add(copy.file.id)
             self._restore_start[copy.file.id] = time.monotonic()
 
-        # Restore it.  We deliberately do this every time, to hedge against
-        # our initial request being forgotten/ignored by HSM.
-        self._lfs.hsm_restore(copy.path)
+            # Restore it.
+            self._lfs.hsm_restore(copy.path)
 
         # Tell the caller to wait
         return True
@@ -386,7 +385,7 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
             # Do the check by inlining the Default-I/O function
             from ._default_asyncs import check_async
 
-            check_async(task, node_io.node, copy)
+            check_async(task, node_io, copy)
 
             # Release the file if the DB says it should be
             if not ArchiveFileCopy.get(id=copy.id).ready:

--- a/alpenhorn/pool.py
+++ b/alpenhorn/pool.py
@@ -94,7 +94,7 @@ class Worker(threading.Thread):
                 # Otherwise, execute the task.
                 log.info(f"Beginning task {task}")
                 try:
-                    task()
+                    finished = task()
                 except OperationalError as operr:
                     # Try to clean up. This runs task.do_cleanup()
                     # until it raises something other than OperationalError
@@ -131,7 +131,10 @@ class Worker(threading.Thread):
 
                 self._queue.task_done(key)
 
-                log.info(f"Finished task {task}")
+                if finished:
+                    log.info(f"Finished task: {task}")
+                else:
+                    log.info(f"Deferring task: {task}")
 
     def stop_working(self) -> None:
         """Tell the worker to stop after finishing the current task."""


### PR DESCRIPTION
Calling it more than once seems to result in the second call not completing until the file is restored (locking up the worker).

Probably we should add a timeout to the restore-wait (#188) but I want to run it as-is for a while to see how this goes.

Also, fixed the `check_async` call.

Also, some logging tweaks.