### PR TITLE
fix(db): Fix db.threadsafe

### DIFF
--- a/alpenhorn/common/extensions.py
+++ b/alpenhorn/common/extensions.py
@@ -275,7 +275,6 @@ def io_module(name: str) -> ModuleType:
 
     # Try to load the module from alpenhorn.io
     try:
-        log.info(f"importing: alpenhorn.io.{name}")
         return importlib.import_module("alpenhorn.io." + name)
     except ImportError:
         # No alpenhorn.io module, maybe it's an extension module

--- a/alpenhorn/common/util.py
+++ b/alpenhorn/common/util.py
@@ -6,6 +6,7 @@ import click
 import socket
 import hashlib
 import logging
+import subprocess
 
 from . import config, extensions, logger
 
@@ -111,8 +112,6 @@ def run_command(
     stderr : string
         Value of stderr.
     """
-
-    import subprocess
 
     log.debug(f"Running command [timeout={timeout}]: " + " ".join(cmd))
 

--- a/alpenhorn/db/_base.py
+++ b/alpenhorn/db/_base.py
@@ -15,12 +15,8 @@ log = logging.getLogger(__name__)
 # We store the database extension here
 _db_ext = None
 
-# Module attributes
-# =================
-# These are all initialised by connect()
-
+# Initialised by connect()
 database_proxy = pw.Proxy()
-threadsafe = None
 
 
 def _capability(key: str) -> Any:
@@ -66,6 +62,11 @@ def _capability(key: str) -> Any:
             raise KeyError(f"unknown database capability: {key}")
 
 
+def threadsafe() -> bool:
+    """Returns bool indicating whether the database is threadsafe."""
+    return _capability("reentrant")
+
+
 def connect() -> None:
     """Connect to the database.
 
@@ -80,10 +81,6 @@ def connect() -> None:
         # dict defined in _capability()
         log.debug("Using internal database module.")
         _db_ext = dict()
-
-    # Tell everyone whether we're threadsafe
-    global threadsafe
-    threadsafe = _capability("reentrant")
 
     # If fetch the database config, if present
     if "database" in config.config:

--- a/alpenhorn/server/service.py
+++ b/alpenhorn/server/service.py
@@ -46,11 +46,12 @@ def cli(conf):
     queue = FairMultiFIFOQueue()
 
     # If we can be multithreaded, start the worker pool
-    if db.threadsafe:
+    if db.threadsafe():
         wpool = pool.WorkerPool(
             num_workers=config.config["service"]["num_workers"], queue=queue
         )
     else:
+        log.warning("Database is not threadsafe: forcing serial I/O.")
         # EmptyPool acts like WorkerPool, but always has zero workers
         wpool = pool.EmptyPool()
 


### PR DESCRIPTION
Something I found while testing #210:

If we want db._base.threadsafe to be imported into `__init__`, it can't be a scalar (because it's going to change after the import).

Instead, make it a function.

Bonus: no need to try to import `subprocess` every time a command is run.  Just import it once at module import.