### PR TITLE
fix(db): Deal with 3.12+ naive UTC datetimes

### DIFF
--- a/alpenhorn/db/__init__.py
+++ b/alpenhorn/db/__init__.py
@@ -45,3 +45,7 @@ from ._base import connect, close, database_proxy, threadsafe
 
 # Prototypes
 from ._base import EnumField, base_model
+
+# Naive-UTC stuff courtesy peewee.  These were originally in datetime
+# but were deprecated in 3.12 as too confusing.
+from peewee import utcnow as utcnow, utcfromtimestamp as utcfromtimestamp

--- a/alpenhorn/db/acquisition.py
+++ b/alpenhorn/db/acquisition.py
@@ -49,7 +49,7 @@ class ArchiveFile(base_model):
     md5sum = pw.CharField(null=True, max_length=32)
     # Note: default here is the now method itself (i.e. "now", not "now()").
     #       Will be evaulated by peewee at row-creation time.
-    registered = pw.DateTimeField(default=datetime.datetime.utcnow)
+    registered = pw.DateTimeField(default=pw.utcnow)
 
     class Meta:
         # (acq,name) is unique

--- a/alpenhorn/db/archive.py
+++ b/alpenhorn/db/archive.py
@@ -48,7 +48,7 @@ class ArchiveFileCopy(base_model):
     wants_file = EnumField(["Y", "M", "N"], default="Y")
     ready = pw.BooleanField(default=False)
     size_b = pw.BigIntegerField(null=True)
-    last_update = pw.DateTimeField(default=datetime.datetime.utcnow)
+    last_update = pw.DateTimeField(default=pw.utcnow)
 
     @property
     def path(self) -> pathlib.Path:
@@ -91,7 +91,7 @@ class ArchiveFileCopyRequest(base_model):
     node_from = pw.ForeignKeyField(StorageNode, backref="requests_from")
     completed = pw.BooleanField(default=False)
     cancelled = pw.BooleanField(default=False)
-    timestamp = pw.DateTimeField(default=datetime.datetime.utcnow, null=True)
+    timestamp = pw.DateTimeField(default=pw.utcnow, null=True)
     transfer_started = pw.DateTimeField(null=True)
     transfer_completed = pw.DateTimeField(null=True)
 

--- a/alpenhorn/db/storage.py
+++ b/alpenhorn/db/storage.py
@@ -367,7 +367,7 @@ class StorageNode(base_model):
             self.avail_gb = None
         else:
             self.avail_gb = new_avail / 2**30
-        self.avail_gb_last_checked = datetime.datetime.utcnow()
+        self.avail_gb_last_checked = pw.utcnow()
 
         # Update the DB with the free space but don't clobber changes made
         # manually to the database

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -8,10 +8,9 @@ import errno
 import shutil
 import logging
 import pathlib
-from datetime import datetime
 
 from . import ioutil
-from ..db import ArchiveFileCopy, ArchiveFileCopyRequest
+from ..db import ArchiveFileCopy, ArchiveFileCopyRequest, utcnow
 from ..server.update import RemoteNode
 
 if TYPE_CHECKING:
@@ -224,7 +223,7 @@ def check_async(task: Task, io: BaseNodeIO, copy: ArchiveFileCopy) -> None:
     log.info(
         f"Updating file copy #{copy.id} for file {copyname} on node {io.node.name}."
     )
-    copy.last_update = datetime.utcnow()
+    copy.last_update = utcnow()
     copy.save()
 
 
@@ -288,7 +287,7 @@ def delete_async(
 
         # Update the DB
         ArchiveFileCopy.update(
-            has_file="N", wants_file="N", last_update=datetime.utcnow()
+            has_file="N", wants_file="N", last_update=utcnow()
         ).where(ArchiveFileCopy.id == copy.id).execute()
 
 
@@ -341,7 +340,7 @@ def group_search_async(
                 has_file="M",
                 wants_file="Y",
                 ready=False,
-                last_update=datetime.utcnow(),
+                last_update=utcnow(),
             )
             .where(
                 ArchiveFileCopy.file == req.file,

--- a/alpenhorn/server/auto_import.py
+++ b/alpenhorn/server/auto_import.py
@@ -6,12 +6,11 @@ from typing import TYPE_CHECKING
 import logging
 import pathlib
 import peewee as pw
-from datetime import datetime
 from watchdog.events import FileSystemEventHandler
 
 from .. import db
 from ..common import config, extensions
-from ..db import ArchiveAcq, ArchiveFile, ArchiveFileCopy
+from ..db import ArchiveAcq, ArchiveFile, ArchiveFileCopy, utcnow
 from ..io import ioutil
 from ..scheduler import Task
 
@@ -163,7 +162,7 @@ def _import_file(task: Task, node: StorageNode, path: pathlib.PurePath) -> None:
             copy.has_file = "M"
             copy.wants_file = "Y"
             copy.ready = True
-            copy.last_update = datetime.utcnow()
+            copy.last_update = utcnow()
             copy.save()
             log.warning(
                 f'Imported file "{path}" formerly present on node {node.name}!  Marking suspect.'
@@ -177,7 +176,7 @@ def _import_file(task: Task, node: StorageNode, path: pathlib.PurePath) -> None:
                 wants_file="Y",
                 ready=True,
                 size_b=node.io.filesize(path, actual=True),
-                last_update=datetime.utcnow(),
+                last_update=utcnow(),
             )
             log.info(f'Registered file copy "{path}" on node "{node.name}".')
 

--- a/alpenhorn/server/update.py
+++ b/alpenhorn/server/update.py
@@ -8,11 +8,16 @@ import json
 import time
 import logging
 import peewee as pw
-from datetime import datetime
 
 from ..common import config, util
 from ..common.extensions import io_module
-from ..db import ArchiveFileCopy, ArchiveFileCopyRequest, StorageNode, StorageGroup
+from ..db import (
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    StorageNode,
+    StorageGroup,
+    utcnow,
+)
 from ..scheduler import global_abort, WorkerPool, EmptyPool
 from . import auto_import
 from .querywalker import QueryWalker
@@ -337,7 +342,7 @@ class UpdateableNode(updateable_base):
 
             # Mark file as needing check
             copy.has_file = "M"
-            copy.last_update = datetime.utcnow()
+            copy.last_update = utcnow()
             copy.save()
 
     def update_idle(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license = {file = "LICENSE"}
 dependencies = [
   "Click >= 6.0",
   "concurrent-log-handler",
-  "peewee >= 3.16",
+  "peewee >= 3.17.1",
   "PyYAML",
   "tabulate",
   "watchdog"

--- a/tests/db/test_acquisition.py
+++ b/tests/db/test_acquisition.py
@@ -2,7 +2,6 @@
 
 import pytest
 import pathlib
-import datetime
 import peewee as pw
 
 from alpenhorn.db.acquisition import ArchiveAcq, ArchiveFile
@@ -39,9 +38,9 @@ def test_acq_model(archiveacq):
 
 def test_file_model(archiveacq, archivefile):
     acq1 = archiveacq(name="acq1")
-    before = datetime.datetime.utcnow().replace(microsecond=0)
+    before = pw.utcnow().replace(microsecond=0)
     archivefile(name="min", acq=acq1)
-    after = datetime.datetime.utcnow()
+    after = pw.utcnow()
     archivefile(
         name="max",
         acq=acq1,

--- a/tests/db/test_archive.py
+++ b/tests/db/test_archive.py
@@ -79,11 +79,9 @@ def test_archivefilecopyrequest_model(
     """Test ArchiveFileCopyRequest model"""
     minnode = storagenode(name="min", group=simplegroup)
     maxnode = storagenode(name="max", group=simplegroup)
-    before = (datetime.datetime.utcnow() - datetime.timedelta(seconds=1)).replace(
-        microsecond=0
-    )
+    before = (pw.utcnow() - datetime.timedelta(seconds=1)).replace(microsecond=0)
     archivefilecopyrequest(file=simplefile, node_from=minnode, group_to=simplegroup)
-    after = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
+    after = pw.utcnow() + datetime.timedelta(seconds=1)
     archivefilecopyrequest(
         file=simplefile,
         node_from=maxnode,

--- a/tests/db/test_storage.py
+++ b/tests/db/test_storage.py
@@ -2,7 +2,6 @@
 
 import pytest
 import pathlib
-import datetime
 import peewee as pw
 
 from alpenhorn.db.storage import StorageGroup, StorageNode, StorageTransferAction
@@ -355,11 +354,11 @@ def test_update_avail_gb(simplenode):
     assert simplenode.avail_gb is None
 
     # Test a number
-    before = datetime.datetime.utcnow()
+    before = pw.utcnow()
     simplenode.update_avail_gb(10000)
     # Now the value is set
     node = StorageNode.get(id=simplenode.id)
-    after = datetime.datetime.utcnow()
+    after = pw.utcnow()
 
     assert node.avail_gb == 10000.0 / 2.0**30
     assert node.avail_gb_last_checked >= before

--- a/tests/io/test_ioutil.py
+++ b/tests/io/test_ioutil.py
@@ -345,7 +345,7 @@ def test_autoclean(
 ):
     """Test post_add running autoclean."""
 
-    before = datetime.datetime.utcnow() - datetime.timedelta(seconds=2)
+    before = pw.utcnow() - datetime.timedelta(seconds=2)
 
     destnode = storagenode(name="dest", group=simplegroup)
 
@@ -370,7 +370,7 @@ def test_autoclean_state(
 ):
     """post_add autoclean only deletes copies with has_file=='Y'."""
 
-    then = datetime.datetime.utcnow() - datetime.timedelta(seconds=200)
+    then = pw.utcnow() - datetime.timedelta(seconds=200)
 
     srcnode = storagenode(name="src", group=simplegroup)
     storagetransferaction(node_from=srcnode, group_to=simplenode.group, autoclean=True)

--- a/tests/io/test_ioutil_crd.py
+++ b/tests/io/test_ioutil_crd.py
@@ -5,6 +5,7 @@ import pytest
 import datetime
 from unittest.mock import patch, MagicMock
 
+from alpenhorn.db import utcfromtimestamp, utcnow
 from alpenhorn.db.archive import ArchiveFileCopy, ArchiveFileCopyRequest
 from alpenhorn.io.ioutil import copy_request_done
 from alpenhorn.server.update import UpdateableNode
@@ -173,7 +174,7 @@ def test_md5ok_true(db_setup):
 
     io, copy, req, start_time, post_add = db_setup
 
-    before = datetime.datetime.utcnow() - datetime.timedelta(seconds=2)
+    before = utcnow() - datetime.timedelta(seconds=2)
     assert (
         copy_request_done(
             req,
@@ -184,13 +185,13 @@ def test_md5ok_true(db_setup):
         )
         is True
     )
-    after = datetime.datetime.utcnow()
+    after = utcnow()
 
     # request is resolved
     afcr = ArchiveFileCopyRequest.get(id=req.id)
     assert afcr.completed
     assert not afcr.cancelled
-    assert afcr.transfer_started == datetime.datetime.utcfromtimestamp(start_time)
+    assert afcr.transfer_started == utcfromtimestamp(start_time)
     assert afcr.transfer_completed >= before
     assert afcr.transfer_completed <= after
 

--- a/tests/io/test_lustrehsmnode.py
+++ b/tests/io/test_lustrehsmnode.py
@@ -1,7 +1,7 @@
 """Test LustreHSMNodeIO."""
 
 import pytest
-import datetime
+import peewee as pw
 from unittest.mock import patch, MagicMock
 
 from alpenhorn.db.archive import ArchiveFileCopy
@@ -94,7 +94,7 @@ def test_release_files(queue, mock_lfs, node):
 
     node.io.release_files()
 
-    before = datetime.datetime.utcnow().replace(microsecond=0)
+    before = pw.utcnow().replace(microsecond=0)
 
     # Job in queue
     assert queue.qsize == 1
@@ -368,7 +368,7 @@ def test_ready_path(mock_lfs, node):
 def test_ready_pull_restored(mock_lfs, node, queue, archivefilecopyrequest):
     """Test LustreHSMNodeIO.ready_pull on a restored file that isn't ready."""
 
-    before = datetime.datetime.utcnow().replace(microsecond=0)
+    before = pw.utcnow().replace(microsecond=0)
 
     copy = ArchiveFileCopy.get(id=1)
     copy.ready = False
@@ -464,7 +464,7 @@ def test_idle_update_empty(queue, mock_lfs, node):
 def test_idle_update_ready(xfs, queue, mock_lfs, node):
     """Test LustreHSMNodeIO.idle_update with copies ready"""
 
-    before = datetime.datetime.utcnow().replace(microsecond=0)
+    before = pw.utcnow().replace(microsecond=0)
 
     node.io.idle_update(False)
 
@@ -504,7 +504,7 @@ def test_idle_update_ready(xfs, queue, mock_lfs, node):
 def test_idle_update_not_ready(xfs, queue, mock_lfs, node):
     """Test LustreHSMNodeIO.idle_update with copies not ready"""
 
-    before = datetime.datetime.utcnow().replace(microsecond=0)
+    before = pw.utcnow().replace(microsecond=0)
 
     # Update all copies
     ArchiveFileCopy.update(ready=False).execute()

--- a/tests/server/test_auto_import.py
+++ b/tests/server/test_auto_import.py
@@ -107,9 +107,7 @@ def test_import_file_create(xfs, dbtables, unode):
 
     xfs.create_file("/node/simplefile_acq/simplefile")
 
-    before = (datetime.datetime.utcnow() - datetime.timedelta(seconds=1)).replace(
-        microsecond=0
-    )
+    before = (pw.utcnow() - datetime.timedelta(seconds=1)).replace(microsecond=0)
 
     with patch(
         "alpenhorn.common.extensions._id_ext",
@@ -122,7 +120,7 @@ def test_import_file_create(xfs, dbtables, unode):
                 )
             )
 
-    after = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
+    after = pw.utcnow() + datetime.timedelta(seconds=1)
 
     # Check DB
     acq = ArchiveAcq.get(name="simplefile_acq")
@@ -212,9 +210,7 @@ def test_import_file_exists(xfs, dbtables, unode, simplefile, archivefilecopy):
     )
     xfs.create_file("/node/simplefile_acq/simplefile")
 
-    before = (datetime.datetime.utcnow() - datetime.timedelta(seconds=1)).replace(
-        microsecond=0
-    )
+    before = (pw.utcnow() - datetime.timedelta(seconds=1)).replace(microsecond=0)
 
     with patch(
         "alpenhorn.common.extensions._id_ext",
@@ -227,7 +223,7 @@ def test_import_file_exists(xfs, dbtables, unode, simplefile, archivefilecopy):
                 )
             )
 
-    after = datetime.datetime.utcnow() + datetime.timedelta(seconds=1)
+    after = pw.utcnow() + datetime.timedelta(seconds=1)
 
     # Check DB
     acq = ArchiveAcq.get(name="simplefile_acq")

--- a/tests/server/test_update_node.py
+++ b/tests/server/test_update_node.py
@@ -2,6 +2,7 @@
 
 import pytest
 import datetime
+import peewee as pw
 from unittest.mock import call, patch, MagicMock
 
 from alpenhorn.db.archive import ArchiveFileCopy
@@ -147,7 +148,7 @@ def test_update_free_space(unode):
     unode.db.avail_gb = 3
     unode.db.save()
 
-    now = datetime.datetime.utcnow()
+    now = pw.utcnow()
     # 2 ** 32 bytes is 4 GiB
     with patch.object(unode.io, "bytes_avail", lambda fast: 2**32):
         unode.update_free_space()
@@ -165,7 +166,7 @@ def test_auto_verify(unode, simpleacq, archivefile, archivefilecopy):
     unode.db.auto_verify = 4
 
     # Last Update time to permit auto verification
-    last_update = datetime.datetime.utcnow() - datetime.timedelta(days=10)
+    last_update = pw.utcnow() - datetime.timedelta(days=10)
 
     # Make some files to verify
     copyY = archivefilecopy(
@@ -213,25 +214,25 @@ def test_auto_verify_time(unode, simpleacq, archivefile, archivefilecopy):
         node=unode.db,
         file=archivefile(name="file9", acq=simpleacq),
         has_file="Y",
-        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=9),
+        last_update=pw.utcnow() - datetime.timedelta(days=9),
     )
     copy8 = archivefilecopy(
         node=unode.db,
         file=archivefile(name="file8", acq=simpleacq),
         has_file="Y",
-        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=8),
+        last_update=pw.utcnow() - datetime.timedelta(days=8),
     )
     copy6 = archivefilecopy(
         node=unode.db,
         file=archivefile(name="file6", acq=simpleacq),
         has_file="Y",
-        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=6),
+        last_update=pw.utcnow() - datetime.timedelta(days=6),
     )
     copy5 = archivefilecopy(
         node=unode.db,
         file=archivefile(name="file5", acq=simpleacq),
         has_file="Y",
-        last_update=datetime.datetime.utcnow() - datetime.timedelta(days=5),
+        last_update=pw.utcnow() - datetime.timedelta(days=5),
     )
 
     unode.run_auto_verify()


### PR DESCRIPTION
peewee-3.17.1 has already done the work of abstracting `utcnow` and `utcfromtimestamp` for the deprecation in 3.12 for us, so let's just import those into `alpenhorn.db` and call it a day.

Closes #191