### PR TITLE
fix(service.update): Don't cancel AFCR for suspect files

### DIFF
--- a/alpenhorn/db/storage.py
+++ b/alpenhorn/db/storage.py
@@ -240,8 +240,8 @@ class StorageNode(base_model):
         # Check has_file
         return copy.has_file != "N"
 
-    def filecopy_present(self, file: ArchiveFile) -> bool:
-        """Is a copy of ArchiveFile `file` present on this node?
+    def filecopy_state(self, file: ArchiveFile) -> str:
+        """What is the state of `file` on this node?
 
         Parameters
         ----------
@@ -250,22 +250,25 @@ class StorageNode(base_model):
 
         Returns
         -------
-        filecopy_present : bool
-            True if there is an ArchiveFileCopy of `file`r
-            with `has_file=='Y'` on this node.  False otherwise.
+        filecopy_state : str
+            One of:
+            - 'Y' file copy exists
+            - 'X' file copy is corrupt
+            - 'M' file copy needs to be checked
+            - 'N' file copy does not exist
         """
         from .archive import ArchiveFileCopy
 
         try:
-            ArchiveFileCopy.get(
+            copy = ArchiveFileCopy.get(
                 ArchiveFileCopy.file == file,
                 ArchiveFileCopy.node == self,
-                ArchiveFileCopy.has_file == "Y",
             )
+            return copy.has_file
         except pw.DoesNotExist:
-            return False
+            pass
 
-        return True
+        return "N"
 
     def get_total_gb(self) -> float:
         """Sum the size in GiB of all files on this node.

--- a/tests/db/test_storage.py
+++ b/tests/db/test_storage.py
@@ -282,19 +282,27 @@ def test_namedcopytracked(simplegroup, storagenode, simplefile, archivefilecopy)
     assert node.named_copy_tracked(acqname, filename) is False
 
 
-def test_copypresent(simplegroup, storagenode, simplefile, archivefilecopy):
-    """Test StorageNode.filecopy_present()."""
+def test_node_copystate(simplegroup, storagenode, simplefile, archivefilecopy):
+    """Test StorageNode.filecopy_state()."""
 
     node = storagenode(name="present", group=simplegroup)
     archivefilecopy(file=simplefile, node=node, has_file="Y")
-    assert node.filecopy_present(simplefile) is True
+    assert node.filecopy_state(simplefile) == "Y"
+
+    node = storagenode(name="suspect", group=simplegroup)
+    archivefilecopy(file=simplefile, node=node, has_file="M")
+    assert node.filecopy_state(simplefile) == "M"
 
     node = storagenode(name="corrupt", group=simplegroup)
     archivefilecopy(file=simplefile, node=node, has_file="X")
-    assert node.filecopy_present(simplefile) is False
+    assert node.filecopy_state(simplefile) == "X"
+
+    node = storagenode(name="removed", group=simplegroup)
+    archivefilecopy(file=simplefile, node=node, has_file="N")
+    assert node.filecopy_state(simplefile) == "N"
 
     node = storagenode(name="missing", group=simplegroup)
-    assert node.filecopy_present(simplefile) is False
+    assert node.filecopy_state(simplefile) == "N"
 
 
 def test_allfiles(simplenode, simpleacq, archivefile, archivefilecopy):


### PR DESCRIPTION
Instead, they'll be skipped until someone gets around to checking the file.

Closes #211

I've replaced `StorageNode.filecopy_present` with `filecopy_state` which simply returns `('N', 'X', 'M', 'Y')` and leaves it to the caller to decide what "present" means, since the two places we were calling this function, there were different meanings.