### PR TITLE
feat(CLI): node init command

### DIFF
--- a/alpenhorn/cli/node/__init__.py
+++ b/alpenhorn/cli/node/__init__.py
@@ -17,6 +17,7 @@ from .autoclean import autoclean
 from .clean import clean
 from .create import create
 from .deactivate import deactivate
+from .init import init
 from .list import list_
 from .modify import modify
 from .rename import rename
@@ -38,6 +39,7 @@ cli.add_command(autoclean, "autoclean")
 cli.add_command(clean, "clean")
 cli.add_command(create, "create")
 cli.add_command(deactivate, "deactivate")
+cli.add_command(init, "init")
 cli.add_command(list_, "list")
 cli.add_command(modify, "modify")
 cli.add_command(rename, "rename")

--- a/alpenhorn/cli/node/init.py
+++ b/alpenhorn/cli/node/init.py
@@ -1,0 +1,36 @@
+"""alpenhorn node init command"""
+
+import click
+import peewee as pw
+
+from ...db import database_proxy, ArchiveFileImportRequest, StorageNode
+from ..cli import echo
+
+
+@click.command()
+@click.argument("name", metavar="NODE")
+def init(name):
+    """Initialise a known Storage Node.
+
+    This requests the daemon initialise the Node named NODE.  NODE must
+    already exist in the data index.  NODE must be active for the daemon
+    to act on this request.
+
+    What initialisation means can vary by node I/O class, but typically
+    it means creating the top-level "ALPENHORN_NODE" file.
+
+    Note: to create a new node, use "node create".  Node initialsation can
+    also happen at node creation time by using the "--init" flag with
+    "node create".
+    """
+
+    with database_proxy.atomic():
+        try:
+            node = StorageNode.get(name=name)
+        except pw.DoesNotExist:
+            raise click.ClickException("no such node: " + name)
+
+        # Add request
+        ArchiveFileImportRequest.create(node=node, path="ALPENHORN_NODE")
+
+    echo('Requested initialisation of Node "{name}".')

--- a/alpenhorn/daemon/auto_import.py
+++ b/alpenhorn/daemon/auto_import.py
@@ -61,6 +61,8 @@ def import_file(
         If not None, req will be marked as complete if the import isn't skipped.
     """
 
+    path = pathlib.PurePath(path)
+
     # Occasionally the watchdog sends events on the node root directory itself. Skip these.
     if path == pathlib.PurePath(node.db.root):
         log.debug("Skipping import request of node root")
@@ -86,7 +88,9 @@ def import_file(
     # Ignore the node info file.  NB: this happens even on nodes which
     # don't use an ALPENHORN_NODE file, meaning even on those nodes,
     # this path is disallowed as a data file.
-    if str(path) == "ALPENHORN_NODE":
+    if pathlib.PurePath(node.db.root).joinpath(path) == pathlib.PurePath(
+        node.db.root
+    ).joinpath("ALPENHORN_NODE"):
         log.debug("ignoring ALPENHORN_NODE file during import")
         if req:
             log.info(f"Completed import request #{req.id}.")

--- a/alpenhorn/db/archive.py
+++ b/alpenhorn/db/archive.py
@@ -128,8 +128,8 @@ class ArchiveFileImportRequest(base_model):
     node : foreign key
         The StorageNode on which the import should happen
     path : string
-        The path to import.  If this is a directory and
-        recurse is True, it will be recursively scanned.
+        The path to import.  If this is a directory and recurse is True,
+        it will be recursively scanned.
     recurse : bool
         If True, recursively scan path for files, if path is a directory.
     register : bool
@@ -139,6 +139,15 @@ class ArchiveFileImportRequest(base_model):
         Set to true when the import request has completed.
     timestamp : datetime
         The UTC time when the request was made.
+
+    If `path` is the special value "ALPENHORN_NODE", then the request is
+    a node initialisation request, instead of a normal import request.
+    This only happens on active nodes which aren't already initialised:
+    an initialisation request on an already initialised node is ignored.
+
+    Note: How node initialisation works is dependent on the I/O class of
+    the node.  There is no requirement for initialisation to create an
+    ALPENHORN_NODE node file.
     """
 
     node = pw.ForeignKeyField(StorageNode, backref="import_requests")

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -193,15 +193,15 @@ class DefaultNodeIO(BaseNodeIO):
             name=f"Check file {copy.file.path} on {self.node.name}",
         )
 
-    def check_active(self) -> bool:
-        """Check that this is an active node.
+    def check_init(self) -> bool:
+        """Check that this node is initialised.
 
         Checks that the file `node.root`/ALPENHORN_NODE exists and
         contains the name of the node.
 
         Returns
         -------
-        active : bool
+        init : bool
             True if the `ALPENHORN_NODE` check succeeded;
             False otherwise.
         """
@@ -331,6 +331,29 @@ class DefaultNodeIO(BaseNodeIO):
             True if `size_b` fits on the node.  False otherwise.
         """
         return self.reserve_bytes(size_b, check_only=True)
+
+    def init(self) -> bool:
+        """Initialise this node.
+
+        We do that by creating the ALPENHORN_NODE file, if it
+        doesn't already exit.
+        """
+
+        # Sanity check
+        if self.check_init():
+            return True
+
+        # Create file
+        try:
+            with open(
+                pathlib.Path(self.node.root).joinpath("ALPENHORN_NODE"), mode="wt"
+            ) as f:
+                f.write(self.node.name + "\n")
+        except IOError as e:
+            log.warning(f"Node initialistion failed: {e}")
+            return False
+
+        return True
 
     def locked(self, path: os.PathLike) -> bool:
         """Is file `path` locked?

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -440,13 +440,12 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
         else:
             log.debug(f"Skipping check of {copy.path}: restore in progress.")
 
-    def check_active(self) -> bool:
-        """Check that this is an active node.
+    def check_init(self) -> bool:
+        """Check that this node is initialised.
 
-        There's no ALPENHORN_NODE file on HSM,
-        so this just returns `self.node.active`.
+        There's no ALPENHORN_NODE file on HSM, so just return True.
         """
-        return self.node.active
+        return True
 
     def exists(self, path: pathlib.PurePath) -> bool:
         """Does `path` exist?
@@ -486,6 +485,15 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
 
         Returns True: everything fits in HSM.
         """
+        return True
+
+    def init(self) -> bool:
+        """Initialise this node.
+
+        This should never be called, because check_init always returns
+        True, but in case it does, we implement it anyways.
+        """
+        # Initialisaiton is a no-op
         return True
 
     def open(self, path: os.PathLike | str, binary: bool = True) -> IO:

--- a/tests/cli/node/test_create.py
+++ b/tests/cli/node/test_create.py
@@ -2,7 +2,7 @@
 
 import json
 import pytest
-from alpenhorn.db import StorageGroup, StorageNode
+from alpenhorn.db import StorageGroup, StorageNode, ArchiveFileImportRequest
 
 
 def test_no_group(clidb, cli):
@@ -265,3 +265,15 @@ def test_bad_min_avail(clidb, cli):
 
     cli(2, ["node", "create", "TEST", "--create-group", "--min-avail=-1"])
     cli(2, ["node", "create", "TEST", "--create-group", "--min-avail=none"])
+
+
+def test_init(clidb, cli):
+    """Test create with --init"""
+
+    cli(0, ["node", "create", "TEST", "--init", "--create-group"])
+
+    node = StorageNode.get(name="TEST")
+    afir = ArchiveFileImportRequest.get(id=1)
+
+    assert afir.node == node
+    assert afir.path == "ALPENHORN_NODE"

--- a/tests/cli/node/test_init.py
+++ b/tests/cli/node/test_init.py
@@ -1,0 +1,36 @@
+"""Test CLI: alpenhorn node init"""
+
+from alpenhorn.db import StorageGroup, StorageNode, ArchiveFileImportRequest, utcnow
+
+
+def test_no_node(clidb, cli):
+    """Test a missing NODE name"""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(2, ["node", "init"])
+
+
+def test_bad_node(clidb, cli):
+    """Test a bad node name"""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["node", "init", "MISSING"])
+
+
+def test_init(clidb, cli):
+    """Test the default invocation."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, root="/root")
+
+    cli(0, ["node", "init", "Node"])
+
+    # Request created
+    afir = ArchiveFileImportRequest.get(id=1)
+
+    assert afir.node == node
+    assert afir.path == "ALPENHORN_NODE"

--- a/tests/io/test_defaultnode.py
+++ b/tests/io/test_defaultnode.py
@@ -14,17 +14,33 @@ def test_bytes_avail(xfs, unode):
     assert unode.io.bytes_avail() == 10000.0
 
 
-def test_check_active(xfs, unode):
-    """test DefaultNodeIO.check_active()"""
+def test_check_init(xfs, unode):
+    """test DefaultNodeIO.check_init()"""
 
-    assert unode.io.check_active() is False
+    assert unode.io.check_init() is False
 
     xfs.create_file("/node/ALPENHORN_NODE", contents="not-node")
-    assert unode.io.check_active() is False
+    assert unode.io.check_init() is False
 
     with open("/node/ALPENHORN_NODE", mode="w") as f:
         f.write("simplenode")
-    assert unode.io.check_active() is True
+    assert unode.io.check_init() is True
+
+
+def test_init(xfs, unode, queue):
+    """test DefaultNodeIO.init()"""
+
+    # Somewhere for I/O to happen
+    xfs.create_dir("/node")
+
+    # Not initialised
+    assert unode.io.check_init() is False
+
+    # Run init
+    assert unode.io.init() is True
+
+    # Now initialised
+    assert unode.io.check_init() is True
 
 
 def test_exists(unode, xfs):


### PR DESCRIPTION
Also a --init flag to "node create" to do the same thing.

This requests the daemon intialise the node, which typically means creating the ALPENHORN_NODE file, but doesn't have to.  The request is made via the ArchiveFileImportRequest with path="ALPENHORN_NODE" (which is otherwise a forbidden path to try to import).

This has involved some changes to the daemon to give it the ability to create ALPENHORN_NODE files.  The request can't be handled in the normal part of the loop (which is skipped for uninitialised nodes), so instead it's handled during the `check_init` test in the early part of the update loop.

I've also taken the opportunity to disambiguate two different uses of the term "active" which used to be in the daemon:

* the `StorageNode.active` bit is set
* the I/O layer is ready for I/O

The second of these is now called "initialised" and "active" now only refers to the first one.

Closes #227 