### PR TITLE
feat(daemon): Import request functionality

### DIFF
--- a/alpenhorn/db/__init__.py
+++ b/alpenhorn/db/__init__.py
@@ -37,7 +37,7 @@ thread, typically via the peewee table models provided by this module.
 
 # Table models
 from .acquisition import ArchiveAcq, ArchiveFile
-from .archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from .archive import ArchiveFileCopy, ArchiveFileCopyRequest, ArchiveFileImportRequest
 from .storage import StorageGroup, StorageNode, StorageTransferAction
 
 # Basic functionality

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -300,12 +300,13 @@ class BaseNodeIO:
         """
         raise NotImplementedError("method must be re-implemented in subclass.")
 
-    def file_walk(self) -> Iterator[pathlib.PurePath]:
-        """Iterate over file copies
+    def file_walk(self, path: pathlib.Path) -> Iterator[pathlib.PurePath]:
+        """Iterate through directory `path`.
 
-        Should successively yield a pathlib.PurePath for each file copy on the
-        node.  The returned path may either be absolute (i.e have node.root
-        pre-pended) or else be relative to node.root.  The former is preferred.
+        Should successively yield a pathlib.PurePath for each file under `path`,
+        which is relative to the node `root.  The returned path may either be
+        absolute (i.e have node.root pre-pended) or else be relative to
+        node.root.  The former is preferred.
         """
         raise NotImplementedError("method must be re-implemented in subclass.")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ from alpenhorn.db import (
     ArchiveFile,
     ArchiveFileCopy,
     ArchiveFileCopyRequest,
+    ArchiveFileImportRequest,
     StorageGroup,
     StorageNode,
     StorageTransferAction,
@@ -358,7 +359,7 @@ def mock_statvfs(fs):
 def mock_stat(fs):
     """Mocks pathlib.PosixPath.stat to work with pyfakefs."""
 
-    def _mocked_stat(path):
+    def _mocked_stat(path, follow_symlinks=False):
         """Mock of pathlib.PosixPath.stat to report the size of pyfakefs files."""
         nonlocal fs
 
@@ -504,6 +505,7 @@ def dbtables(dbproxy):
             ArchiveFile,
             ArchiveFileCopy,
             ArchiveFileCopyRequest,
+            ArchiveFileImportRequest,
         ]
     )
 
@@ -686,6 +688,7 @@ def clidb(clidb_noinit):
             ArchiveFile,
             ArchiveFileCopy,
             ArchiveFileCopyRequest,
+            ArchiveFileImportRequest,
         ]
     )
 
@@ -794,6 +797,11 @@ def archivefilecopyrequest(factory_factory):
     return factory_factory(ArchiveFileCopyRequest)
 
 
+@pytest.fixture
+def archivefileimportrequest(factory_factory):
+    return factory_factory(ArchiveFileImportRequest)
+
+
 # Generic versions of the above.  When you just want a record, but don't care
 # what it is.
 
@@ -855,7 +863,7 @@ def simplecopy(
 
 
 @pytest.fixture
-def simplerequest(
+def simplecopyrequest(
     archiveacq,
     archivefile,
     archivefilecopyrequest,
@@ -866,12 +874,27 @@ def simplerequest(
 
     Creates all necessary backrefs.
     """
-    acq = archiveacq(name="simplerequest_acq")
-    file = archivefile(name="simplerequest_file", acq=acq, size_b=2**20)
-    group1 = storagegroup(name="simplerequest_group1")
-    group2 = storagegroup(name="simplerequest_group2")
-    node = storagenode(name="simplerequest_node", group=group1)
+    acq = archiveacq(name="simplecopyrequest_acq")
+    file = archivefile(name="simplecopyrequest_file", acq=acq, size_b=2**20)
+    group1 = storagegroup(name="simplecopyrequest_group1")
+    group2 = storagegroup(name="simplecopyrequest_group2")
+    node = storagenode(name="simplecopyrequest_node", group=group1)
     return archivefilecopyrequest(file=file, node_from=node, group_to=group2)
+
+
+@pytest.fixture
+def simpleimportrequest(
+    archivefileimportrequest,
+    storagenode,
+    storagegroup,
+):
+    """Create a simple ArchiveFileCopyRequest record.
+
+    Creates all necessary backrefs.
+    """
+    group = storagegroup(name="simpleimportrequest_group")
+    node = storagenode(name="simpleimportrequest_node", group=group)
+    return archivefileimportrequest(path="simpleimportrequest", node=node)
 
 
 @pytest.fixture

--- a/tests/daemon/test_auto_import.py
+++ b/tests/daemon/test_auto_import.py
@@ -18,13 +18,13 @@ def test_import_file_bad_paths(queue, unode):
     """Test that bad paths are rejected by import_file."""
 
     # Path outside root
-    auto_import.import_file(unode, queue, pathlib.PurePath("/bad/path"))
+    auto_import.import_file(unode, queue, pathlib.PurePath("/bad/path"), True, None)
 
     # no job queued
     assert queue.qsize == 0
 
     # node root is ignored
-    auto_import.import_file(unode, queue, pathlib.PurePath(unode.db.root))
+    auto_import.import_file(unode, queue, pathlib.PurePath(unode.db.root), True, None)
 
     # no job queued
     assert queue.qsize == 0
@@ -33,7 +33,9 @@ def test_import_file_bad_paths(queue, unode):
 def test_import_file_queue(queue, unode):
     """Test job queueing in import_file()"""
 
-    auto_import.import_file(unode, queue, pathlib.PurePath("/node/acq/file"))
+    auto_import.import_file(
+        unode, queue, pathlib.PurePath("/node/acq/file"), True, None
+    )
 
     # job in queue
     assert queue.qsize == 1
@@ -44,7 +46,7 @@ def test_import_file_queue(queue, unode):
         "/node/acq/file": "released",
     }
 )
-def test_import_file_not_ready(dbtables, queue, simplenode, mock_lfs):
+def test_import_file_not_ready(dbtables, xfs, queue, simplenode, mock_lfs):
     """Test _import_file() on unready file."""
 
     # Set up node for LustreHSMIO
@@ -52,8 +54,17 @@ def test_import_file_not_ready(dbtables, queue, simplenode, mock_lfs):
     simplenode.io_config = '{"quota_group": "qgroup", "headroom": 300000}'
     unode = UpdateableNode(queue, simplenode)
 
+    xfs.create_file("/node/acq/file")
+
     # _import_file is a generator function, so it needs to be interated to run.
-    assert next(auto_import._import_file(None, unode, pathlib.PurePath("acq/file"))) > 0
+    assert (
+        next(
+            auto_import._import_file(
+                None, unode, pathlib.PurePath("acq/file"), True, None
+            )
+        )
+        > 0
+    )
 
     # File is being restored
     assert mock_lfs("").hsm_state("/node/acq/file") == HSMState.RESTORING
@@ -64,7 +75,11 @@ def test_import_file_no_ext(dbtables, unode):
 
     # _import_file is a generator function, so it needs to be interated to run.
     with pytest.raises(StopIteration):
-        next(auto_import._import_file(None, unode, pathlib.PurePath("acq/file")))
+        next(
+            auto_import._import_file(
+                None, unode, pathlib.PurePath("acq/file"), True, None
+            )
+        )
 
     # No acq has been added
     with pytest.raises(pw.DoesNotExist):
@@ -78,7 +93,11 @@ def test_import_file_no_detect(dbtables, unode):
         "alpenhorn.common.extensions._id_ext", [lambda path, node: (None, None)]
     ):
         with pytest.raises(StopIteration):
-            next(auto_import._import_file(None, unode, pathlib.PurePath("acq/file")))
+            next(
+                auto_import._import_file(
+                    None, unode, pathlib.PurePath("acq/file"), True, None
+                )
+            )
 
     # No acq has been added
     with pytest.raises(pw.DoesNotExist):
@@ -94,7 +113,7 @@ def test_import_file_locked(xfs, dbtables, unode):
     with pytest.raises(StopIteration):
         next(
             auto_import._import_file(
-                None, unode, pathlib.PurePath("simplefile_acq/simplefile")
+                None, unode, pathlib.PurePath("simplefile_acq/simplefile"), True, None
             )
         )
 
@@ -117,7 +136,11 @@ def test_import_file_create(xfs, dbtables, unode):
         with pytest.raises(StopIteration):
             next(
                 auto_import._import_file(
-                    None, unode, pathlib.PurePath("simplefile_acq/simplefile")
+                    None,
+                    unode,
+                    pathlib.PurePath("simplefile_acq/simplefile"),
+                    True,
+                    None,
                 )
             )
 
@@ -163,6 +186,62 @@ def test_import_file_create(xfs, dbtables, unode):
     }
 
 
+def test_import_file_no_register(xfs, dbtables, unode):
+    """Test _import_file() without registration"""
+
+    xfs.create_file("/node/acq/file")
+
+    with patch(
+        "alpenhorn.common.extensions._id_ext",
+        [lambda path, node: ("acq", None)],
+    ):
+        with pytest.raises(StopIteration):
+            next(
+                auto_import._import_file(
+                    None, unode, pathlib.PurePath("acq/file"), False, None
+                )
+            )
+
+    # Check DB
+    assert ArchiveAcq.select().count() == 0
+    assert ArchiveFile.select().count() == 0
+    assert ArchiveFileCopy.select().count() == 0
+
+    # Now create the ArchiveAcq and try again
+    acq = ArchiveAcq.create(name="acq")
+
+    with patch(
+        "alpenhorn.common.extensions._id_ext",
+        [lambda path, node: ("acq", None)],
+    ):
+        with pytest.raises(StopIteration):
+            next(
+                auto_import._import_file(
+                    None, unode, pathlib.PurePath("acq/file"), False, None
+                )
+            )
+
+    assert ArchiveFile.select().count() == 0
+    assert ArchiveFileCopy.select().count() == 0
+
+    # Now create the ArchiveAcq and try again
+    ArchiveFile.create(name="file", acq=acq)
+
+    with patch(
+        "alpenhorn.common.extensions._id_ext",
+        [lambda path, node: ("acq", None)],
+    ):
+        with pytest.raises(StopIteration):
+            next(
+                auto_import._import_file(
+                    None, unode, pathlib.PurePath("acq/file"), False, None
+                )
+            )
+
+    # Now the file was imported
+    assert ArchiveFileCopy.select().count() == 1
+
+
 def test_import_file_callback(xfs, dbtables, unode):
     """Test _import_file() with callback"""
 
@@ -183,7 +262,11 @@ def test_import_file_callback(xfs, dbtables, unode):
         with pytest.raises(StopIteration):
             next(
                 auto_import._import_file(
-                    None, unode, pathlib.PurePath("simplefile_acq/simplefile")
+                    None,
+                    unode,
+                    pathlib.PurePath("simplefile_acq/simplefile"),
+                    True,
+                    None,
                 )
             )
 
@@ -220,7 +303,11 @@ def test_import_file_exists(xfs, dbtables, unode, simplefile, archivefilecopy):
         with pytest.raises(StopIteration):
             next(
                 auto_import._import_file(
-                    None, unode, pathlib.PurePath("simplefile_acq/simplefile")
+                    None,
+                    unode,
+                    pathlib.PurePath("simplefile_acq/simplefile"),
+                    True,
+                    None,
                 )
             )
 
@@ -240,6 +327,65 @@ def test_import_file_exists(xfs, dbtables, unode, simplefile, archivefilecopy):
     assert copy_data["last_update"] <= after
     del copy_data["last_update"]
 
+    assert copy_data == {
+        "id": 1,
+        "node": 1,
+        "file": 1,
+        "has_file": "Y",
+        "wants_file": "Y",
+        "ready": True,
+        "size_b": None,
+    }
+
+
+def test_import_file_missing(xfs, dbtables, unode, simplefile, archivefilecopy):
+    """Test _import_file() with known missing file."""
+
+    # Create the file copy.  "Missing" means has_file="N", wants_file="Y"
+    archivefilecopy(
+        file=simplefile,
+        node=unode.db,
+        has_file="N",
+        wants_file="Y",
+        ready=False,
+        last_update=datetime.datetime(2000, 1, 1, 0, 0, 0),
+    )
+    xfs.create_file("/node/simplefile_acq/simplefile")
+
+    before = (pw.utcnow() - datetime.timedelta(seconds=1)).replace(microsecond=0)
+
+    with patch(
+        "alpenhorn.common.extensions._id_ext",
+        [lambda path, node: ("simplefile_acq", None)],
+    ):
+        with pytest.raises(StopIteration):
+            next(
+                auto_import._import_file(
+                    None,
+                    unode,
+                    pathlib.PurePath("simplefile_acq/simplefile"),
+                    True,
+                    None,
+                )
+            )
+
+    after = pw.utcnow() + datetime.timedelta(seconds=1)
+
+    # Check DB
+    acq = ArchiveAcq.get(name="simplefile_acq")
+    assert acq == simplefile.acq
+
+    file = ArchiveFile.get(name="simplefile", acq=acq)
+    assert file == simplefile
+
+    copy = ArchiveFileCopy.get(file=file, node=unode.db)
+    copy_data = copy.__data__
+
+    assert copy_data["last_update"] >= before
+    assert copy_data["last_update"] <= after
+    del copy_data["last_update"]
+
+    # File is considered suspect.
     assert copy_data == {
         "id": 1,
         "node": 1,
@@ -315,26 +461,26 @@ def test_update_observers_force_stop(xfs, dbtables, unode, queue):
 
 
 @patch("alpenhorn.daemon.auto_import.import_file")
-def test_catchup_new(mocked_import, xfs, dbtables, unode, queue):
-    """Test auto_import.catchup with new files."""
+def test_scan_new(mocked_import, xfs, dbtables, unode, queue):
+    """Test auto_import.scan with new files."""
 
     # Make some files to "import"
     xfs.create_file("/node/acq1/file1")
     xfs.create_file("/node/acq1/file2")
     xfs.create_file("/node/acq2/file1")
 
-    auto_import.catchup(None, unode, queue)
+    auto_import.scan(None, unode, queue, ".", True, None)
     mocked_import.assert_has_calls(
         [
-            call(unode, queue, pathlib.PurePath("acq1/file1")),
-            call(unode, queue, pathlib.PurePath("acq1/file2")),
-            call(unode, queue, pathlib.PurePath("acq2/file1")),
+            call(unode, queue, pathlib.PurePath("acq1/file1"), True, None),
+            call(unode, queue, pathlib.PurePath("acq1/file2"), True, None),
+            call(unode, queue, pathlib.PurePath("acq2/file1"), True, None),
         ],
     )
 
 
 @patch("alpenhorn.daemon.auto_import.import_file")
-def test_catchup_exists(
+def test_scan_exists(
     mocked_import,
     xfs,
     queue,
@@ -343,7 +489,7 @@ def test_catchup_exists(
     archivefile,
     archivefilecopy,
 ):
-    """Test auto_import.catchup skips existing copies."""
+    """Test auto_import.scan skips existing copies."""
 
     # Make files in DB
     af1 = archivefile(name="file1", acq=simpleacq)
@@ -366,11 +512,31 @@ def test_catchup_exists(
     xfs.create_file("/node/simpleacq/file5")  # no copy but ArchiveFile
     xfs.create_file("/node/simpleacq/file6")  # no copy or ArchiveFile
 
-    auto_import.catchup(None, unode, queue)
+    auto_import.scan(None, unode, queue, ".", True, None)
 
     # Only files4 through 6 should be imported
     assert mocked_import.mock_calls == [
-        call(unode, queue, pathlib.PurePath("simpleacq/file4")),
-        call(unode, queue, pathlib.PurePath("simpleacq/file5")),
-        call(unode, queue, pathlib.PurePath("simpleacq/file6")),
+        call(unode, queue, pathlib.PurePath("simpleacq/file4"), True, None),
+        call(unode, queue, pathlib.PurePath("simpleacq/file5"), True, None),
+        call(unode, queue, pathlib.PurePath("simpleacq/file6"), True, None),
+    ]
+
+
+@patch("alpenhorn.daemon.auto_import.import_file")
+def test_scan_file(
+    mocked_import,
+    xfs,
+    queue,
+    unode,
+    simpleacq,
+):
+    """Test auto_import.scan with a file path."""
+
+    xfs.create_file("/node/simpleacq/file1")
+
+    auto_import.scan(None, unode, queue, "simpleacq/file1", True, None)
+
+    # File is imported
+    assert mocked_import.mock_calls == [
+        call(unode, queue, pathlib.Path("simpleacq/file1"), True, None),
     ]

--- a/tests/daemon/test_entry.py
+++ b/tests/daemon/test_entry.py
@@ -28,7 +28,11 @@ from urllib.parse import quote as urlquote
 
 from alpenhorn.db import database_proxy, EnumField
 from alpenhorn.db.acquisition import ArchiveAcq, ArchiveFile
-from alpenhorn.db.archive import ArchiveFileCopy, ArchiveFileCopyRequest
+from alpenhorn.db.archive import (
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    ArchiveFileImportRequest,
+)
 from alpenhorn.db.storage import StorageGroup, StorageNode, StorageTransferAction
 from alpenhorn.daemon.entry import entry
 
@@ -48,6 +52,7 @@ def e2e_db(xfs, clidb_noinit, hostname):
         [
             ArchiveFileCopy,
             ArchiveFileCopyRequest,
+            ArchiveFileImportRequest,
             StorageGroup,
             StorageNode,
             StorageTransferAction,

--- a/tests/io/test_defaultgroup.py
+++ b/tests/io/test_defaultgroup.py
@@ -60,26 +60,26 @@ def test_exists(xfs, groupnode):
     assert group.io.exists("no-acq/no-file") is None
 
 
-def test_pull_force_handoff(groupnode, simplerequest):
+def test_pull_force_handoff(groupnode, simplecopyrequest):
     """Test DefaultGroupIO.pull_force()."""
 
     group, node = groupnode
     node.io.pull = MagicMock(return_value=None)
 
     # Call pull_force
-    group.io.pull_force(simplerequest)
+    group.io.pull_force(simplecopyrequest)
 
     # Check for hand-off to the node
-    node.io.pull.assert_called_with(simplerequest)
+    node.io.pull.assert_called_with(simplecopyrequest)
 
 
-def test_pull(groupnode, simplerequest, queue):
+def test_pull(groupnode, simplecopyrequest, queue):
     """Test task submission in DefaultGroupIO.pull()."""
 
     group, node = groupnode
 
     with patch("alpenhorn.io.default.group_search_async") as mock:
-        group.io.pull(simplerequest)
+        group.io.pull(simplecopyrequest)
 
         # Task is queued
         assert queue.qsize == 1
@@ -97,7 +97,7 @@ def test_pull(groupnode, simplerequest, queue):
         mock.assert_called_once()
 
 
-def test_group_search_dispatch(groupnode, simplerequest, queue):
+def test_group_search_dispatch(groupnode, simplecopyrequest, queue):
     """Test group_search_async dispatch to pull_force"""
 
     group, node = groupnode
@@ -106,10 +106,10 @@ def test_group_search_dispatch(groupnode, simplerequest, queue):
     group.io.pull_force = mock
 
     # Run the async.  First argument is Task
-    group_search_async(None, group.io, simplerequest)
+    group_search_async(None, group.io, simplecopyrequest)
 
     # Check dispatch
-    mock.assert_called_once_with(simplerequest)
+    mock.assert_called_once_with(simplecopyrequest)
 
 
 def test_group_search_in_db(

--- a/tests/io/test_defaultnode.py
+++ b/tests/io/test_defaultnode.py
@@ -57,12 +57,47 @@ def test_file_walk(unode, xfs):
     xfs.create_file("/node/dir/subdir/file4")
     xfs.create_link("/node/dir/file2", "/node/dir/subdir/file5")
 
-    assert sorted(list(unode.io.file_walk())) == [
+    assert sorted(list(unode.io.file_walk(pathlib.PurePath(".")))) == [
         pathlib.PurePath("/node/dir/file1"),
         pathlib.PurePath("/node/dir/file2"),
         pathlib.PurePath("/node/dir/subdir/file4"),
         pathlib.PurePath("/node/dir/subdir/file5"),
     ]
+
+
+def test_file_walk_path(unode, xfs):
+    """test DefaultNodeIO.file_walk() with a path"""
+
+    # Make some things.
+    xfs.create_file("/node/dir1/file1")
+    xfs.create_file("/node/dir1/file2")
+    xfs.create_file("/node/dir2/file3")
+    xfs.create_file("/node/dir2/file4")
+
+    assert sorted(list(unode.io.file_walk(pathlib.PurePath("dir1")))) == [
+        pathlib.PurePath("/node/dir1/file1"),
+        pathlib.PurePath("/node/dir1/file2"),
+    ]
+
+
+def test_file_walk_missing(unode, xfs):
+    """test DefaultNodeIO.file_walk() with a missing path"""
+
+    # Make some things.
+    xfs.create_file("/node/dir1/file1")
+
+    assert len(list(unode.io.file_walk(pathlib.PurePath("dir3")))) == 0
+
+
+def test_file_walk_file(unode, xfs):
+    """test DefaultNodeIO.file_walk() with a file path"""
+
+    # Make some things.
+    xfs.create_file("/node/dir1/file1")
+
+    result = list(unode.io.file_walk(pathlib.PurePath("dir1/file1")))
+    assert len(result) == 1
+    assert str(result[0]) == "/node/dir1/file1"
 
 
 def test_fits(unode, xfs):


### PR DESCRIPTION
This adds a new table to the data index: ArchiveFileImportRequest, which contains requests for the daemon to import new file(s) into the data index.

Each request contains a node in which the import is done, a path (relative to node.root) to import, and two flags:

* recurse: whether path should be recursively scanned for files to import
* register: whether new files should be added to the data index, or whether the import should just add new ArchiveFileCopy records for pre-registered ArchiveFiles.

A third `completed` flag indicates to the daemon whether the request has been handled.

In terms of the update loop itself, there's not a whole lot to add. The `auto_import` module already has all the necessary functionality to handle these requests, and I've added a new function (`update_import`) to the `UpdateableNode` class in `daemon.update` to find all pending import requests for a node and dispatch them to the appropriate `auto_import` function.

There are two such functions in the `auto_import` module:

* `import_file` can be used to import a single file (i.e. when the `recurse` flag is False.  This is the same function that is called by the auto-import watchdogs to import newly discovered files.
* for the `recurse == True` case, `scan`, which has been renamed from `auto_import.catchup` is a Task-run function to recursively scan the given path and call `import_file` on unimported files found.

The functionality of the two functions haven't seen a whole lot of change from what was in `auto_import` previously.  `scan` now takes a path relative to `node.root` (which can be `"."` to scan the whole node).  Both functions get passed the `register` flag from the import request, and functionality has been adeed to the inner `_import_file` function to handle the case when we should import known files but not register new ones.

Finally, both functions take the `ArchiveFileImportRequest` record itself so they can mark it as completed once the operation finishes.

The CLI-facing side to this functionality will be added in a second PR.