### PR TITLE
fix(lfs): make HSM interactions more robust

### DIFF
--- a/alpenhorn/db/storage.py
+++ b/alpenhorn/db/storage.py
@@ -367,17 +367,18 @@ class StorageNode(base_model):
         """
         # The value in the database is in GiB (2**30 bytes)
         if new_avail is None:
-            self.avail_gb = None
+            # Warn unless we never knew the free space
+            if self.avail_gb is not None:
+                log.warning(f'Unable to determine available space for "{self.name}".')
         else:
             self.avail_gb = new_avail / 2**30
+
+        # Record check time, even if we failed to update
         self.avail_gb_last_checked = pw.utcnow()
 
         # Update the DB with the free space but don't clobber changes made
-        # manually to the database
+        # manually to the database.
         self.save(only=[StorageNode.avail_gb, StorageNode.avail_gb_last_checked])
-
-        if new_avail is None:
-            log.info(f'Unable to determine available space for "{self.name}".')
 
 
 class StorageTransferAction(base_model):

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -75,6 +75,9 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
     Optional io_config keys:
         * lfs : string
             the lfs(1) executable.  Defaults to "lfs"; may be a full path.
+        * lfs_timeout: the timeout, in seconds, for an lfs(1) call.  Calls
+            that run longer than this will be abandonned.  Defaults to 60
+            seconds if not given.
         * fixed_quota : integer
             the quota, in kiB, on the Lustre disk backing the HSM system
         * release_check_count : integer

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -38,10 +38,6 @@ del TYPE_CHECKING
 
 log = logging.getLogger(__name__)
 
-# Retry delays (in seconds) after a successful or timed-out hsm_restore request
-RESTORE_TIMEOUT_RETRY = 1 * 3600  # 1 hour
-RESTORE_SUCCESS_RETRY = 4 * 3600  # 4 hours
-
 
 class LustreHSMNodeRemote(BaseNodeRemote):
     """LustreHSMNodeRemote: information about a LustreHSM remote node."""
@@ -96,16 +92,12 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         self._headroom = config["headroom"] * 2**10  # convert from kiB
 
         # QueryWalker for the HSM state check
-        self._release_qw = None
+        self._statecheck_qw = None
 
         # Tracks files we're in the process of retrieving, so we can avoid
         # waiting for the same file twice.  The elements in this set are
         # `ArchiveFile.id`s
         self._restoring = set()
-
-        # The time.monotonic value after which we should try to restore again.
-        # Keys are elements in self._restoring.
-        self._restore_retry = dict()
 
         # For informational purposes.  Keys are elements in self._restoring.
         self._restore_start = dict()
@@ -140,14 +132,28 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         # What's the current situation?
         state = self._lfs.hsm_state(copy.path)
 
-        if state == self._lfs.HSM_MISSING:
-            log.warning(f"Unable to restore {copy.path}: missing.")
+        if state == None:
+            log.warning(f"Unable to restore {copy.path}: state check failed.")
             self._restore_start.pop(copy.file.id, None)
-            self._restore_retry.pop(copy.file.id, None)
             self._restoring.discard(copy.file.id)
             return None
 
-        if state != self._lfs.HSM_RELEASED:
+        if state == self._lfs.HSM_MISSING:
+            log.warning(f"Unable to restore {copy.path}: missing.")
+            self._restore_start.pop(copy.file.id, None)
+            self._restoring.discard(copy.file.id)
+            return None
+
+        if state == self._lfs.HSM_RESTORING:
+            if copy.file.id not in self._restoring:
+                self._restoring.add(copy.file.id)
+                self._restore_start[copy.file.id] = time.monotonic()
+
+            log.debug(f"Restore in progress: {copy.path}")
+
+            # Tell the caller to wait
+            return True
+        elif state != self._lfs.HSM_RELEASED:
             # i.e. file is restored or unarchived, so we're done.
             if copy.file.id not in self._restoring:
                 log.debug(f"Already restored: {copy.path}")
@@ -157,54 +163,30 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
                     f"{copy.file.path} restored on node {self.node.name}"
                     f"after {pretty_deltat(deltat)}"
                 )
-                self._restore_start.pop(copy.file.id, None)
-                self._restore_retry.pop(copy.file.id, None)
+                del self._restore_start[copy.file.id]
                 self._restoring.discard(copy.file.id)
             return False
 
         # If we got here, copy is released.
+        if copy.file.id not in self._restoring:
+            self._restoring.add(copy.file.id)
+            self._restore_start[copy.file.id] = time.monotonic()
 
-        # Have we hit the retry time for an in-progress restore?
-        retry_restore = (
-            copy.file.id in self._restoring
-            and self._restore_retry[copy.file.id] <= time.monotonic()
-        )
+        # Try to restore it.
+        result = self._lfs.hsm_restore(copy.path)
 
-        if retry_restore or copy.file.id not in self._restoring:
-            # Add this copy to the list of copies we're waiting on.  Other tasks
-            # can use this to see if the file they're interested in is already
-            # "in use".
-            if not retry_restore:
-                self._restoring.add(copy.file.id)
-                self._restore_start[copy.file.id] = time.monotonic()
+        if result is False:
+            log.warning(f"Restore request failed: {copy.path}")
+            # Reqeust failed. Abandon the restore attempt entirely,
+            # in case it was deleted from the node.
+            del self._restore_start[copy.file.id]
+            self._restoring.discard(copy.file.id)
 
-            # Try to restore it.
-            result = self._lfs.hsm_restore(copy.path)
-            log.warning(f"restore result: {result}")
-
-            if result is False:
-                # Reqeust failed. Abandon the restore attempt entirely,
-                # in case it was deleted from the node.
-                self._restore_retry.pop(copy.file.id, None)
-                self._restore_start.pop(copy.file.id, None)
-                self._restoring.discard(copy.file.id)
-
-                # Report failure
-                return None
-            elif result is None:
-                # Request timeout.  This seems to happen when the file
-                # is already being restored, but let's try again in a
-                # little while, just to be safe.
-                self._restore_retry[copy.file.id] = (
-                    time.monotonic() + RESTORE_TIMEOUT_RETRY
-                )
-            else:
-                # Request success; restore should be in-progress, but
-                # we'll still schedule a retry for some time in the future
-                # to guard against HSM forgetting/abandonning our request
-                self._restore_retry[copy.file.id] = (
-                    time.monotonic() + RESTORE_SUCCESS_RETRY
-                )
+            # Report failure
+            return None
+        elif result is None:
+            # Might have worked.  Caller should check again in a bit.
+            log.warning(f"Restore request timeout: {copy.path}")
 
         # Tell the caller to wait
         return True
@@ -217,7 +199,13 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         to happen (i.e. the node is currently idle).
         """
 
-        headroom_needed = self._headroom - self._lfs.quota_remaining(self.node.root)
+        # Can't do anything if we don't know how much free space we have
+        size_gib = self.node.avail_gb
+        if size_gib is None:
+            log.debug("Skipping release_files: free space unknown.")
+            return
+
+        headroom_needed = self._headroom - int(size_gib * 2**30)
 
         # Nothing to do
         if headroom_needed <= 0:
@@ -238,8 +226,8 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
                 )
                 .order_by(ArchiveFileCopy.last_update)
             ):
-                # Skip unarchived files
-                if not lfs.hsm_archived(copy.path):
+                # The only files we can release are ones that are fully restored
+                if lfs.hsm_state(copy.path) != lfs.HSM_RESTORED:
                     continue
 
                 log.debug(
@@ -308,9 +296,9 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         super().idle_update(newly_idle)
 
         # Check the query walker.  Initialised if necessary.
-        if self._release_qw is None:
+        if self._statecheck_qw is None:
             try:
-                self._release_qw = QueryWalker(
+                self._statecheck_qw = QueryWalker(
                     ArchiveFileCopy,
                     ArchiveFileCopy.node == self.node,
                     ArchiveFileCopy.has_file == "Y",
@@ -320,17 +308,21 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
 
         # Try to get a bunch of copies to check
         try:
-            copies = self._release_qw.get(self._nrelease)
+            copies = self._statecheck_qw.get(self._nrelease)
         except pw.DoesNotExist:
             # Not sure why all the file copies have gone away, but given there's
             # nothing on the node now, can't hurt to re-init the QW in this case
-            self._release_qw = None
+            self._statecheck_qw = None
             return
 
         def _async(task, node, lfs, copies):
             for copy in copies:
                 state = lfs.hsm_state(copy.path)
-                if state == lfs.HSM_MISSING:
+                if state is None:
+                    log.warning(
+                        f"Unable to determine state for {copy.file.path} on node {node.name}."
+                    )
+                elif state == lfs.HSM_MISSING:
                     # File is unexpectedly gone.
                     log.warning(
                         f"File copy {copy.file.path} on node {node.name} is missing!"
@@ -338,7 +330,7 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
                     ArchiveFileCopy.update(
                         has_file="N", ready=False, last_update=utcnow()
                     ).where(ArchiveFileCopy.id == copy.id).execute()
-                elif state == lfs.HSM_RELEASED:
+                elif state == lfs.HSM_RELEASED or state == lfs.HSM_RESTORING:
                     if copy.ready:
                         log.info(f"Updating file copy {copy.file.path}: ready -> False")
                         ArchiveFileCopy.update(ready=False, last_update=utcnow()).where(
@@ -452,6 +444,19 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         """
         return self.node.active
 
+    def exists(self, path: pathlib.PurePath) -> bool:
+        """Does `path` exist?
+
+        Checks whether `lfs hsm_state` returns ENOENT.
+
+        Parameters
+        ----------
+        path : pathlib.PurePath
+            path relative to `node.root`
+        """
+        full_path = pathlib.PurePath(self.node.root).joinpath(path)
+        return self._lfs.hsm_state(full_path) != self._lfs.HSM_MISSING
+
     def filesize(self, path: pathlib.Path, actual: bool = False) -> int:
         """Return size in bytes of the file given by `path`.
 
@@ -508,7 +513,10 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         # Make abs path
         p = pathlib.Path(self.node.root, path)
 
-        if self._lfs.hsm_released(p):
+        state = self._lfs.hsm_state(p)
+        if state is None:
+            raise OSError(f"Can't get state for {path}.")
+        if state != self._lfs.HSM_RESTORED and state != self._lfs.HSM_UNARCHIVED:
             raise OSError(f"{path} is not restored.")
         return open(p, mode="rb" if binary else "rt")
 
@@ -559,7 +567,7 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
             restore_wait = node_io._restore_wait(copy)
             while restore_wait:
                 # Wait for a bit
-                yield 60
+                yield 600
 
                 # Now check again
                 restore_wait = node_io._restore_wait(copy)

--- a/alpenhorn/io/lustrequota.py
+++ b/alpenhorn/io/lustrequota.py
@@ -37,6 +37,9 @@ class LustreQuotaNodeIO(DefaultNodeIO):
         * fixed_quota: a fixed number of kiB to use to override the max quota
             reported by the "lfs quota" command.
         * lfs: the lfs(1) executable.  Defaults to "lfs"; may be a full path.
+        * lfs_timeout: the timeout, in seconds, for an lfs(1) call.  Calls
+            that run longer than this will be abandonned.  Defaults to 60
+            seconds if not given.
 
     Notes
     -----
@@ -62,6 +65,7 @@ class LustreQuotaNodeIO(DefaultNodeIO):
             quota_group=config["quota_group"],
             fixed_quota=config.get("fixed_quota", None),
             lfs=config.get("lfs", "lfs"),
+            timeout=config.get("lfs_timeout", None),
         )
 
     # I/O METHODS

--- a/alpenhorn/server/update.py
+++ b/alpenhorn/server/update.py
@@ -301,8 +301,10 @@ class UpdateableNode(updateable_base):
 
         self.db.update_avail_gb(bytes_avail)
 
-        if bytes_avail is not None:
-            log.info(f"Node {self.name}: {util.pretty_bytes(bytes_avail)} available.")
+        if self.db.avail_gb is not None:
+            log.info(
+                f"Node {self.name}: {util.pretty_bytes(self.db.avail_gb * 2**30)} available."
+            )
 
     def run_auto_verify(self) -> None:
         """Run auto-verification on this node.

--- a/tests/db/test_storage.py
+++ b/tests/db/test_storage.py
@@ -368,13 +368,22 @@ def test_update_avail_gb(simplenode):
     node = StorageNode.get(id=simplenode.id)
     after = pw.utcnow()
 
-    assert node.avail_gb == 10000.0 / 2.0**30
+    avail = node.avail_gb
+    assert avail == 10000.0 / 2.0**30
     assert node.avail_gb_last_checked >= before
     assert node.avail_gb_last_checked <= after
 
-    # Test None
+    # Reset time
+    StorageNode.update(avail_gb_last_checked=0).where(
+        StorageNode.id == simplenode.id
+    ).execute()
+
+    # Test None -- shouldn't change value, but last
+    # update has happened
     simplenode.update_avail_gb(None)
-    assert StorageNode.get(id=simplenode.id).avail_gb is None
+    node = StorageNode.get(id=simplenode.id)
+    assert node.avail_gb == avail
+    assert node.avail_gb_last_checked >= after
 
 
 def test_edge_model(storagetransferaction, storagenode, storagegroup):

--- a/tests/io/test_lustrehsmgroup.py
+++ b/tests/io/test_lustrehsmgroup.py
@@ -131,6 +131,13 @@ def test_idle(queue, group):
         assert group.idle is True
 
 
+@pytest.mark.lfs_hsm_state(
+    {
+        "/hsm/test/one": "restored",
+        "/hsm/test/two": "released",
+        "/hsm/test/three": "missing",
+    }
+)
 def test_exists(xfs, group):
     """Test TransportGroupIO.exists()."""
     group, hsm, smallfile = group

--- a/tests/server/test_auto_import.py
+++ b/tests/server/test_auto_import.py
@@ -9,6 +9,7 @@ from watchdog.observers.api import BaseObserver, ObservedWatch
 
 from alpenhorn.db.archive import ArchiveFileCopy
 from alpenhorn.db.acquisition import ArchiveAcq, ArchiveFile
+from alpenhorn.io.lfs import HSMState
 from alpenhorn.server import auto_import
 from alpenhorn.server.update import UpdateableNode
 
@@ -54,8 +55,8 @@ def test_import_file_not_ready(dbtables, queue, simplenode, mock_lfs):
     # _import_file is a generator function, so it needs to be interated to run.
     assert next(auto_import._import_file(None, unode, pathlib.PurePath("acq/file"))) > 0
 
-    # File has been restored
-    assert not mock_lfs("").hsm_released("/node/acq/file")
+    # File is being restored
+    assert mock_lfs("").hsm_state("/node/acq/file") == HSMState.RESTORING
 
 
 def test_import_file_no_ext(dbtables, unode):

--- a/tests/server/test_service.py
+++ b/tests/server/test_service.py
@@ -109,6 +109,7 @@ def e2e_db(xfs, clidb_noinit, hostname):
         root="/nl1",
         host=hostname,
         active=True,
+        avail_gb=2000.0 / 2**30,
         # This is mostly ignored
         io_config='{"quota_group": "qgroup", "headroom": 10}',
     )
@@ -128,6 +129,7 @@ def e2e_db(xfs, clidb_noinit, hostname):
         host=hostname,
         active=True,
         io_config='{"quota_group": "qgroup", "headroom": 1, "release_check_count": 1}',
+        avail_gb=2000.0 / 2**30,
     )
     StorageNode.create(name="sf2", group=nlgrp, root="/sf2", host=hostname, active=True)
     xfs.create_file("/sf2/ALPENHORN_NODE", contents="sf2")
@@ -305,7 +307,6 @@ def e2e_config(xfs, hostname, clidb_uri):
     xfs.create_file("/etc/alpenhorn/alpenhorn.conf", contents=yaml.dump(config))
 
 
-@pytest.mark.lfs_quota_remaining(2000)
 @pytest.mark.lfs_hsm_state(
     {
         "/nl2/acq1/correct.me": "restored",
@@ -323,7 +324,7 @@ def test_cli(e2e_db, e2e_config, mock_lfs, mock_rsync, loop_once):
     # Check HSM
     lfs = mock_lfs(quota_group="qgroup")
     assert lfs.hsm_state("/nl2/acq1/correct.me") == lfs.HSM_RESTORED
-    assert lfs.hsm_state("/nl1/acq1/restore.me") == lfs.HSM_RESTORED
+    assert lfs.hsm_state("/nl1/acq1/restore.me") == lfs.HSM_RESTORING
     assert lfs.hsm_state("/nl1/acq1/release.me") == lfs.HSM_RELEASED
 
     # Check results


### PR DESCRIPTION
## All  `lfs` calls need a timeout
It seems pretty clear now that `lfs` invocation should always have a timeout to guard against Lustre locking-up all our workers.  So, now use a 1-minute timeout by default in `run_lfs`.

Then, handle both `lfs quota` and `lfs hsm_state` not returning successfully.  In `StorageNode.update_avail_gb`, passing `None` now means don't update `avail.gb` (but do still update the last check time).  If the current value of `avail_gb` is not null/None, a warning is issued.

For `hsm_state` failing, various places in `LustreHSM` where it was used now handles not being able to determine the state.

Also removed an unnecessary `lfs quota` invocation from the idle update `LustreHSMNodeIO.release_files()`

## Using `hsm_action` to probe HSM restores in-progress
I was reading through the lustre source code last night to see if I could figure out what's up with `hsm_restore` timing out when files are in the process of being restored.

I didn't figure that out because I discovered, instead, the `hsm_action` command which tells you what HSM is currently doing to a file (e.g. is it working on restoring it?).

So, there's another `HSMState`: `RESTORING` for files which HSM is in the process of restoring, and alpenhorn will now use that to track progress during restores.  This removes the need for `_restore_retry` (because alpenhorn no longer needs to guess as to whether a restore is happening or not).

Closes #198 (because those constants are no longer present).

## Removing stats from LustreHSM
The idea here is: using `stat()` to check for file existance, while avoiding making an external `lfs` call, causes trouble when `/nearline` is acting up because the `stat()` will get a worker stuck in IO-wait, while the `lfs` call can be abandonned (by subprocess timeout) meaning the workers don't get stuck.

So, I've removed the stat from at the top of `lfs.hsm_state`. I originally had it there because I thought that a cheap `stat` would save us from an expensive `lfs` call.  I've modified `lfs_run` to detect and report missing files instead.

I've also re-implemented `LustreHSMNodeIO.exists` to use `lfs` instead of stat-ting the filesystem.