### PR TITLE
fix(_default_asyncs): Use full path for copy target

### DIFF
--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -108,11 +108,11 @@ def pull_async(
             # calculate the md5 hash as it goes, so we'll do that to save doing
             # it at the end.
             log.info(f"Pulling remote file {req.file.path} using bbcp")
-            ioresult = ioutil.bbcp(from_path, to_dir, req.file.size_b)
+            ioresult = ioutil.bbcp(from_path, to_file, req.file.size_b)
         elif shutil.which("rsync") is not None:
             # Next try rsync over ssh.
             log.info(f"Pulling remote file {req.file.path} using rsync")
-            ioresult = ioutil.rsync(from_path, to_dir, req.file.size_b, local)
+            ioresult = ioutil.rsync(from_path, to_file, req.file.size_b, local)
         else:
             # We have no idea how to transfer the file...
             log.error("No commands available to complete remote pull.")
@@ -137,7 +137,7 @@ def pull_async(
         if ioresult is None:
             if shutil.which("rsync") is not None:
                 log.info(f"Pulling local file {req.file.path} using rsync")
-                ioresult = ioutil.rsync(from_path, to_dir, req.file.size_b, local)
+                ioresult = ioutil.rsync(from_path, to_file, req.file.size_b, local)
             else:
                 log.error("No commands available to complete local pull.")
                 ioresult = {"ret": -1, "check_src": False}

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -70,17 +70,17 @@ def _pull_timeout(size_b: int) -> float | None:
     return base + size_b / bps
 
 
-def bbcp(from_path: str | os.PathLike, to_dir: str | os.PathLike, size_b: int) -> dict:
+def bbcp(source: str | os.PathLike, target: str | os.PathLike, size_b: int) -> dict:
     """Transfer a file with BBCP.
 
     Command times out after `_pull_timeout(size_b)` seconds have elapsed.
 
     Parameters
     ----------
-    from_path : path-like
+    source : path-like
         Source location
-    to_dir : path-like
-        Destination directory
+    target : path-like
+        Target location
     size_b : int
         Size of the file to transfer.  Only used to
         set the timeout.
@@ -166,8 +166,8 @@ def bbcp(from_path: str | os.PathLike, to_dir: str | os.PathLike, size_b: int) -
             # and https://github.com/chime-experiment/alpenhorn/pull/15
             "-E",
             "%md5=",
-            str(from_path),
-            str(to_dir),
+            str(source),
+            str(target),
         ],
         timeout=_pull_timeout(size_b),
     )
@@ -192,7 +192,7 @@ def bbcp(from_path: str | os.PathLike, to_dir: str | os.PathLike, size_b: int) -
 
 
 def rsync(
-    from_path: str | os.PathLike, to_dir: str | os.PathLike, size_b: int, local: bool
+    source: str | os.PathLike, target: str | os.PathLike, size_b: int, local: bool
 ) -> dict:
     """Rsync a file (either local or remote).
 
@@ -200,10 +200,10 @@ def rsync(
 
     Parameters
     ----------
-    from_path : path-like
+    source : path-like
         Source location
-    to_dir : path-like
-        Destination directory
+    target : path-like
+        Target location
     size_b : int
         Size of the file to transfer.  Only used to
         set the timeout.
@@ -247,8 +247,8 @@ def rsync(
             "--owner",
             "--copy-links",
             "--sparse",
-            str(from_path),
-            str(to_dir),
+            str(source),
+            str(target),
         ],
         timeout=_pull_timeout(size_b),
     )
@@ -278,7 +278,9 @@ def rsync(
     return ioresult
 
 
-def hardlink(from_path, to_dir, filename) -> dict | None:
+def hardlink(
+    from_path: str | os.PathLike, to_dir: str | os.PathLike, filename: str
+) -> dict | None:
     """Hard link `from_path` as `to_dir/filename`
 
     Atomically overwrites an existing `to_dir/filename`.
@@ -289,9 +291,9 @@ def hardlink(from_path, to_dir, filename) -> dict | None:
 
     Parameters
     ----------
-    from_path : str
+    from_path : path-like
         Source location
-    to_dir : str
+    to_dir : spath-like
         Destination directory
     filename : str
         Destination filename


### PR DESCRIPTION
Yesterday's failure goes like this:
* alpenhorn start
* "tidy up" task from #182 starts because node is idle
* pull request task starts during group update
* pull task creates new directory and placeholder file
* tidy-up task deletes placeholder file and new directory
* bbcp creates file as directory name (because that's the "target" it was given).

This PR doesn't actually fix this problem. (I'm working on another PR for that), but this does provide some mitigation so that, if a third-party comes by and deletes a destination directory during a pull, the pull will fail (due to missing target directory), instead of wrongly creating the destination file as the target directory name.

Also renamed the parameters in `ioutil.bbcp` and `ioutil.rsync` to something more generic to indicate they're not interpreted in any particular way