### PR TITLE
feat(util): Make `pretty_bytes` more forgiving

### DIFF
--- a/alpenhorn/cli/acq/files.py
+++ b/alpenhorn/cli/acq/files.py
@@ -48,16 +48,12 @@ def files(acq, group, node, show_removed):
         for copy in query:
             state = copy.state
             if show_removed or state != "Removed":
-                file_size = (
-                    "-" if copy.file.size_b is None else pretty_bytes(copy.file.size_b)
-                )
-                node_size = pretty_bytes(copy.size_b) if copy.size_b else "-"
                 data.append(
                     (
                         copy.file.name,
-                        file_size,
+                        pretty_bytes(copy.file.size_b),
                         state,
-                        node_size,
+                        pretty_bytes(copy.size_b),
                         copy.file.md5sum,
                     )
                 )
@@ -91,19 +87,21 @@ def files(acq, group, node, show_removed):
                 else:
                     state = "Corrupt"
 
-                file_size = (
-                    "-" if copy.file.size_b is None else pretty_bytes(copy.file.size_b)
+                data.append(
+                    (
+                        copy.file.name,
+                        pretty_bytes(copy.file.size_b),
+                        state,
+                        copy.file.md5sum,
+                    )
                 )
-
-                data.append((copy.file.name, file_size, state, copy.file.md5sum))
     else:
         headers = ["Name", "Size", "MD5"]
 
         query = ArchiveFile.select().where(ArchiveFile.acq == acq)
 
         for file in query:
-            file_size = "-" if file.size_b is None else pretty_bytes(file.size_b)
-            data.append((file.name, file_size, file.md5sum))
+            data.append((file.name, pretty_bytes(file.size_b), file.md5sum))
 
     if data:
         echo(tabulate(data, headers=headers))

--- a/alpenhorn/cli/acq/show.py
+++ b/alpenhorn/cli/acq/show.py
@@ -57,12 +57,11 @@ def show(acq, show_groups, show_nodes):
             .group_by(StorageNode.id)
         )
         for row in query.dicts():
-            pretty_size = pretty_bytes(row["size"]) if row["size"] is not None else "-"
             if show_groups:
                 group_dict = node_totals.setdefault(row["group"], {})
-                group_dict[row["node"]] = (row["count"], pretty_size)
+                group_dict[row["node"]] = (row["count"], pretty_bytes(row["size"]))
             else:
-                node_totals[row["node"]] = (row["count"], pretty_size)
+                node_totals[row["node"]] = (row["count"], pretty_bytes(row["size"]))
 
     if show_groups:
         group_totals = (
@@ -92,7 +91,7 @@ def show(acq, show_groups, show_nodes):
                 (
                     group["name"],
                     group["count"],
-                    pretty_bytes(group["size"]) if group["size"] is not None else "-",
+                    pretty_bytes(group["size"]),
                 )
             )
             if show_nodes and group["gid"] in node_totals:

--- a/alpenhorn/cli/node/stats.py
+++ b/alpenhorn/cli/node/stats.py
@@ -114,13 +114,12 @@ def get_stats(nodes: list[StorageNode], extra_stats: bool) -> dict[int, dict]:
             stats[node.id]["count"] = 0
 
         if "size" in node_stats and node_stats["size"]:
-            size = pretty_bytes(node_stats["size"])
             if node.max_total_gb:
                 percent = 100.0 * node_stats["size"] / node.max_total_gb / 2**30
                 stats[node.id]["percent"] = f"{percent:5.2f}"
             else:
                 stats[node.id]["percent"] = "-"
-            stats[node.id]["size"] = size
+            stats[node.id]["size"] = pretty_bytes(node_stats["size"])
         else:
             stats[node.id]["size"] = "-"
             stats[node.id]["percent"] = "-"

--- a/alpenhorn/cli/node/verify.py
+++ b/alpenhorn/cli/node/verify.py
@@ -105,7 +105,7 @@ def _run_query(
             what = "verification"
             goal = ""
 
-        size = pretty_bytes(total.size) if total.size is not None else "size unknown"
+        size = "unknown size" if total.size is None else pretty_bytes(total.size)
         echo(f"{verb} {what} of {total.count} {files} ({size}){goal}.")
 
         if update:

--- a/alpenhorn/common/util.py
+++ b/alpenhorn/common/util.py
@@ -220,19 +220,19 @@ def get_hostname() -> str:
     return socket.gethostname().split(".")[0]
 
 
-def pretty_bytes(num: int) -> str:
+def pretty_bytes(num: int | None) -> str:
     """Return a nicely formatted string describing a size in bytes.
 
     Parameters
     ----------
-    num : int
+    num : int or None
         Number of bytes
 
     Returns
     -------
     pretty_bytes : str
-        A formatted string using power-of-two prefixes,
-        e.g. "103.4 GiB"
+        If `num` was None, this will be "-".  Otherwise, it's a
+        formatted string using power-of-two prefixes, e.g. "103.4 GiB".
 
     Raises
     ------
@@ -242,8 +242,13 @@ def pretty_bytes(num: int) -> str:
         `num` was less than zero
     """
 
+    # Return something unhelpful if given None
+    if num is None:
+        return "-"
+
     # Reject weird stuff
     try:
+        num = int(num)
         if num < 0:
             raise ValueError("negative size")
     except TypeError:

--- a/tests/cli/acq/test_files.py
+++ b/tests/cli/acq/test_files.py
@@ -112,7 +112,7 @@ def test_list_node(clidb, cli, assert_row_present):
     assert "File2" not in result.output
     assert "File3" not in result.output
     assert_row_present(result.output, "FileMY", "789 B", "Suspect", "1.205 kiB")
-    assert_row_present(result.output, "FileXY", "5.545 kiB", "Corrupt", "-")
+    assert_row_present(result.output, "FileXY", "5.545 kiB", "Corrupt", "0 B")
     assert_row_present(result.output, "FileNY", "0 B", "Missing", "-")
     assert_row_present(result.output, "FileYM", "-", "Removable", "-")
     assert_row_present(result.output, "FileMM", "-", "Removable", "-")

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -71,7 +71,13 @@ def test_pretty_bytes():
         util.pretty_bytes(-1)
 
     with pytest.raises(TypeError):
-        util.pretty_bytes(None)
+        util.pretty_bytes({})
+
+    # This is explicitly allowed
+    assert util.pretty_bytes(None) == "-"
+
+    # int conversion should happen
+    assert util.pretty_bytes("456") == "456 B"
 
     # This is an overflow
     assert util.pretty_bytes(1234567890123456789012) == "1234567890123456789012 B"


### PR DESCRIPTION
While it was pretty easy to avoid passing weird stuff to `pretty_bytes` in ths daemon, that's harder to do in the CLI.

I've found I've been doing the same None check a lot before using the function to deal with the potential for nulls in the database.

So, let's make the function a little more forgiving about the input. Not sure if "??? B" is the best thing to return in the None case. Let me know if you have a preference for something else.