### PR TITLE
fix errors found by ruff

### DIFF
--- a/alpenhorn/config.py
+++ b/alpenhorn/config.py
@@ -230,7 +230,7 @@ def merge_dict_tree(a, b):
     """
 
     # Different types should return b
-    if type(a) != type(b):
+    if type(a) is not type(b):
         return b
 
     # From this point on both have the same type, so we only need to check

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -448,7 +448,7 @@ class BaseGroupIO:
     # SETUP
 
     def __init__(
-        self, group: StorageGroup, config: dict, queue: FairMultiFifoQueue
+        self, group: StorageGroup, config: dict, queue: FairMultiFIFOQueue
     ) -> None:
         self.group = group
         self._queue = queue

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -343,7 +343,7 @@ def post_add(node: StorageNode, file_: ArchiveFile) -> None:
     for edge in StorageTransferAction.select().where(
         StorageTransferAction.node_from == node,
         StorageTransferAction.group_to != node.group,
-        StorageTransferAction.autosync == True,
+        StorageTransferAction.autosync == True,  # noqa: E712
     ):
         if edge.group_to.filecopy_state(file_) != "Y":
             log.debug(
@@ -359,7 +359,7 @@ def post_add(node: StorageNode, file_: ArchiveFile) -> None:
     for edge in StorageTransferAction.select().where(
         StorageTransferAction.group_to == node.group,
         StorageTransferAction.node_from != node,
-        StorageTransferAction.autoclean == True,
+        StorageTransferAction.autoclean == True,  # noqa: E712
     ):
         count = (
             ArchiveFileCopy.update(wants_file="N", last_update=datetime.utcnow())
@@ -545,7 +545,9 @@ def remove_filedir(
                     # Already deleted, which is fine.
                     pass
                 else:
-                    log.warning(f"Error deleting directory {dirname} on {name}: {e}")
+                    log.warning(
+                        f"Error deleting directory {dirname} on {node.name}: {e}"
+                    )
                     # Otherwise, let's try to soldier on
 
             dirname = dirname.parent

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
     from ..archive import ArchiveFileCopyRequest
     from ..queue import FairMultiFIFOQueue
     from ..update import UpdateableNode, UpdateableGroup
-    from .lfs import LFS
 
 log = logging.getLogger(__name__)
 
@@ -194,7 +193,7 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
                 .where(
                     ArchiveFileCopy.node == node,
                     ArchiveFileCopy.has_file == "Y",
-                    ArchiveFileCopy.ready == True,
+                    ArchiveFileCopy.ready == True,  # noqa: E712
                 )
                 .order_by(ArchiveFileCopy.last_update)
             ):
@@ -582,7 +581,7 @@ class LustreHSMGroupIO(DefaultGroupIO):
     # SETUP
 
     def __init__(
-        self, queue: FairMultiFifoQueue, group: UpdateableGroup, config: dict
+        self, queue: FairMultiFIFOQueue, group: UpdateableGroup, config: dict
     ) -> None:
         super().__init__(queue, group, config)
 

--- a/alpenhorn/update.py
+++ b/alpenhorn/update.py
@@ -492,7 +492,7 @@ class UpdateableGroup(updateable_base):
 
     Parameters
     ----------
-    queue : FairMultiFifoQueue
+    queue : FairMultiFIFOQueue
         The task queue/scheduler
     group : StorageGroup
         The underlying StorageGroup instance
@@ -508,7 +508,7 @@ class UpdateableGroup(updateable_base):
     def __init__(
         self,
         *,
-        queue: FairMultiFifoQueue,
+        queue: FairMultiFIFOQueue,
         group: StorageGroup,
         nodes: list[UpdateableNode],
         idle: bool,
@@ -745,7 +745,10 @@ def update_loop(queue: FairMultiFIFOQueue, pool: WorkerPool | EmptyPool) -> None
                 node.name: node
                 for node in (
                     StorageNode.select()
-                    .where(StorageNode.host == host, StorageNode.active == True)
+                    .where(
+                        StorageNode.host == host,
+                        StorageNode.active == True,  # noqa: E712
+                    )
                     .execute()
                 )
             }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -345,8 +345,6 @@ def mock_exists(fs):
         """
         nonlocal fs
 
-        from math import ceil
-
         try:
             dir_ = fs.get_object(path.parent)
             # Parent directory not readable
@@ -357,7 +355,7 @@ def mock_exists(fs):
 
         # Directory is readable
         try:
-            file = fs.get_object(path)
+            fs.get_object(path)
         except PermissionError:
             pass
         except FileNotFoundError:

--- a/tests/io/test_defaultnode.py
+++ b/tests/io/test_defaultnode.py
@@ -121,7 +121,7 @@ def test_md5_bad(unode, xfs):
 
     # Try an unreadable file
     xfs.create_file("/node/dir/file", st_mode=0)
-    assert unode.io.md5("dir/file") == None
+    assert unode.io.md5("dir/file") is None
 
 
 def test_open_absolute(unode, xfs):
@@ -196,9 +196,9 @@ def test_idle_cleanup(unode, archiveacq, archivefile, queue, xfs):
     full_acq = archiveacq(name="full")
 
     # Create some files
-    empty_file = archivefile(name="empty", acq=empty_acq)
-    dirty_file = archivefile(name="dirty", acq=dirty_acq)
-    full_file = archivefile(name="full", acq=full_acq)
+    archivefile(name="empty", acq=empty_acq)
+    archivefile(name="dirty", acq=dirty_acq)
+    archivefile(name="full", acq=full_acq)
 
     # Popluate the node filesystem
     xfs.create_dir(f"{root}/empty")

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -246,8 +246,6 @@ def test_rotate_bad_size(set_config, logger, xfs):
 def test_rotatefile_logging(set_config, logger, xfs):
     """Test file logging and rotating."""
 
-    mock = MagicMock()
-
     with patch("alpenhorn.logger.RotatingFileHandler") as mock:
         logger.configure_logging()
 

--- a/tests/test_update_group.py
+++ b/tests/test_update_group.py
@@ -1,10 +1,9 @@
 """Tests for UpdateableGroup."""
 
 import pytest
-import datetime
 from unittest.mock import patch, call
 
-from alpenhorn.archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from alpenhorn.archive import ArchiveFileCopyRequest
 from alpenhorn.storage import StorageGroup
 from alpenhorn.update import UpdateableGroup, UpdateableNode
 


### PR DESCRIPTION
I don't want to add a ruff check to the CI yet, because the alpenhorn client code is very broken, but here are some fixes found by running it manually.

Most of these are unused variables.  In peewee `.where` clauses, `<field> == True` can't be converted to `is True` because (as explained in the peewee docs) `is` can't be overloaded like `==` can.   So in those cases, I've disabled the specific check (`# noqa: E712`).