### PR TITLE
fix(io/lustrehsm): Handle timeout in hsm_restore call.

### DIFF
--- a/alpenhorn/util.py
+++ b/alpenhorn/util.py
@@ -51,9 +51,7 @@ def run_command(
     except subprocess.TimeoutExpired:
         log.warning(f"Process overrun [timeout={timeout}]: " + " ".join(cmd))
         proc.kill()
-        stdout_val = ""
-        stderr_val = ""
-        retval = None
+        return (None, "", "")
 
     return (
         retval,

--- a/tests/io/test_lfs.py
+++ b/tests/io/test_lfs.py
@@ -40,7 +40,7 @@ def test_run_lfs_fail(have_lfs, mock_run_command):
 
     lfs = LFS(None)
 
-    assert lfs.run_lfs("arg1", "arg2") is None
+    assert lfs.run_lfs("arg1", "arg2") is False
     assert mock_run_command() == {
         "cmd": ["LFS", "arg1", "arg2"],
         "kwargs": dict(),
@@ -255,7 +255,7 @@ def test_hsm_restore(mock_lfs, mock_run_command):
 
     lfs = LFS("qgroup")
 
-    assert not lfs.hsm_restore("/missing")
+    assert lfs.hsm_restore("/missing") is False
     assert lfs.hsm_restore("/unarchived")
     assert lfs.hsm_restore("/restored")
 
@@ -266,6 +266,17 @@ def test_hsm_restore(mock_lfs, mock_run_command):
     assert lfs.hsm_restore("/released")
     assert "hsm_restore" in mock_run_command()["cmd"]
     assert "/released" in mock_run_command()["cmd"]
+
+
+@pytest.mark.run_command_result(None, "", "")
+@pytest.mark.lfs_hsm_state({"/released": "released"})
+@pytest.mark.lfs_dont_mock("hsm_restore")
+def test_hsm_restore_timeout(mock_lfs, mock_run_command):
+    """Test hsm_restore() timeout."""
+
+    lfs = LFS("qgroup")
+
+    assert lfs.hsm_restore("/released") is None
 
 
 @pytest.mark.lfs_hsm_state(

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -26,13 +26,19 @@ def test_run_stdout():
 
 
 def test_run_stderr():
-    """Test getting stdout from run_command."""
+    """Test getting stderr from run_command."""
     retval, stdout, stderr = util.run_command(
         ["python3", "-c", "import os; os.write(2, b'stderr')"]
     )
     assert stderr == "stderr"
     assert stdout == ""
     assert retval == 0
+
+
+def test_run_timeout():
+    """Test run_command timing out."""
+    retval, stdout, stderr = util.run_command(["sleep", "10"], timeout=0.1)
+    assert retval is None
 
 
 def test_md5sum_file(tmp_path):


### PR DESCRIPTION
On `cedar`, at least, running `lfs hsm_restore` on a file that is already being restored causes `lfs` to wait for a very long time (~15 minutes) before returning.

This deals with that eventuality by returning a timeout error if the hsm_restore call takes more than a minute.  On timeout, alpenhorn will assume success (the idea being the timeout was due to the file restore being already in progress).

However, to guard against a false assumption, alpenhorn will retry the restore request after an hour.  This retry is now also done (but after four hours) on a successful hsm_restore request.  This is to mitigate a potential issue I've been thinking about: alpenhorn submitting a successful hsm_restore request that is later abandonned by the HSM backend before the file is restored, which has been a potential problem since https://github.com/radiocosmology/alpenhorn/pull/189.

Bonus: fixed a crash-on-timeout bug in `util.run_command` which I introduced in https://github.com/radiocosmology/alpenhorn/pull/179.

Closes #188 