### PR TITLE
fix(CLI): Re-implement "node verify"

### DIFF
--- a/alpenhorn/cli/group/autosync.py
+++ b/alpenhorn/cli/group/autosync.py
@@ -1,4 +1,4 @@
-"""alpenhorn group auto-sync command"""
+"""alpenhorn group autosync command"""
 
 import click
 import peewee as pw
@@ -13,17 +13,17 @@ from ..cli import echo
 @click.option(
     "--remove",
     is_flag=True,
-    help="Remove (instead of add) NODE as an auto-sync source.",
+    help="Remove (instead of add) NODE as an autosync source.",
 )
 @click.pass_context
 def autosync(ctx, group_name, node_name, remove):
-    """Manage auto-sync sources for this group.
+    """Manage autosync sources for this group.
 
     This allows you to add (the default) or remove (using --remove)
-    the StorageNode named NODE as a an auto-sync souce for the Storage
+    the StorageNode named NODE as a an autosync souce for the Storage
     Group named GROUP.
 
-    If NODE is added as an auto-sync source for GROUP, then, whenever
+    If NODE is added as an autosync source for GROUP, then, whenever
     a file is added to NODE, it will be automatically synced into the
     Group GROUP, so long as the file isn't already present in the Group.
     """
@@ -39,10 +39,10 @@ def autosync(ctx, group_name, node_name, remove):
         except pw.DoesNotExist:
             raise click.ClickException(f"no such node: {node_name}")
 
-        # Sanity check: can't auto-sync within a group
+        # Sanity check: can't autosync within a group
         if group == node.group and not remove:
             raise click.ClickException(
-                "can't enable auto-sync: "
+                "can't enable autosync: "
                 f'Node "{node_name}" is in group "{group_name}"'
             )
 

--- a/alpenhorn/cli/group/show.py
+++ b/alpenhorn/cli/group/show.py
@@ -8,6 +8,7 @@ from tabulate import tabulate
 from ...db import StorageGroup, StorageNode, StorageTransferAction
 from ..cli import echo
 from ..node.stats import get_stats
+from ..options import cli_option
 
 
 @click.command()
@@ -17,7 +18,7 @@ from ..node.stats import get_stats
     is_flag=True,
     help="Show post-transfer auto-actions affecting this group.",
 )
-@click.option("all_", "--all", "-a", is_flag=True, help="Show all additional data.")
+@cli_option("all_", help="Show all additional data.")
 @click.option("--node-details", is_flag=True, help="Show details of listed nodes.")
 @click.option("--node-stats", is_flag=True, help="Show usage stats of listed nodes.")
 def show(group_name, actions, all_, node_details, node_stats):

--- a/alpenhorn/cli/node/autoclean.py
+++ b/alpenhorn/cli/node/autoclean.py
@@ -1,4 +1,4 @@
-"""alpenhorn node auto-clean command"""
+"""alpenhorn node autoclean command"""
 
 import click
 import peewee as pw
@@ -13,17 +13,17 @@ from ..cli import echo
 @click.option(
     "--remove",
     is_flag=True,
-    help="Remove (instead of add) GROUP as an auto-clean trigger.",
+    help="Remove (instead of add) GROUP as an autoclean trigger.",
 )
 @click.pass_context
 def autoclean(ctx, group_name, node_name, remove):
-    """Manage auto-clean triggers for this node.
+    """Manage autoclean triggers for this node.
 
     This allows you to add (the default) or remove (using --remove)
-    the StorageGroup named GROUP as a an auto-clean trigger for the
+    the StorageGroup named GROUP as a an autoclean trigger for the
     Storage Node named NODE.
 
-    If GROUP is added as an auto-clean trigger for NODE, then, whenever
+    If GROUP is added as an autoclean trigger for NODE, then, whenever
     a file is added to GROUP, it will be automatically released for
     deletion on NODE.
     """
@@ -39,10 +39,10 @@ def autoclean(ctx, group_name, node_name, remove):
         except pw.DoesNotExist:
             raise click.ClickException(f"no such group: {group_name}")
 
-        # Sanity check: can't auto-clean within a group
+        # Sanity check: can't autoclean within a group
         if group == node.group and not remove:
             raise click.ClickException(
-                "can't enable auto-clean: "
+                "can't enable autoclean: "
                 f'Node "{node_name}" is in group "{group_name}"'
             )
 

--- a/alpenhorn/cli/node/show.py
+++ b/alpenhorn/cli/node/show.py
@@ -8,6 +8,7 @@ from tabulate import tabulate
 from ...common.util import pretty_bytes
 from ...db import StorageGroup, StorageNode, StorageTransferAction
 from ..cli import echo
+from ..options import cli_option
 from .stats import get_stats
 
 
@@ -18,7 +19,7 @@ from .stats import get_stats
     is_flag=True,
     help="Show post-transfer auto-actions affecting this group.",
 )
-@click.option("all_", "--all", "-a", is_flag=True, help="Show all additional data.")
+@cli_option("all_", help="Show all additional data.")
 @click.option("--stats", is_flag=True, help="Show usage stats of the node.")
 def show(name, actions, all_, stats):
     """Show details of a Storage Node.

--- a/alpenhorn/cli/node/verify.py
+++ b/alpenhorn/cli/node/verify.py
@@ -1,0 +1,292 @@
+"""alpenhorn node verify command"""
+
+from __future__ import annotations
+
+import click
+import peewee as pw
+
+from ...common.util import pretty_bytes
+from ...db import StorageNode, ArchiveAcq, ArchiveFile, ArchiveFileCopy, database_proxy
+from ..options import cli_option, not_both
+from ..cli import check_then_update, echo
+
+
+def _run_query(
+    update: bool,
+    ctx,
+    name: str,
+    acq: list,
+    file_selection: pw.Expression,
+    verify_goal: str,
+    first_time: bool,
+):
+    """Run the veroify query, either in check mode or update mode.
+
+    Must be done twice because the DB contents can change while we wait
+    for the user's confirmation.
+
+    Parameters:
+    -----------
+    update:
+        True if in "update" mode.  False in "count" mode.
+    ctx:
+        click context object
+    name:
+        node name
+    acq:
+        list of --acq arguments, if any
+    file_selection:
+        a peewee.Expression encapsulating the --corrupt, --missing, and
+        --healthy optons.  This is a constraint which will be applied to
+        the `where` clause of the `ArchiveFileCopy` query.
+    verify_goal:
+        The value we want to set has_file to.  This is 'M' except in
+        --cancel mode.
+    """
+
+    with database_proxy.atomic():
+        # Check name
+        try:
+            node = StorageNode.get(name=name)
+        except pw.DoesNotExist:
+            raise click.ClickException("no such node: " + name)
+
+        # Resolve acqs
+        acqs = []
+        for acqname in acq:
+            try:
+                acqs.append(ArchiveAcq.get(name=acqname))
+            except pw.DoesNotExist:
+                raise click.ClickException("No such acquisition: " + acqname)
+
+        # Find all candidate file copies
+        query = ArchiveFileCopy.select(ArchiveFileCopy.id).where(
+            ArchiveFileCopy.node == node, file_selection
+        )
+
+        # Limit to acquisitions, if any
+        if acqs:
+            query = query.join(ArchiveFile).where(ArchiveFile.acq << acqs)
+
+        # Perform the query
+        copies = list(query.execute())
+
+        # Did we match?
+        if not copies:
+            echo("No matching files found.")
+            ctx.exit()
+
+        # Tot everything up.
+        total = (
+            ArchiveFileCopy.select(
+                pw.fn.COUNT(ArchiveFileCopy.id).alias("count"),
+                pw.fn.Sum(ArchiveFile.size_b).alias("size"),
+            )
+            .join(ArchiveFile)
+            .where(ArchiveFileCopy.id << copies)
+            .execute()
+        )[0]
+
+        # Grammar
+        files = "file" if total.count == 1 else "files"
+        if verify_goal != "M":  # i.e. cancelling
+            if update:
+                verb = "Forcing"
+            else:
+                verb = "Would force"
+            what = "status"
+
+            if verify_goal == "Y":
+                goal = " to healthy"
+            elif verify_goal == "N":
+                goal = " to missing"
+            else:
+                goal = " to corrupt"
+        else:
+            if update:
+                verb = "Requesting"
+            else:
+                verb = "Would request"
+            what = "verification"
+            goal = ""
+
+        size = pretty_bytes(total.size) if total.size is not None else "size unknown"
+        echo(f"{verb} {what} of {total.count} {files} ({size}){goal}.")
+
+        if update:
+            # Do the update
+            count = (
+                ArchiveFileCopy.update(has_file=verify_goal)
+                .where(ArchiveFileCopy.id << copies)
+                .execute()
+            )
+            files = "file" if count == 1 else "files"
+            echo(f"Updated {count} {files}.")
+
+
+@click.command()
+@click.argument("name", metavar="NODE")
+@cli_option("acq")
+@cli_option(
+    "all_",
+    help="Ignored if used with --cancel.  Otherwise, verify all files "
+    '(equivalent to "--corrupt --healthy --missing").',
+)
+@click.option(
+    "--cancel",
+    is_flag=True,
+    help="Cancel existing verifcation requests by explicitly setting their status",
+)
+@click.option(
+    "--count",
+    is_flag=True,
+    help="Don't actually perform the operation, just print how many files "
+    "would be affected",
+)
+@click.option(
+    "--corrupt",
+    help="With --cancel, set file status to corrupt.  Without --cancel, "
+    "verify known corrupt files",
+    is_flag=True,
+)
+@click.option(
+    "--force",
+    help="Force update (skips confirmation).  Incompatible with --count",
+    is_flag=True,
+)
+@click.option(
+    "--healthy",
+    help="With --cancel, set file status to healthy.  Without --cancel, "
+    "verify known good files",
+    is_flag=True,
+)
+@click.option(
+    "--missing",
+    help="With --cancel, set file status to missing.  Without --cancel, "
+    "verify known missing files",
+    is_flag=True,
+)
+@click.pass_context
+def verify(ctx, name, acq, all_, cancel, count, corrupt, force, healthy, missing):
+    """Verify files on a Storage Node.
+
+    Use this command to request verification of files on NODE, or to
+    explicitly set the status of suspect files (thus, cancelling verificaiton).
+
+    \b
+    VERIFYING FILES
+    ---------------
+
+    Without the "--cancel" flag, this command requests that the daemon re-verify
+    the integrity of files on NODE.  This is done by changing the status of the
+    files being re-verified to "suspect".
+
+    By default, only files known to be corrupt or missing are verified,
+    but the types of files to re-verify can be explicitly chosen with the
+    --all, --corrupt, --healthy, and --missing flags.  If any of these flags
+    are used, the default selection is ignored.
+
+    Files to verify may be further restricted by specifying one or
+    more acqusitions to limit the operation to (via the --acq option).
+    Files which have been released for immediate removal (via, say, the
+    "node clean" command) are always skipped.
+
+    NOTE: Be careful when you request re-verification.  After this command
+    sets an affected file to "suspect", that file will not be available for
+    other operations (e.g. transfer) until the daemon has re-verified the
+    it.  Re-verification, therefore, is best done during times of low
+    activity on the NODE.
+
+    \b
+    CANCELLING VERIFICATION
+    -----------------------
+
+    With the "--cancel" flag, this command instead, changes the status
+    of matching suspect files to the new status specified by one of the
+    flags "--corrupt", "--missing", or "--healthy".  (If none are given,
+    "--corrupt" is the default.)
+
+    Which files are updated may be further restricted with the "--acq"
+    option.
+
+    NOTE: If you cancel verification of a file which the daemon happens to
+    be in the process of re-verifying, the result of the daemon's check
+    will override whatever status you set manually.
+    """
+    # usage checks
+    not_both(count, "count", force, "force")
+
+    # Cancel and non-cancel modes are fairly different about what most
+    # of the flags mean
+    if cancel:
+        # All is explicitly ignored in cancel mode: we effectively cancel
+        # all matching verification requests
+        not_both(corrupt, "corrupt", healthy, "healthy")
+        not_both(corrupt, "corrupt", missing, "missing")
+        not_both(healthy, "healthy", missing, "missing")
+
+        # We match against suspect files in this case
+        file_selection = (ArchiveFileCopy.has_file == "M") & (
+            ArchiveFileCopy.wants_file != "N"
+        )
+
+        # Our goal is determined by flag.  This is the
+        # value we'll be setting has_file to in the update
+        if healthy:
+            verify_goal = "Y"
+        elif missing:
+            verify_goal = "N"
+        else:
+            # --corrupt is the default, if no flag is given
+            verify_goal = "X"
+    else:
+        # Verify mode; normalise corrupt/missing/healthy flags
+        if all_:
+            corrupt = True
+            missing = True
+            healthy = True
+        elif not corrupt and not healthy and not missing:
+            corrupt = True
+            missing = True
+
+        # In verify mode, we're always going to set has_file to 'M'
+        verify_goal = "M"
+
+        # Build up a peewee.Expression for the types of files we want to find
+        if corrupt:
+            file_selection = (ArchiveFileCopy.has_file == "X") & (
+                ArchiveFileCopy.wants_file != "N"
+            )
+        else:
+            file_selection = None
+
+        if healthy:
+            healthy_expr = (ArchiveFileCopy.has_file == "Y") & (
+                ArchiveFileCopy.wants_file != "N"
+            )
+            if file_selection is None:
+                file_selection = healthy_expr
+            else:
+                file_selection = file_selection | healthy_expr
+
+        if missing:
+            missing_expr = (ArchiveFileCopy.has_file == "N") & (
+                ArchiveFileCopy.wants_file == "Y"
+            )
+            if file_selection is None:
+                file_selection = missing_expr
+            else:
+                file_selection = file_selection | missing_expr
+
+        # Sanity check
+        if file_selection is None:
+            raise RuntimeError("Something went wrong!  Selection expression is empty.")
+
+    # Do a check-then-update with the `_run_query` function.
+    check_then_update(
+        not force,
+        not count,
+        _run_query,
+        ctx,
+        args=[name, acq, file_selection, verify_goal],
+    )

--- a/alpenhorn/cli/options.py
+++ b/alpenhorn/cli/options.py
@@ -19,13 +19,26 @@ def cli_option(option: str, **extra_kwargs):
     """
 
     # Set args for the click.option decorator
-    if option == "address":
+    if option == "acq":
+        args = ("--acq",)
+        kwargs = {
+            "metavar": "ACQ",
+            "default": None,
+            "multiple": True,
+            "help": "May be specified multiple times.  "
+            "Limits operation to files in acquisition(s) named ACQ.",
+        }
+    elif option == "address":
         args = ("--address",)
         kwargs = {
             "metavar": "ADDR",
             "help": "Domain name or IP address to use for remote access to the "
             "node.",
         }
+    elif option == "all_":
+        # Has no help; must be provided when used
+        args = ("all_", "--all", "-a")
+        kwargs = {"is_flag": True}
     elif option == "archive":
         args = ("--archive",)
         kwargs = {
@@ -135,6 +148,12 @@ def cli_option(option: str, **extra_kwargs):
 
     # Update kwargs, if given
     kwargs.update(extra_kwargs)
+
+    # Default help string for common options missing them
+    if "help" not in kwargs:
+        kwargs["help"] = (
+            "SOMEONE FORGOT TO WRITE SOME HELP FOR THIS OPTION.  GOOD LUCK, I GUESS!"
+        )
 
     def _decorator(func):
         nonlocal args, kwargs

--- a/tests/cli/node/test_clean.py
+++ b/tests/cli/node/test_clean.py
@@ -37,7 +37,7 @@ def test_cancel_size(clidb, cli):
     cli(2, ["node", "clean", "NODE", "--cancel", "--size=3"])
 
 
-def test_cancel_size(clidb, cli):
+def test_check_force(clidb, cli):
     """Test --check --force fails."""
 
     group = StorageGroup.create(name="Group")
@@ -64,31 +64,6 @@ def test_bad_size(clidb, cli):
 
     cli(2, ["node", "clean", "NODE", "--size=0"])
     cli(2, ["node", "clean", "NODE", "--size=-1"])
-
-
-def test_bad_size(clidb, cli):
-    """Test non-positive --size."""
-
-    group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
-
-    cli(2, ["node", "clean", "NODE", "--size=0"])
-    cli(2, ["node", "clean", "NODE", "--size=-1"])
-
-
-def test_cancel(clidb, cli):
-    """Test cancelling a clean."""
-
-    group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
-    acq = ArchiveAcq.create(name="Acq")
-    file = ArchiveFile.create(name="File", acq=acq, size_b=1234)
-    ArchiveFileCopy.create(node=node, file=file, has_file="Y", wants_file="Y")
-
-    cli(0, ["node", "clean", "NODE"], input="N\n")
-
-    # Clean should not have run
-    assert ArchiveFileCopy.get(node=node, file=file).wants_file == "Y"
 
 
 def test_run(clidb, cli):

--- a/tests/cli/node/test_verify.py
+++ b/tests/cli/node/test_verify.py
@@ -1,0 +1,383 @@
+"""Test CLI: alpenhorn node verify"""
+
+import pytest
+from datetime import timedelta
+
+from alpenhorn.db import (
+    StorageGroup,
+    StorageNode,
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    utcnow,
+)
+
+
+@pytest.fixture
+def file_gamut(clidb):
+    """Fixture to create the has_file/wants_file gamut of files.
+
+    Yields node and a list of 3-tuples:
+        (has_file, wants_file, ArchiveFileCopy)
+    """
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    acq = ArchiveAcq.create(name="Acq")
+    files = []
+    for has in ["Y", "M", "X", "N"]:
+        for wants in ["Y", "M", "N"]:
+            file = ArchiveFile.create(name="File" + has + wants, acq=acq, size_b=1234)
+            ArchiveFileCopy.create(node=node, file=file, has_file=has, wants_file=wants)
+            files.append((has, wants, file))
+
+    return node, files
+
+
+def test_no_node(clidb, cli):
+    """Test clean with no node."""
+
+    cli(1, ["node", "verify", "TEST"])
+
+
+def test_check_force(clidb, cli):
+    """Test --check --force fails."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+
+    cli(2, ["node", "verify", "NODE", "--check", "--force"])
+
+
+def test_cancel_multistatus(clidb, cli):
+    """Test --cancel with multiple statuses chosen."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+
+    cli(2, ["node", "verify", "NODE", "--cancel", "--corrupt", "--healthy"])
+    cli(2, ["node", "verify", "NODE", "--cancel", "--corrupt", "--missing"])
+    cli(2, ["node", "verify", "NODE", "--cancel", "--healthy", "--missing"])
+
+
+def test_run(clidb, cli, file_gamut):
+    """Test a simple verify."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE"], input="Y\n")
+
+    # Verify should have run on 'XY', 'XM', 'NY'
+    for item in files:
+        if item[0] == "X" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "N" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    # i.e. we didn't update the existing has_file == 'M' copies
+    assert "Updated 3 files" in result.output
+
+
+def test_verify_corrupt(clidb, cli, file_gamut):
+    """Test verify --corupt."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--corrupt"], input="Y\n")
+
+    # Verify should have run on 'XY', 'XM'
+    for item in files:
+        if item[0] == "X" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 2 files" in result.output
+
+
+def test_verify_missing(clidb, cli, file_gamut):
+    """Test verify --missing."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--missing"], input="Y\n")
+
+    # Verify should have run on 'NY' only
+    for item in files:
+        if item[0] == "N" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 1 file" in result.output
+
+
+def test_verify_healthy(clidb, cli, file_gamut):
+    """Test verify --healthy."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--healthy"], input="Y\n")
+
+    # Verify should have run on 'YY', 'YM'
+    for item in files:
+        if item[0] == "Y" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "Y" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 2 files" in result.output
+
+
+def test_corrupt_missing(clidb, cli, file_gamut):
+    """Test explicit verify --corrupt --missing."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--corrupt", "--missing"], input="Y\n")
+
+    # Verify should have run on 'XY', 'XM', 'NY'
+    for item in files:
+        if item[0] == "X" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "N" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    # i.e. we didn't update the existing has_file == 'M' copies
+    assert "Updated 3 files" in result.output
+
+
+def test_corrupt_healtyh(clidb, cli, file_gamut):
+    """Test verify --corrupt --healthy."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--corrupt", "--healthy"], input="Y\n")
+
+    # Verify should have run on 'YY', 'YM', 'XY', 'XM'
+    for item in files:
+        if item[0] == "Y" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "Y" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 4 files" in result.output
+
+
+def test_healthy_missing(clidb, cli, file_gamut):
+    """Test verify --healthy --missing."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--healthy", "--missing"], input="Y\n")
+
+    # Verify should have run on 'YY', 'YM', 'NY'
+    for item in files:
+        if item[0] == "Y" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "Y" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "N" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 3 files" in result.output
+
+
+def test_hmc(clidb, cli, file_gamut):
+    """Test verify --healthy --missing --corrupt."""
+
+    node, files = file_gamut
+
+    result = cli(
+        0,
+        ["node", "verify", "NODE", "--healthy", "--missing", "--corrupt"],
+        input="Y\n",
+    )
+
+    # Verify should have run on 'YY', 'YM', 'XY', 'XM', 'NY'
+    for item in files:
+        if item[0] == "Y" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "Y" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "N" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 5 files" in result.output
+
+
+def test_all(clidb, cli, file_gamut):
+    """Test verify --all.
+
+    Should be the same as the previous --healthy --missing --corrupt test.
+    """
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--all"], input="Y\n")
+
+    # Verify should have run on 'YY', 'YM', 'XY', 'XM', 'NY'
+    for item in files:
+        if item[0] == "Y" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "Y" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "X" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        elif item[0] == "N" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "M"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 5 files" in result.output
+
+
+def test_cancel(clidb, cli, file_gamut):
+    """Test verify --cancel."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--cancel"], input="Y\n")
+
+    # should have run on 'MY', 'MM', and set has_file to 'X'
+    for item in files:
+        if item[0] == "M" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "X"
+        elif item[0] == "M" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "X"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 2 files" in result.output
+
+
+def test_cancel_corrupt(clidb, cli, file_gamut):
+    """Test verify --cancel --corrupt."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--cancel", "--corrupt"], input="Y\n")
+
+    # should have run on 'MY', 'MM', and set has_file to 'X'
+    for item in files:
+        if item[0] == "M" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "X"
+        elif item[0] == "M" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "X"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 2 files" in result.output
+
+
+def test_cancel_missing(clidb, cli, file_gamut):
+    """Test verify --cancel --missing."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--cancel", "--missing"], input="Y\n")
+
+    # should have run on 'MY', 'MM', and set has_file to 'N'
+    for item in files:
+        if item[0] == "M" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "N"
+        elif item[0] == "M" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "N"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 2 files" in result.output
+
+
+def test_cancel_missing(clidb, cli, file_gamut):
+    """Test verify --cancel --healthy."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--cancel", "--healthy"], input="Y\n")
+
+    # should have run on 'MY', 'MM', and set has_file to 'N'
+    for item in files:
+        if item[0] == "M" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "Y"
+        elif item[0] == "M" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "Y"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 2 files" in result.output
+
+
+def test_cancel_all(clidb, cli, file_gamut):
+    """Test --cancel --all (--all should be ignored)."""
+
+    node, files = file_gamut
+
+    result = cli(0, ["node", "verify", "NODE", "--cancel", "--all"], input="Y\n")
+
+    # should have run on 'MY', 'MM', and set has_file to 'X'
+    for item in files:
+        if item[0] == "M" and item[1] == "Y":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "X"
+        elif item[0] == "M" and item[1] == "M":
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == "X"
+        else:
+            assert ArchiveFileCopy.get(node=node, file=item[2]).has_file == item[0]
+
+    assert "Updated 2 files" in result.output
+
+
+def test_verify_bad_acq(clidb, cli, file_gamut):
+    """Test verify with bad --acq."""
+
+    result = cli(1, ["node", "verify", "NODE", "--acq=BAD"])
+
+
+def test_verify_acq(clidb, cli):
+    """Test verify with some --acq constraints."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    acq = ArchiveAcq.create(name="Acq1")
+    file1 = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(node=node, file=file1, has_file="X", wants_file="Y")
+    acq = ArchiveAcq.create(name="Acq2")
+    file2 = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(node=node, file=file2, has_file="X", wants_file="Y")
+    acq = ArchiveAcq.create(name="Acq3")
+    file3 = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(node=node, file=file3, has_file="X", wants_file="Y")
+
+    result = cli(0, ["node", "verify", "NODE", "--acq=Acq1", "--acq=Acq2"], input="Y\n")
+
+    # only 1 and 2 should be updated
+    assert ArchiveFileCopy.get(node=node, file=file1).has_file == "M"
+    assert ArchiveFileCopy.get(node=node, file=file2).has_file == "M"
+    assert ArchiveFileCopy.get(node=node, file=file3).has_file == "X"


### PR DESCRIPTION
This is a re-implementation of "node verify" which removes all I/O from the CLI.

As previously discussed, I think it's difficult to have I/O in the client.  In general, it's difficult to keep I/O clean unless we're
very specific on how I/O works, which we've become less-so with the new I/O framework stuff.  So, keeping I/O to the daemon vastly simplifies things.

Even with the preexisting simplified version of verification that I'm replacing, issues like #141 show how easy it is to get in to situations where verification fails.  The verify-in-cli scheme requires both running where the node is hosted and from a user that has access to the files on the node.

I don't know how we would ever run a CLI-based verify on a node like `cedar_nearline` where it would have to wait for files to be recalled.

This new verify command can also be used to "cancel" a verification, which really means force the `has_file='M'` suspect file into one of the other `has_file` values.

I've taken the check-confirm-update stuff from my implementation of `clean` and put it in a utility function so it can be used elsewhere (like here).

With this PR, I think neither of the issues linked to the verify command are relevant anymore:

* With the removal of I/O from the CLI, where its run is now immaterial: #141
* The underlying problem with #133 was trying to find a way to check files on Storage Nodes hosted where there was no daemon running.  In alpenhorn1 you could do some of the daemon's work in the client, but it was never a complete solution, and in practice we always ended up putting daemons on machines where we had nodes (e.g. the transport disk off-load machine here at UBC), even if that daemon spent most of its time doing nothing.

The current answer to #133 would be: run the daemon to maintain the node.

There are also a couple of commits in this PR tidying up minor things I overlooked in the previous PRs.