### PR TITLE
fix(update): Remove I/O from main loop pull handling

### DIFF
--- a/alpenhorn/auto_import.py
+++ b/alpenhorn/auto_import.py
@@ -69,7 +69,7 @@ def import_file(
     Task(
         func=_import_file,
         queue=queue,
-        key=node.name,
+        key=node.io.fifo,
         args=(node, path),
         name=f"Import {path} on {node.name}",
         # If the job fails due to DB connection loss, re-start the
@@ -310,7 +310,7 @@ def update_observer(
         Task(
             func=catchup,
             queue=queue,
-            key=node.name,
+            key=node.io.fifo,
             args=(node, queue),
             name=f"Catch-up on {node.name}",
             # If the job fails due to DB connection loss, re-start it

--- a/alpenhorn/io/transport.py
+++ b/alpenhorn/io/transport.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import logging
 
-from .base import BaseGroupIO
+from .default import DefaultGroupIO
 
 if TYPE_CHECKING:
     import pathlib
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class TransportGroupIO(BaseGroupIO):
+class TransportGroupIO(DefaultGroupIO):
     """Transport Group I/O.
 
     This implements (the formerly special-cased) transport disk logic.
@@ -97,7 +97,7 @@ class TransportGroupIO(BaseGroupIO):
 
         return None
 
-    def pull(self, req: ArchiveFileCopyRequest) -> None:
+    def pull_force(self, req: ArchiveFileCopyRequest) -> None:
         """Handle a pull request.
 
         Only local pulls are only fulfilled.  Remote pulls are ignored.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -499,7 +499,9 @@ def mockio():
     # The I/O instances
     node = MagicMock()
     node.bytes_avail.return_value = 10000
+    node.fifo = "n:mockio"
     group = MagicMock()
+    group.fifo = "g:mockio"
 
     # This is our mock I/O module
     class MockIO:
@@ -545,7 +547,9 @@ def mockgroupandnode(hostname, queue, storagenode, storagegroup, mockio):
     mockio.group.set_nodes = lambda nodes: nodes
 
     node = UpdateableNode(queue, stnode)
-    yield mockio, UpdateableGroup(group=stgroup, nodes=[node], idle=True), node
+    yield mockio, UpdateableGroup(
+        queue=queue, group=stgroup, nodes=[node], idle=True
+    ), node
 
 
 # Data table fixtures.  Each of these will add a row with the specified

--- a/tests/io/test_defaultgroup.py
+++ b/tests/io/test_defaultgroup.py
@@ -1,9 +1,11 @@
 """Test DefaultGroupIO."""
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from alpenhorn.update import UpdateableNode, UpdateableGroup
+from alpenhorn.archive import ArchiveFileCopy
+from alpenhorn.io._default_asyncs import group_search_async
 
 
 @pytest.fixture
@@ -15,7 +17,7 @@ def groupnode(xfs, queue, storagegroup, storagenode):
     node = UpdateableNode(
         queue, storagenode(name="node", group=stgroup, active=True, root="/node")
     )
-    group = UpdateableGroup(group=stgroup, nodes=[node], idle=True)
+    group = UpdateableGroup(queue=queue, group=stgroup, nodes=[node], idle=True)
 
     # Create the directory
     xfs.create_dir("/node")
@@ -23,24 +25,24 @@ def groupnode(xfs, queue, storagegroup, storagenode):
     return group, node
 
 
-def test_too_many_nodes(storagegroup, storagenode):
+def test_too_many_nodes(storagegroup, storagenode, queue):
     """Test DefaultGroupIO rejecting more than one node."""
 
     stgroup = storagegroup(name="group")
     node1 = UpdateableNode(None, storagenode(name="node1", group=stgroup, active=True))
     node2 = UpdateableNode(None, storagenode(name="node2", group=stgroup, active=True))
 
-    group = UpdateableGroup(group=stgroup, nodes=[node1, node2], idle=True)
+    group = UpdateableGroup(queue=queue, group=stgroup, nodes=[node1, node2], idle=True)
     assert group._nodes is None
 
 
-def test_just_enough_nodes(storagegroup, storagenode):
+def test_just_enough_nodes(storagegroup, storagenode, queue):
     """Test DefaultGroupIO accepting one node."""
 
     stgroup = storagegroup(name="group")
     node = UpdateableNode(None, storagenode(name="node1", group=stgroup, active=True))
 
-    group = UpdateableGroup(group=stgroup, nodes=[node], idle=True)
+    group = UpdateableGroup(queue=queue, group=stgroup, nodes=[node], idle=True)
     assert group._nodes == [node]
 
 
@@ -58,15 +60,112 @@ def test_exists(xfs, groupnode):
     assert group.io.exists("no-acq/no-file") is None
 
 
-def test_pull_handoff(groupnode, simplerequest):
-    """Test DefaultGroupIO.pull()."""
+def test_pull_force_handoff(groupnode, simplerequest):
+    """Test DefaultGroupIO.pull_force()."""
 
-    # We mock the DefaultNodeIO.pull() method because we don't need to test it here.
     group, node = groupnode
     node.io.pull = MagicMock(return_value=None)
 
-    # Call pull
-    group.io.pull(simplerequest)
+    # Call pull_force
+    group.io.pull_force(simplerequest)
 
     # Check for hand-off to the node
     node.io.pull.assert_called_with(simplerequest)
+
+
+def test_pull(groupnode, simplerequest, queue):
+    """Test task submission in DefaultGroupIO.pull()."""
+
+    group, node = groupnode
+
+    with patch("alpenhorn.io.default.group_search_async") as mock:
+        group.io.pull(simplerequest)
+
+        # Task is queued
+        assert queue.qsize == 1
+
+        # Dequeue
+        task, key = queue.get()
+
+        # Run the "task"
+        task()
+
+        # Clean up queue
+        queue.task_done(key)
+
+        assert key == group.io.fifo
+        mock.assert_called_once()
+
+
+def test_group_search_dispatch(groupnode, simplerequest, queue):
+    """Test group_search_async dispatch to pull_force"""
+
+    group, node = groupnode
+
+    mock = MagicMock()
+    group.io.pull_force = mock
+
+    # Run the async.  First argument is Task
+    group_search_async(None, group.io, simplerequest)
+
+    # Check dispatch
+    mock.assert_called_once_with(simplerequest)
+
+
+def test_group_search_existing(
+    groupnode, simplefile, archivefilecopyrequest, queue, dbtables, xfs
+):
+    """Test group_search_async with existing file."""
+
+    group, node = groupnode
+
+    mock = MagicMock()
+    group.io.pull_force = mock
+
+    # Create a file on the dest
+    xfs.create_file(f"{node.db.root}/{simplefile.path}")
+
+    # Create a copy request for the file.
+    # Source here doesn't matter
+    afcr = archivefilecopyrequest(file=simplefile, node_from=node.db, group_to=group.db)
+
+    # Run the async.  First argument is Task
+    group_search_async(None, group.io, afcr)
+
+    # Check dispatch
+    mock.assert_not_called()
+
+    # Check for an archivefilecopy record requesting a check
+    afc = ArchiveFileCopy.get(file=afcr.file, node=node.db)
+    assert afc.has_file == "M"
+
+
+def test_group_search_hasN(
+    groupnode, simplefile, archivefilecopyrequest, archivefilecopy, queue, xfs
+):
+    """Test group_search_async with existing file and has_file=N."""
+
+    group, node = groupnode
+
+    mock = MagicMock()
+    group.io.pull_force = mock
+
+    # Create a file on the dest
+    xfs.create_file(f"{node.db.root}/{simplefile.path}")
+
+    # Create the copy record
+    archivefilecopy(file=simplefile, node=node.db, has_file="N", wants_file="N")
+
+    # Create a copy request for the file.
+    # Source here doesn't matter
+    afcr = archivefilecopyrequest(file=simplefile, node_from=node.db, group_to=group.db)
+
+    # Run the async.  First argument is Task
+    group_search_async(None, group.io, afcr)
+
+    # Check dispatch
+    mock.assert_not_called()
+
+    # Check for an archivefilecopy record requesting a check
+    afc = ArchiveFileCopy.get(file=afcr.file, node=node.db)
+    assert afc.has_file == "M"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -77,7 +77,7 @@ def test_update_node_not_idle(
     mockio.node.before_update.return_value = True
 
     # Ensure queue non-idle
-    queue.put(None, node.name)
+    queue.put(None, mockio.node.fifo)
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
@@ -195,7 +195,7 @@ def test_ioload(storagegroup, storagenode, mock_lfs):
         assert isinstance(unode.io, BaseNodeIO)
 
     for group in StorageGroup.select().execute():
-        ugroup = update.UpdateableGroup(group=group, nodes=[], idle=True)
+        ugroup = update.UpdateableGroup(queue=None, group=group, nodes=[], idle=True)
         assert isinstance(ugroup.io, BaseGroupIO)
 
 
@@ -215,7 +215,7 @@ def test_update_group_not_idle_node(
     mockio.group.before_update.return_value = True
 
     # Node not idle
-    queue.put(None, node.name)
+    queue.put(None, mockio.node.fifo)
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
@@ -245,8 +245,8 @@ def test_update_group_not_idle_group(
     # This function adds something to the queue so that after the
     # node update, it's not idle
     def node_before_update(idle):
-        nonlocal queue, node
-        queue.put(None, node.name)
+        nonlocal queue, mockio
+        queue.put(None, mockio.node.fifo)
 
         return True
 

--- a/tests/test_update_node.py
+++ b/tests/test_update_node.py
@@ -101,7 +101,7 @@ def test_idle(unode, queue):
     assert unode.idle is True
 
     # Enqueue something into this node's queue
-    queue.put(None, unode.name)
+    queue.put(None, unode.io.fifo)
 
     # Now not idle
     assert unode.idle is False
@@ -113,7 +113,7 @@ def test_idle(unode, queue):
     assert unode.idle is False
 
     # Finish the task
-    queue.task_done(unode.name)
+    queue.task_done(key)
 
     # Now idle again
     assert unode.idle is True
@@ -267,7 +267,7 @@ def test_update_idle(unode, queue):
             assert len(rav.mock_calls) == 0
             assert len(ioiu.mock_calls) == 1
 
-            queue.put(None, unode.name)
+            queue.put(None, unode.io.fifo)
             unode.update_idle()
 
             # didn't run because not idle
@@ -276,7 +276,7 @@ def test_update_idle(unode, queue):
 
             # Empty the queue
             queue.get()
-            queue.task_done(unode.name)
+            queue.task_done(unode.io.fifo)
             unode.update_idle()
 
             # idle again, so ran again
@@ -404,6 +404,7 @@ def test_update_node_run(
     mock = MagicMock()
     mock.before_update.return_value = True
     mock.bytes_avail.return_value = None
+    mock.fifo = "n:mock"
     with patch.object(unode, "io", mock):
         # update runs
         unode.update()


### PR DESCRIPTION
This fixes another instance of unnecessary I/O in the MainThread.  Specifically, when processing a pull request, the UpdateableGroup was searching the group's node(s) for a hitherto unknown copy of the file on disk (which can happen if alpenhorn crashes during a pull).

This check has been moved to a Task (`_default_asyncs.group_search_async`) and is now done later in the pull request processing, after non-I/O checks have finished (which should, overall, reduce the amount of I/O going on).

The `group.io.pull` method has been broken into two pieces:
* `pull_force` which does what the prior `pull` method did: chooses a node to receive the file and dispatch the request to that node, and
* a new `pull` which runs the search asyncm which, in turn, will call `pull_force` to pull the file, if the search finds nothing.

The net effect here is that the `group_search_async` task will queue a second task at the node level to do the pull.  (That's fine: tasks queueing more tasks has always been supported).

The tricky part is that this is the first Task that needs to run at the Group level, instead of the Node level, so some work has been done to add Task support to groups (which was always my plan, it just turned out there were no group tasks to implement when I first refactored alpenhorn).

In order to distinguish tasks for a group and a node, which may have the same name, there is now a `fifo` attribute in I/O objects which produces the fifo key that's used when submitting tasks to the queue.  This is the node/group name with a prefix of `n:` or `g:`.

Has been deployed to cedar.