### PR TITLE
fix(CLI): fix "db init"

### DIFF
--- a/alpenhorn/cli/cli.py
+++ b/alpenhorn/cli/cli.py
@@ -6,7 +6,6 @@ import click
 import datetime
 import peewee as pw
 
-from .. import db
 from ..common.logger import echo as echo
 from ..db import (
     ArchiveAcq,
@@ -66,30 +65,6 @@ def update_or_remove(field: str, new: str | None, old: str | None) -> dict:
 
 # The rest of this file were top-level commands that have been
 # temporarily dummied out while they're re-tooled.
-
-
-# @cli.command()
-def init():
-    """Initialise an alpenhorn database.
-
-    Creates the database tables required for alpenhorn and any extensions
-    specified in its configuration.
-    """
-
-    # Create any alpenhorn core tables
-    core_tables = [
-        ArchiveAcq,
-        ArchiveFile,
-        ArchiveFileCopy,
-        ArchiveFileCopyRequest,
-        StorageGroup,
-        StorageNode,
-        StorageTransferAction,
-    ]
-
-    db.database_proxy.create_tables(core_tables, safe=True)
-
-    # TODO Create any tables registered by extensions
 
 
 # @cli.command()

--- a/alpenhorn/cli/db/__init__.py
+++ b/alpenhorn/cli/db/__init__.py
@@ -1,0 +1,13 @@
+"""Alpenhorn CLI for operations on the database"""
+
+import click
+
+from .init import init
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def cli():
+    """Manage the Data Index."""
+
+
+cli.add_command(init, "init")

--- a/alpenhorn/cli/db/init.py
+++ b/alpenhorn/cli/db/init.py
@@ -1,0 +1,41 @@
+"""alpenhorn db init command"""
+
+import click
+import peewee as pw
+
+from ...db import (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    StorageGroup,
+    StorageNode,
+    StorageTransferAction,
+    database_proxy,
+)
+
+
+@click.command()
+def init():
+    """Initialise the Data Index.
+
+    This command will create all the database table required
+    by the Alpenhorn Data Index.  Pre-existing tables will not
+    be overwritten.
+
+    The tables created here are required for most of alpenhorn's
+    functionality.
+    """
+
+    # Create any alpenhorn core tables
+    core_tables = [
+        ArchiveAcq,
+        ArchiveFile,
+        ArchiveFileCopy,
+        ArchiveFileCopyRequest,
+        StorageGroup,
+        StorageNode,
+        StorageTransferAction,
+    ]
+
+    database_proxy.create_tables(core_tables, safe=True)

--- a/alpenhorn/cli/entry.py
+++ b/alpenhorn/cli/entry.py
@@ -7,7 +7,7 @@ import click
 from .. import db
 from ..common.util import start_alpenhorn, version_option
 
-from . import acq, group, node, transport
+from . import acq, db, group, node, transport
 from .options import not_both
 
 
@@ -78,6 +78,7 @@ def entry(conf, quiet, verbose, debug):
 
 
 entry.add_command(acq.cli, "acq")
+entry.add_command(db.cli, "db")
 entry.add_command(group.cli, "group")
 entry.add_command(node.cli, "node")
 entry.add_command(transport.cli, "transport")

--- a/tests/cli/db/test_init.py
+++ b/tests/cli/db/test_init.py
@@ -1,0 +1,70 @@
+"""Test CLI: alpenhorn db init"""
+
+import pytest
+import peewee as pw
+
+from alpenhorn.db import (
+    StorageGroup,
+    StorageNode,
+    StorageTransferAction,
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+)
+
+
+def test_init(clidb_noinit, cli):
+    """Test DB init"""
+
+    # No tables
+    with pytest.raises(pw.OperationalError):
+        StorageGroup.create(name="Test")
+
+    cli(0, ["db", "init"])
+
+    # Now we should have tables
+    StorageGroup.create(name="Test")
+    assert StorageGroup.get(name="Test").id == 1
+
+    StorageNode.create(name="Test", group_id=1)
+    assert StorageNode.get(name="Test").id == 1
+
+    StorageTransferAction.create(group_to_id=1, node_from_id=1)
+    assert StorageTransferAction.get(group_to_id=1, node_from_id=1).id == 1
+
+    ArchiveAcq.create(name="Test")
+    assert ArchiveAcq.get(name="Test").id == 1
+
+    ArchiveFile.create(name="Test", acq_id=1)
+    assert ArchiveFile.get(name="Test", acq_id=1).id == 1
+
+    ArchiveFileCopy.create(file_id=1, node_id=1)
+    assert ArchiveFileCopy.get(file_id=1, node_id=1).id == 1
+
+    ArchiveFileCopyRequest.create(file_id=1, node_from_id=1, group_to_id=1)
+    assert ArchiveFileCopyRequest.get(file_id=1, node_from_id=1, group_to_id=1).id == 1
+
+
+def test_init_safe(clidb, cli):
+    """Test DB init doesn't overwrite tables"""
+
+    # Tables are already present
+    StorageGroup.create(name="Test")
+    StorageNode.create(name="Test", group_id=1)
+    StorageTransferAction.create(group_to_id=1, node_from_id=1)
+    ArchiveAcq.create(name="Test")
+    ArchiveFile.create(name="Test", acq_id=1)
+    ArchiveFileCopy.create(file_id=1, node_id=1)
+    ArchiveFileCopyRequest.create(file_id=1, node_from_id=1, group_to_id=1)
+
+    cli(0, ["db", "init"])
+
+    # Tables weren't overwritten
+    assert StorageGroup.get(name="Test").id == 1
+    assert StorageNode.get(name="Test").id == 1
+    assert StorageTransferAction.get(group_to_id=1, node_from_id=1).id == 1
+    assert ArchiveAcq.get(name="Test").id == 1
+    assert ArchiveFile.get(name="Test", acq_id=1).id == 1
+    assert ArchiveFileCopy.get(file_id=1, node_id=1).id == 1
+    assert ArchiveFileCopyRequest.get(file_id=1, node_from_id=1, group_to_id=1).id == 1


### PR DESCRIPTION
Not much to fix here.  The extension tables aren't handled but they can't be unless we were to create some sort of new extension type which provides a list of tables to create.

Given that the only use of such an extension would be to pass them to `create_tables` in this function, it may be more trouble than it's worth.  Probably easier for both alpenhorn and the extension creators to just tell them to create their own tables.

In any case, it's very low priority.

I have another command in the `db` group listed in #202 called `status`.  Not sure it's going to get implemented.  Not sure what it would tell us.