### PR TITLE
feat(queue): Scheduling for exclusive tasks

### DIFF
--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -140,3 +140,55 @@ def test_concurrency(clean_queue):
     # There shouldn't be anything left
     assert clean_queue.qsize == 0
     assert clean_queue.inprogress_size == 0
+
+
+def test_exclusive(clean_queue):
+    """Test exclusive puts and gets."""
+
+    # queue some things.  The second thing is exclusive
+    clean_queue.put(1, "fifo")
+    clean_queue.put(2, "fifo", exclusive=True)
+    clean_queue.put(3, "fifo")
+
+    assert clean_queue.qsize == 3
+    assert clean_queue.inprogress_size == 0
+
+    # Get the first thing
+    item, key = clean_queue.get(timeout=0.1)
+    assert item == 1
+
+    # Fail to get the second thing because
+    # there's something in-progress from the queue
+    assert clean_queue.get(timeout=0.1) is None
+
+    # But getting something from another FIFO
+    # should work.
+    clean_queue.put(4, "fifo2")
+    item, key2 = clean_queue.get(timeout=0.1)
+    clean_queue.task_done(key2)
+
+    assert item == 4
+    assert key2 == "fifo2"
+
+    # Finish the first thing
+    clean_queue.task_done(key)
+
+    # Now we can get the second thing
+    item, key = clean_queue.get(timeout=0.1)
+    assert item == 2
+
+    # Fail to get the third thing because
+    # the fifo is locked during exclusive task
+    assert clean_queue.get(timeout=0.1) is None
+
+    # Finish the second thing, unlocking the fifo
+    clean_queue.task_done(key)
+
+    # Now we can get the third thing
+    item, key = clean_queue.get(timeout=0.1)
+    assert item == 3
+    clean_queue.task_done(key)
+
+    # Everything's taken care of
+    assert clean_queue.qsize == 0
+    assert clean_queue.inprogress_size == 0


### PR DESCRIPTION
I think the solution for the problem outlined in #193 is to only run the "tidy-up" task when no other I/O is happening on the node.  This task is unusual in that it has the potential to modify anything on the node.  (Typically, tasks only concern themselves with a single file that they can be fairly certain no other tasks are also working on).

So here, I add the ability to flag an item in the task scheduler (i.e. the `FairMultiFIFOQueue`) as "exclusive".

* Exclusive items aren't returned by get() unless there's nothing else in-progress from its FIFO.
* When an exclusive item is returned by get(), the FMFQ locks its FIFO, preventing further items from that FIFO from being returned. The FIFO remains locked until the next task_done() call for that FIFO.

Before implementing this, I considered changing the way group idleness is computed, because that could fix it, too (the root problem is that the group is submitting tasks for the node, which adds a wrinkle to the update loop logic). I think this is probably cleaner, though I could be convinced otherwise, if that seems like a better solution.