### PR TITLE
feat(CLI): StorageTransferAction support

### DIFF
--- a/alpenhorn/cli/group/__init__.py
+++ b/alpenhorn/cli/group/__init__.py
@@ -5,6 +5,7 @@ import peewee as pw
 
 from ...db import StorageGroup, StorageNode
 
+from .autosync import autosync
 from .create import create
 from .list import list_
 from .modify import modify
@@ -17,6 +18,7 @@ def cli():
     """Manage Storage Groups."""
 
 
+cli.add_command(autosync, "autosync")
 cli.add_command(create, "create")
 cli.add_command(list_, "list")
 cli.add_command(modify, "modify")

--- a/alpenhorn/cli/group/autosync.py
+++ b/alpenhorn/cli/group/autosync.py
@@ -1,0 +1,76 @@
+"""alpenhorn group auto-sync command"""
+
+import click
+import peewee as pw
+
+from ...db import StorageGroup, StorageNode, StorageTransferAction, database_proxy
+from ..cli import echo
+
+
+@click.command()
+@click.argument("group_name", metavar="GROUP")
+@click.argument("node_name", metavar="NODE")
+@click.option(
+    "--remove",
+    is_flag=True,
+    help="Remove (instead of add) NODE as an auto-sync source.",
+)
+@click.pass_context
+def autosync(ctx, group_name, node_name, remove):
+    """Manage auto-sync sources for this group.
+
+    This allows you to add (the default) or remove (using --remove)
+    the StorageNode named NODE as a an auto-sync souce for the Storage
+    Group named GROUP.
+
+    If NODE is added as an auto-sync source for GROUP, then, whenever
+    a file is added to NODE, it will be automatically synced into the
+    Group GROUP, so long as the file isn't already present in the Group.
+    """
+
+    with database_proxy.atomic():
+        try:
+            group = StorageGroup.get(name=group_name)
+        except pw.DoesNotExist:
+            raise click.ClickException(f"no such group: {group_name}")
+
+        try:
+            node = StorageNode.get(name=node_name)
+        except pw.DoesNotExist:
+            raise click.ClickException(f"no such node: {node_name}")
+
+        # Sanity check: can't auto-sync within a group
+        if group == node.group and not remove:
+            raise click.ClickException(
+                "can't enable auto-sync: "
+                f'Node "{node_name}" is in group "{group_name}"'
+            )
+
+        # What's the current state?
+        try:
+            action = StorageTransferAction.get(node_from=node, group_to=group)
+            if action.autosync is not remove:
+                echo("No change")
+                ctx.exit()
+        except pw.DoesNotExist:
+            # No need to create a record to set autosync to zero
+            if remove:
+                echo("No change")
+                ctx.exit()
+            action = None
+
+        # Upsert the change
+        if action:
+            StorageTransferAction.update(autosync=not remove).where(
+                StorageTransferAction.id == action.id
+            ).execute()
+        else:
+            StorageTransferAction.create(
+                node_from=node, group_to=group, autosync=not remove
+            )
+
+        echo(
+            'Auto-sync from "'
+            + node.name
+            + ('" started' if not remove else '" stopped.')
+        )

--- a/alpenhorn/cli/node/__init__.py
+++ b/alpenhorn/cli/node/__init__.py
@@ -13,6 +13,7 @@ from ...common import util
 from ...db import ArchiveAcq, ArchiveFile, ArchiveFileCopy, StorageGroup, StorageNode
 
 from .activate import activate
+from .autoclean import autoclean
 from .clean import clean
 from .create import create
 from .deactivate import deactivate
@@ -31,6 +32,7 @@ def cli():
 
 
 cli.add_command(activate, "activate")
+cli.add_command(autoclean, "autoclean")
 cli.add_command(clean, "clean")
 cli.add_command(create, "create")
 cli.add_command(deactivate, "deactivate")

--- a/alpenhorn/cli/node/autoclean.py
+++ b/alpenhorn/cli/node/autoclean.py
@@ -1,0 +1,76 @@
+"""alpenhorn node auto-clean command"""
+
+import click
+import peewee as pw
+
+from ...db import StorageGroup, StorageNode, StorageTransferAction, database_proxy
+from ..cli import echo
+
+
+@click.command()
+@click.argument("node_name", metavar="NODE")
+@click.argument("group_name", metavar="GROUP")
+@click.option(
+    "--remove",
+    is_flag=True,
+    help="Remove (instead of add) GROUP as an auto-clean trigger.",
+)
+@click.pass_context
+def autoclean(ctx, group_name, node_name, remove):
+    """Manage auto-clean triggers for this node.
+
+    This allows you to add (the default) or remove (using --remove)
+    the StorageGroup named GROUP as a an auto-clean trigger for the
+    Storage Node named NODE.
+
+    If GROUP is added as an auto-clean trigger for NODE, then, whenever
+    a file is added to GROUP, it will be automatically released for
+    deletion on NODE.
+    """
+
+    with database_proxy.atomic():
+        try:
+            node = StorageNode.get(name=node_name)
+        except pw.DoesNotExist:
+            raise click.ClickException(f"no such node: {node_name}")
+
+        try:
+            group = StorageGroup.get(name=group_name)
+        except pw.DoesNotExist:
+            raise click.ClickException(f"no such group: {group_name}")
+
+        # Sanity check: can't auto-clean within a group
+        if group == node.group and not remove:
+            raise click.ClickException(
+                "can't enable auto-clean: "
+                f'Node "{node_name}" is in group "{group_name}"'
+            )
+
+        # What's the current state?
+        try:
+            action = StorageTransferAction.get(node_from=node, group_to=group)
+            if action.autoclean is not remove:
+                echo("No change")
+                ctx.exit()
+        except pw.DoesNotExist:
+            # No need to create a record to set autoclean to zero
+            if remove:
+                echo("No change")
+                ctx.exit()
+            action = None
+
+        # Upsert the change
+        if action:
+            StorageTransferAction.update(autoclean=not remove).where(
+                StorageTransferAction.id == action.id
+            ).execute()
+        else:
+            StorageTransferAction.create(
+                node_from=node, group_to=group, autoclean=not remove
+            )
+
+        echo(
+            'Auto-clean trigger: Group "'
+            + group.name
+            + ('" added' if not remove else '" removed.')
+        )

--- a/tests/cli/group/test_autosync.py
+++ b/tests/cli/group/test_autosync.py
@@ -1,0 +1,106 @@
+"""Test CLI: alpenhorn group autosync"""
+
+import pytest
+from alpenhorn.db import StorageGroup, StorageNode, StorageTransferAction
+
+
+def test_no_group(clidb, cli):
+    """Test autosync with a bad group name."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["group", "autosync", "MISSING", "Node"])
+
+
+def test_no_node(clidb, cli):
+    """Test autosync with a bad node name."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["group", "autosync", "Group", "Node"])
+
+
+def test_node_in_group(clidb, cli):
+    """Can't start autosync with NODE in GROUP."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["group", "autosync", "Group", "Node"])
+
+
+def test_stop_node_in_group(clidb, cli):
+    """But we can stop autosync with NODE in GROUP."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(0, ["group", "autosync", "Group", "Node", "--remove"])
+
+
+def test_start_noop(clidb, cli):
+    """Test autosync already on."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    StorageTransferAction.create(node_from=node, group_to=group, autosync=1)
+
+    cli(0, ["group", "autosync", "Group", "Node"])
+
+
+def test_stop_noop(clidb, cli):
+    """Test stopping autosync already explicity off."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    StorageTransferAction.create(node_from=node, group_to=group, autosync=0)
+
+    cli(0, ["group", "autosync", "Group", "Node", "--remove"])
+
+    assert not StorageTransferAction.get(node_from=node, group_to=group).autosync
+
+
+def test_start_from_stop(clidb, cli):
+    """Test starting autosync already explicitly off."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    StorageTransferAction.create(node_from=node, group_to=group, autosync=0)
+
+    cli(0, ["group", "autosync", "Group", "Node"])
+
+    assert StorageTransferAction.get(node_from=node, group_to=group).autosync
+
+
+def test_stop_from_start(clidb, cli):
+    """Test starting autosync already explicitly off."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    StorageTransferAction.create(node_from=node, group_to=group, autosync=1)
+
+    cli(0, ["group", "autosync", "Group", "Node", "--remove"])
+
+    assert not StorageTransferAction.get(node_from=node, group_to=group).autosync
+
+
+def test_start_create(clidb, cli):
+    """Test starting autosync through record creation."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    cli(0, ["group", "autosync", "Group", "Node"])
+
+    assert StorageTransferAction.get(node_from=node, group_to=group).autosync

--- a/tests/cli/node/test_autoclean.py
+++ b/tests/cli/node/test_autoclean.py
@@ -1,0 +1,106 @@
+"""Test CLI: alpenhorn node autoclean"""
+
+import pytest
+from alpenhorn.db import StorageGroup, StorageNode, StorageTransferAction
+
+
+def test_no_node(clidb, cli):
+    """Test autoclean with a bad node name."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["node", "autoclean", "MISSING", "Group"])
+
+
+def test_no_group(clidb, cli):
+    """Test autoclean with a bad group name."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["node", "autoclean", "Node", "MISSING"])
+
+
+def test_node_in_group(clidb, cli):
+    """Can't add autoclean with NODE in GROUP."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["node", "autoclean", "Node", "Group"])
+
+
+def test_remove_node_in_group(clidb, cli):
+    """But we can remove autoclean with NODE in GROUP."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(0, ["node", "autoclean", "Node", "Group", "--remove"])
+
+
+def test_add_noop(clidb, cli):
+    """Test autoclean already on."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    StorageTransferAction.create(node_from=node, group_to=group, autoclean=1)
+
+    cli(0, ["node", "autoclean", "Node", "Group"])
+
+
+def test_remove_noop(clidb, cli):
+    """Test removing autoclean already explicity off."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    StorageTransferAction.create(node_from=node, group_to=group, autoclean=0)
+
+    cli(0, ["node", "autoclean", "Node", "Group", "--remove"])
+
+    assert not StorageTransferAction.get(node_from=node, group_to=group).autoclean
+
+
+def test_add_from_remove(clidb, cli):
+    """Test adding autoclean already explicitly off."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    StorageTransferAction.create(node_from=node, group_to=group, autoclean=0)
+
+    cli(0, ["node", "autoclean", "Node", "Group"])
+
+    assert StorageTransferAction.get(node_from=node, group_to=group).autoclean
+
+
+def test_remove_from_add(clidb, cli):
+    """Test adding autoclean already explicitly off."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    StorageTransferAction.create(node_from=node, group_to=group, autoclean=1)
+
+    cli(0, ["node", "autoclean", "Node", "Group", "--remove"])
+
+    assert not StorageTransferAction.get(node_from=node, group_to=group).autoclean
+
+
+def test_add_create(clidb, cli):
+    """Test adding autoclean through record creation."""
+
+    group = StorageGroup.create(name="NodeGroup")
+    node = StorageNode.create(name="Node", group=group)
+    group = StorageGroup.create(name="Group")
+
+    cli(0, ["node", "autoclean", "Node", "Group"])
+
+    assert StorageTransferAction.get(node_from=node, group_to=group).autoclean


### PR DESCRIPTION
This is based on my suggestion to remove the `action` group in #202, which I think was ill-defined.

Instead:

* Adds an `--actions` flag to `node show` and `group show` to show relevant `StorageTransferAction`s affecting the node/group.
* Adds an `--all` flag to `node show` and `group show` to provide a way to list everything without having to know what lists what.
* Adds two new commands to manipulate `StorageTransferAction`s:
  * `group auto-sync GROUP NODE` to set/clear the autosync flag
  * `node auto-clean NODE GROUP` to set/clear the autoclean flag

For a given (NODE, GROUP) pair, these two commands modify the same row in the `StorageTransferAction` table (the pair has to be unique in the table).  So, there's ambiguity over which command goes with which "noun". The way I've done it, the command is associated with the object that the auto-action modifies (auto-sync adds files to GROUP; auto-clean deletes files from NODE).  There's probably an argument for doing it the other way; I'm not sure it matters much, so long as we are consistent about it.

Also: should the command names have a dash in them?  Or would `group autosync GROUP NODE` etc. be better?