### PR TITLE
feat(server): A few optimations for deep queues

### DIFF
--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -427,15 +427,16 @@ def copy_request_done(
             stderr = "Unspecified error."
         if check_src:
             # If the copy didn't work, then the remote file may be corrupted.
-            log.error(f"Copy failed: {stderr};  Marking source file suspect.")
+            log.error(f"Copy failed.  Marking source file suspect.")
+            log.info(f"Output: {stderr}")
             ArchiveFileCopy.update(has_file="M", last_update=utcnow()).where(
                 ArchiveFileCopy.file == req.file,
                 ArchiveFileCopy.node == req.node_from,
             ).execute()
         else:
-            # An error occurred that can't be due to the source
-            # being corrupt
-            log.error(f"Copy failed: {stderr}")
+            # An error occurred that can't be due to the source being corrupt
+            log.error(f"Copy failed")
+            log.info(f"Output: {stderr}")
         return False
 
     # Otherwise, transfer was completed, remember end time

--- a/alpenhorn/server/update.py
+++ b/alpenhorn/server/update.py
@@ -466,6 +466,7 @@ class UpdateableNode(updateable_base):
             self.update_delete()
 
             # Prepare files for pulls out from this node
+            remote = RemoteNode(self.db)
             for req in ArchiveFileCopyRequest.select().where(
                 ArchiveFileCopyRequest.completed == 0,
                 ArchiveFileCopyRequest.cancelled == 0,
@@ -473,8 +474,9 @@ class UpdateableNode(updateable_base):
             ):
                 state = self.db.filecopy_state(req.file)
                 if state == "Y":
-                    self._io_happened = True
-                    self.io.ready_pull(req)
+                    if not remote.io.pull_ready(req.file):
+                        self._io_happened = True
+                        self.io.ready_pull(req)
                 else:
                     reasons = {
                         "N": "not present",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -543,6 +543,8 @@ def mockio():
     Access the mocks via mockio.group and mockio.node.
     """
     # The I/O instances
+    remote = MagicMock()
+    remote.pull_ready.return_value = False
     node = MagicMock()
     node.bytes_avail.return_value = 10000
     node.fifo = "n:mockio"
@@ -552,11 +554,19 @@ def mockio():
     # This is our mock I/O module
     class MockIO:
         # The I/O "classes"
+        def MockNodeRemote(*args, **kwargs):
+            nonlocal remote
+            remote._instance_args = args
+            remote._instance_kwargs = kwargs
+            return remote
+
         def MockNodeIO(*args, **kwargs):
             nonlocal node
             node._instance_args = args
             node._instance_kwargs = kwargs
             return node
+
+        MockNodeIO.remote_class = MockNodeRemote
 
         def MockGroupIO(*args, **kwargs):
             nonlocal group
@@ -564,6 +574,7 @@ def mockio():
             node._instance_kwargs = kwargs
             return group
 
+    MockIO.remote = remote
     MockIO.node = node
     MockIO.group = group
 

--- a/tests/io/test_defaultnode_pull.py
+++ b/tests/io/test_defaultnode_pull.py
@@ -441,3 +441,22 @@ def test_pull_fail_unlink(xfs, queue, pull_async):
 
     # File is gone
     assert not path.exists()
+
+
+def test_pull_already_done(xfs, queue, pull_async, archivefilecopy):
+    """Test pulling a file that's already on the node."""
+
+    node, req = pull_async
+
+    # Create the archivefilecopy record
+    archivefilecopy(file=req.file, node=node.db, has_file="Y", wants_file="Y")
+
+    # Call the async
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # Pull cancelled
+    afcr = ArchiveFileCopyRequest.get(id=req.id)
+    assert afcr.completed is False
+    assert afcr.cancelled is True


### PR DESCRIPTION
A couple of changes to reduce the amount of churn when it's taking a long time between job submission and execution because of a lot of other stuff already in the queue:

* when looking for file to ready for a remote pull, don't (re-)submit a ready job for things that are already ready (which is harmless to do, but not in any way helpful

* at the start of a pull job, re-check whether the file copy already exists on the destination node.  Again: would be harmless not to check: a new copy of the same file would overwrite the old one, but there's no harm to checking.

  This takes care of the case when two pulls for the same file happen in series.  It does not solve the case of the two identical pulls occurring in parallel.