### PR TITLE
feat(CLI): "file show" command

### DIFF
--- a/alpenhorn/cli/acq/files.py
+++ b/alpenhorn/cli/acq/files.py
@@ -58,7 +58,7 @@ def files(acq, group, node, show_removed):
                     )
                 )
     elif group:
-        headers = ["Name", "Size", "Group State", "MD5"]
+        headers = ["Name", "Size", "Group State", "Node", "MD5"]
 
         try:
             group = StorageGroup.get(name=group)
@@ -74,7 +74,7 @@ def files(acq, group, node, show_removed):
         )
 
         for copy in query:
-            state = group.filecopy_state(copy.file)
+            state, node = group.state_on_node(copy.file)
 
             if show_removed or state != "N":
                 # Convert state to words
@@ -92,6 +92,7 @@ def files(acq, group, node, show_removed):
                         copy.file.name,
                         pretty_bytes(copy.file.size_b),
                         state,
+                        "-" if node is None else node.name,
                         copy.file.md5sum,
                     )
                 )

--- a/alpenhorn/cli/cli.py
+++ b/alpenhorn/cli/cli.py
@@ -128,3 +128,11 @@ def update_or_remove(field: str, new: str | None, old: str | None) -> dict:
 
     # Otherwise, no change.  Return no update.
     return {}
+
+
+def pretty_time(time):
+    """Print a human-readable time."""
+
+    if time:
+        return time.ctime() + " UTC"
+    return "-"

--- a/alpenhorn/cli/entry.py
+++ b/alpenhorn/cli/entry.py
@@ -7,7 +7,7 @@ import click
 from .. import db
 from ..common.util import start_alpenhorn, version_option
 
-from . import acq, db, group, node
+from . import acq, db, file, group, node
 from .options import not_both
 
 
@@ -79,5 +79,6 @@ def entry(conf, quiet, verbose, debug):
 
 entry.add_command(acq.cli, "acq")
 entry.add_command(db.cli, "db")
+entry.add_command(file.cli, "file")
 entry.add_command(group.cli, "group")
 entry.add_command(node.cli, "node")

--- a/alpenhorn/cli/file/__init__.py
+++ b/alpenhorn/cli/file/__init__.py
@@ -1,0 +1,14 @@
+"""Alpenhorn CLI for operations on `ArchiveFile`s and `ArchiveFileCopy`s."""
+
+import click
+import peewee as pw
+
+from .show import show
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def cli():
+    """Manage Files."""
+
+
+cli.add_command(show, "show")

--- a/alpenhorn/cli/file/show.py
+++ b/alpenhorn/cli/file/show.py
@@ -1,0 +1,144 @@
+"""alpenhorn file show command."""
+
+import click
+import peewee as pw
+from tabulate import tabulate
+
+from ...common.util import pretty_bytes
+from ...db import (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    StorageGroup,
+    StorageNode,
+)
+from ..cli import echo, pretty_time
+from ..options import cli_option, file_from_path
+
+
+@click.command()
+@click.argument("path", metavar="FILE")
+@cli_option("all_", help="Show all additional data.")
+@click.option("--groups", is_flag=True, help="show file status in Storage Groups")
+@click.option("--nodes", is_flag=True, help="show file status on Storage Nodes")
+@click.option("--transfers", is_flag=True, help="show file transfer requests")
+def show(path, all_, groups, nodes, transfers):
+    """Show details of a File.
+
+    Show details of the Archive File FILE, which should
+    be specified as "<acq_name>/<file_name>".
+    """
+
+    if all_:
+        groups = True
+        nodes = True
+        transfers = True
+
+    # Find the file given the pathspec; doesn't return if file couldn't be found
+    file_ = file_from_path(path)
+
+    echo("       Name: " + file_.name)
+    echo("Acquisition: " + file_.acq.name)
+    echo("       Path: " + file_.acq.name + "/" + file_.name)
+    echo()
+    echo(
+        "       Size: "
+        + ("unknown" if file_.size_b is None else pretty_bytes(file_.size_b))
+    )
+    echo("   MD5 Hash: " + ("-" if file_.md5sum is None else file_.md5sum.lower()))
+    echo(" Registered: " + pretty_time(file_.registered))
+
+    if groups:
+        echo("\nGroup status\n")
+
+        # "Absent" could be "missing" or "removed".  Groups don't tell us.
+        states = {"Y": "Present", "M": "Suspect", "X": "Corrupt", "N": "Absent"}
+
+        # Find groups containing file
+        data = []
+        for group in (
+            StorageGroup.select()
+            .join(StorageNode, pw.JOIN.LEFT_OUTER)
+            .join(ArchiveFileCopy, pw.JOIN.LEFT_OUTER)
+            .where(ArchiveFileCopy.file == file_)
+            .distinct()
+            .execute()
+        ):
+            state, node = group.state_on_node(file_)
+            data.append(
+                (group.name, states.get(state, "Unknown"), node.name if node else "-")
+            )
+
+        if data:
+            echo(tabulate(data, headers=["Group", "State", "Node"]))
+        else:
+            echo("No extant copies.")
+
+    if nodes:
+        echo("\nNode status:\n")
+
+        data = []
+        for copy in (
+            ArchiveFileCopy.select()
+            .join(StorageNode)
+            .where(ArchiveFileCopy.file == file_)
+            .execute()
+        ):
+            # Only print size if it makes sense
+            if copy.has_file in ["Y", "M"]:
+                size = pretty_bytes(copy.size_b)
+            else:
+                size = "-"
+            data.append((copy.node.name, copy.state, size))
+
+        if data:
+            echo(tabulate(data, headers=["Node", "State", "Size on Node"]))
+        else:
+            echo("No extant copies.")
+
+    if transfers:
+        echo("\nTransfer requests:\n")
+        data = []
+        for req in (
+            ArchiveFileCopyRequest.select()
+            .join(StorageGroup)
+            .switch(ArchiveFileCopyRequest)
+            .join(StorageNode)
+            .where(ArchiveFileCopyRequest.file == file_)
+            .execute()
+        ):
+            if req.completed:
+                status = "Complete"
+            elif req.cancelled:
+                status = "Cancelled"
+            else:
+                status = "Pending"
+
+            data.append(
+                (
+                    req.node_from.name,
+                    req.group_to.name,
+                    status,
+                    pretty_time(req.timestamp),
+                    pretty_time(req.transfer_started),
+                    pretty_time(req.transfer_completed),
+                )
+            )
+
+        if data:
+            echo(
+                tabulate(
+                    data,
+                    headers=[
+                        "Source Node",
+                        "Dest. Group",
+                        "Status",
+                        "Request Time",
+                        "Start Time",
+                        "Completion Time",
+                    ],
+                )
+            )
+        else:
+            echo("No transfers")

--- a/alpenhorn/cli/node/show.py
+++ b/alpenhorn/cli/node/show.py
@@ -13,7 +13,7 @@ from ...db import (
     ArchiveFileCopyRequest,
     ArchiveFile,
 )
-from ..cli import echo
+from ..cli import echo, pretty_time
 from ..options import cli_option
 from .stats import get_stats
 
@@ -68,11 +68,6 @@ def show(name, actions, all_, stats, transfers):
     else:
         avail = "-"
 
-    if node.avail_gb_last_checked:
-        last_checked = node.avail_gb_last_checked.ctime() + " UTC"
-    else:
-        last_checked = "???"
-
     # Print a report
     echo("   Storage Node: " + node.name)
     echo("  Storage Group: " + node.group.name)
@@ -93,7 +88,7 @@ def show(name, actions, all_, stats, transfers):
     echo("      Max Total: " + max_total)
     echo("      Available: " + avail)
     echo("  Min Available: " + min_avail)
-    echo("   Last Checked: " + last_checked)
+    echo("   Last Checked: " + pretty_time(node.avail_gb_last_checked))
 
     echo("\nI/O Config:\n")
     if node.io_config:

--- a/alpenhorn/daemon/update.py
+++ b/alpenhorn/daemon/update.py
@@ -679,7 +679,7 @@ class UpdateableGroup(updateable_base):
             The pull request to process.
         """
         # What's the current situation on the destination?
-        copy_state = self.db.filecopy_state(req.file)
+        copy_state = self.db.state_on_node(req.file)[0]
         if copy_state == "Y":
             # We mark the AFCR cancelled rather than complete becase
             # _this_ AFCR clearly hasn't been responsible for creating

--- a/alpenhorn/db/archive.py
+++ b/alpenhorn/db/archive.py
@@ -63,22 +63,28 @@ class ArchiveFileCopy(base_model):
     def state(self) -> str:
         """A human-readable description of the copy state."""
 
-        if self.wants_file == "N":
-            return "Removed" if self.has_file == "N" else "Released"
-        if self.wants_file == "M":
-            return "Removed" if self.has_file == "N" else "Removable"
+        # key is '{has_file}{wants_file}'
+        states = {
+            # has_file == 'Y'
+            "YY": "Present",
+            "YM": "Removable",
+            "YN": "Released",
+            # has_file == 'M'
+            "MY": "Suspect",
+            "MM": "Suspect",
+            "MN": "Released",
+            # has_file == 'X'
+            "XY": "Corrupt",
+            "XM": "Corrupt",
+            "XN": "Released",
+            # has_file == 'N'
+            "NY": "Missing",
+            "NM": "Removed",
+            "NN": "Removed",
+        }
 
-        # Otherwise, wants_file == 'Y'
-        if self.has_file == "Y":
-            return "Present"
-        if self.has_file == "M":
-            return "Suspect"
-        if self.has_file == "N":
-            # i.e. a third-party deleted it
-            return "Missing"
-
-        # wants_file == 'X' and has_file == 'Y' .. or something completely wrong
-        return "Corrupt"
+        key = self.has_file + self.wants_file
+        return states.get(key, "Corrupt")
 
     class Meta:
         indexes = ((("file", "node"), True),)  # (file, node) is unique

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -349,7 +349,7 @@ def group_search_async(
     # Before doing anything re-check the DB for something
     # in this group.  The situation may have changed while this
     # task was queued.
-    state = groupio.group.filecopy_state(req.file)
+    state = groupio.group.state_on_node(req.file)[0]
     if state == "Y" or state == "M":
         log.info(
             "Cancelling pull request for "

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -353,7 +353,7 @@ def post_add(node: StorageNode, file_: ArchiveFile) -> None:
         StorageTransferAction.group_to != node.group,
         StorageTransferAction.autosync == True,  # noqa: E712
     ):
-        if edge.group_to.filecopy_state(file_) != "Y":
+        if edge.group_to.state_on_node(file_)[0] != "Y":
             log.debug(
                 f"Autosyncing {file_.path} from node {node.name} to group {edge.group_to.name}"
             )

--- a/tests/cli/acq/test_files.py
+++ b/tests/cli/acq/test_files.py
@@ -115,8 +115,8 @@ def test_list_node(clidb, cli, assert_row_present):
     assert_row_present(result.output, "FileXY", "5.545 kiB", "Corrupt", "0 B")
     assert_row_present(result.output, "FileNY", "0 B", "Missing", "-")
     assert_row_present(result.output, "FileYM", "-", "Removable", "-")
-    assert_row_present(result.output, "FileMM", "-", "Removable", "-")
-    assert_row_present(result.output, "FileXM", "-", "Removable", "-")
+    assert_row_present(result.output, "FileMM", "-", "Suspect", "-")
+    assert_row_present(result.output, "FileXM", "-", "Corrupt", "-")
     assert "FileNM" not in result.output
     assert_row_present(result.output, "FileYN", "-", "Released", "-")
     assert_row_present(result.output, "FileMN", "-", "Released", "-")
@@ -185,12 +185,12 @@ def test_list_group_removed(clidb, cli, assert_row_present):
     result = cli(0, ["acq", "files", "Acq1", "--group=Group1", "--show-removed"])
 
     # --group state ignores wants_file
-    assert_row_present(result.output, "FileYY", "123 B", "Present")
-    assert_row_present(result.output, "FileNY", "0 B", "Removed")
-    assert_row_present(result.output, "FileYM", "-", "Present")
-    assert_row_present(result.output, "FileNM", "-", "Removed")
-    assert_row_present(result.output, "FileYN", "-", "Present")
-    assert_row_present(result.output, "FileNN", "-", "Removed")
+    assert_row_present(result.output, "FileYY", "123 B", "Present", "Node1")
+    assert_row_present(result.output, "FileNY", "0 B", "Removed", "-")
+    assert_row_present(result.output, "FileYM", "-", "Present", "Node1")
+    assert_row_present(result.output, "FileNM", "-", "Removed", "-")
+    assert_row_present(result.output, "FileYN", "-", "Present", "Node1")
+    assert_row_present(result.output, "FileNN", "-", "Removed", "-")
     assert result.output.count("File") == 6
 
 
@@ -221,7 +221,7 @@ def test_no_list_node(clidb, cli):
     assert "Name" not in result.output
 
 
-def test_list_node_only_removed(clidb, cli):
+def test_list_node_only_removed(clidb, cli, assert_row_present):
     """Test list --node with only removed files."""
 
     group = StorageGroup.create(name="Group")
@@ -236,7 +236,7 @@ def test_list_node_only_removed(clidb, cli):
 
     result = cli(0, ["acq", "files", "Acq1", "--node=Node1", "--show-removed"])
 
-    assert "File1" in result.output
+    assert_row_present(result.output, "File1", "123 B", "Removed", "-")
 
 
 def test_list_no_group(clidb, cli):
@@ -267,7 +267,7 @@ def test_no_list_group(clidb, cli):
     assert "Name" not in result.output
 
 
-def test_list_group_only_removed(clidb, cli):
+def test_list_group_only_removed(clidb, cli, assert_row_present):
     """Test no list with group constraint."""
 
     group = StorageGroup.create(name="Group1")
@@ -283,13 +283,14 @@ def test_list_group_only_removed(clidb, cli):
 
     result = cli(0, ["acq", "files", "Acq1", "--group=Group1", "--show-removed"])
 
-    # i.e. the header hasn't been printed
-    assert "File1" in result.output
+    assert_row_present(result.output, "File1", "-", "Removed", "-")
 
 
 def test_list_node_group(clidb, cli):
     """Test with both node and group."""
 
     ArchiveAcq.create(name="Acq1")
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
 
     cli(2, ["acq", "files", "Acq1", "--node=Node", "--group=Group"])

--- a/tests/cli/file/test_show.py
+++ b/tests/cli/file/test_show.py
@@ -1,0 +1,332 @@
+"""Test CLI: alpenhorn file show"""
+
+import datetime
+
+from alpenhorn.db import (
+    StorageGroup,
+    StorageNode,
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+)
+
+
+def test_no_file(clidb, cli):
+    """Test with no file."""
+
+    cli(2, ["file", "show"])
+
+
+def test_file_not_found(clidb, cli):
+    """Test with non-existent file."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="File", acq=acq)
+
+    cli(1, ["file", "show", "Acq/File2"])
+
+
+def test_absfile(clidb, cli):
+    """Test show with absolute file."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="File1", acq=acq, size_b=123)
+
+    cli(1, ["file", "show", "/node/Acq/File1"])
+
+
+def test_simple_show(clidb, cli):
+    """Test show with no options."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(
+        name="File", acq=acq, size_b=123, md5sum="D41D8CD98F00B204E9800998ECF8427E"
+    )
+
+    result = cli(0, ["file", "show", "Acq/File"])
+
+    assert "Name: File" in result.output
+    assert "Acquisition: Acq" in result.output
+    assert "Path: Acq/File" in result.output
+
+    assert "Size: 123 B" in result.output
+    assert "MD5 Hash: d41d8cd98f00b204e9800998ecf8427e" in result.output
+
+
+def test_show_groups(clidb, cli, assert_row_present):
+    """Test show with --groups."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq, size_b=123)
+
+    group1 = StorageGroup.create(name="Group1")
+    node1a = StorageNode.create(name="Node1a", group=group1)
+    ArchiveFileCopy.create(
+        node=node1a, file=file, has_file="X", wants_file="Y", size_b=234
+    )
+    node1b = StorageNode.create(name="Node1b", group=group1)
+    ArchiveFileCopy.create(
+        node=node1b, file=file, has_file="M", wants_file="Y", size_b=345
+    )
+    group2 = StorageGroup.create(name="Group2")
+    node2 = StorageNode.create(name="Node2", group=group2)
+    ArchiveFileCopy.create(
+        node=node2, file=file, has_file="Y", wants_file="Y", size_b=456
+    )
+    group3 = StorageGroup.create(name="Group3")
+    node3a = StorageNode.create(name="Node3a", group=group3)
+    node3b = StorageNode.create(name="Node3b", group=group3)
+    ArchiveFileCopy.create(
+        node=node3a, file=file, has_file="N", wants_file="Y", size_b=567
+    )
+    group4 = StorageGroup.create(name="Group4")
+    node4 = StorageNode.create(name="Node4", group=group4)
+
+    result = cli(0, ["file", "show", "Acq/File", "--groups"])
+
+    assert_row_present(result.output, "Group1", "Suspect", "Node1b")
+    assert_row_present(result.output, "Group2", "Present", "Node2")
+    assert_row_present(result.output, "Group3", "Absent", "-")
+    assert "Group4" not in result.output
+
+
+def test_show_no_groups(clidb, cli, assert_row_present):
+    """Test show with --groups, but nothing to show."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq, size_b=123)
+
+    result = cli(0, ["file", "show", "Acq/File", "--groups"])
+
+    assert "No extant copies" in result.output
+
+
+def test_show_nodes(clidb, cli, assert_row_present):
+    """Test show with --nodes."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq, size_b=123)
+
+    group = StorageGroup.create(name="Group")
+
+    node = StorageNode.create(name="NodeYY", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="Y", wants_file="Y", size_b=234
+    )
+    node = StorageNode.create(name="NodeYM", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="Y", wants_file="M", size_b=345
+    )
+    node = StorageNode.create(name="NodeYN", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="Y", wants_file="N", size_b=456
+    )
+
+    node = StorageNode.create(name="NodeMY", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="M", wants_file="Y", size_b=567
+    )
+    node = StorageNode.create(name="NodeMM", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="M", wants_file="M", size_b=678
+    )
+    node = StorageNode.create(name="NodeMN", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="M", wants_file="N", size_b=789
+    )
+
+    node = StorageNode.create(name="NodeXY", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="X", wants_file="Y", size_b=321
+    )
+    node = StorageNode.create(name="NodeXM", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="X", wants_file="M", size_b=423
+    )
+    node = StorageNode.create(name="NodeXN", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="X", wants_file="N", size_b=534
+    )
+
+    node = StorageNode.create(name="NodeNY", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="N", wants_file="Y", size_b=654
+    )
+    node = StorageNode.create(name="NodeNM", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="N", wants_file="M", size_b=765
+    )
+    node = StorageNode.create(name="NodeNN", group=group)
+    ArchiveFileCopy.create(
+        node=node, file=file, has_file="N", wants_file="N", size_b=876
+    )
+    file = ArchiveFile.create(name="File2", acq=acq, size_b=123)
+    node = StorageNode.create(name="Node2", group=group)
+    ArchiveFileCopy.create(node=node, file=file, has_file="Y", wants_file="Y")
+
+    result = cli(0, ["file", "show", "Acq/File", "--nodes"])
+
+    assert_row_present(result.output, "NodeYY", "Present", "234 B")
+    assert_row_present(result.output, "NodeYM", "Removable", "345 B")
+    assert_row_present(result.output, "NodeYN", "Released", "456 B")
+
+    assert_row_present(result.output, "NodeMY", "Suspect", "567 B")
+    assert_row_present(result.output, "NodeMM", "Suspect", "678 B")
+    assert_row_present(result.output, "NodeMN", "Released", "789 B")
+
+    assert_row_present(result.output, "NodeXY", "Corrupt", "-")
+    assert_row_present(result.output, "NodeXM", "Corrupt", "-")
+    assert_row_present(result.output, "NodeXN", "Released", "-")
+
+    assert_row_present(result.output, "NodeNY", "Missing", "-")
+    assert_row_present(result.output, "NodeNM", "Removed", "-")
+    assert_row_present(result.output, "NodeNN", "Removed", "-")
+    assert "Node2" not in result.output
+
+
+def test_show_no_nodes(clidb, cli, assert_row_present):
+    """Test show --nodes with no nodes to show."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq, size_b=123)
+
+    result = cli(0, ["file", "show", "Acq/File", "--nodes"])
+
+    assert "No extant copies" in result.output
+
+
+def test_show_transfers(clidb, cli, assert_row_present):
+    """Test show with --transfers."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq)
+
+    group1 = StorageGroup.create(name="Group1")
+    node1 = StorageNode.create(name="Node1", group=group1)
+
+    group2 = StorageGroup.create(name="Group2")
+    node2 = StorageNode.create(name="Node2", group=group2)
+
+    time1 = datetime.datetime(2001, 1, 1, 1, 1, 1, 1)
+    time2 = datetime.datetime(2002, 2, 2, 2, 2, 2, 2)
+    time3 = datetime.datetime(2003, 3, 3, 3, 3, 3, 3)
+
+    ArchiveFileCopyRequest.create(
+        file=file,
+        node_from=node1,
+        group_to=group1,
+        completed=0,
+        cancelled=0,
+        timestamp=time1,
+        transfer_started=time2,
+        transfer_completed=time3,
+    )
+    ArchiveFileCopyRequest.create(
+        file=file,
+        node_from=node1,
+        group_to=group2,
+        completed=0,
+        cancelled=1,
+        timestamp=time2,
+    )
+    ArchiveFileCopyRequest.create(
+        file=file,
+        node_from=node2,
+        group_to=group1,
+        completed=1,
+        cancelled=0,
+        timestamp=time3,
+    )
+    ArchiveFileCopyRequest.create(
+        file=file,
+        node_from=node2,
+        group_to=group2,
+        completed=1,
+        cancelled=1,
+        timestamp=0,
+    )
+
+    result = cli(0, ["file", "show", "Acq/File", "--transfers"])
+
+    assert_row_present(
+        result.output,
+        "Node1",
+        "Group1",
+        "Pending",
+        "Mon Jan  1 01:01:01 2001 UTC",
+        "Sat Feb  2 02:02:02 2002 UTC",
+        "Mon Mar  3 03:03:03 2003 UTC",
+    )
+    assert_row_present(
+        result.output,
+        "Node1",
+        "Group2",
+        "Cancelled",
+        "Sat Feb  2 02:02:02 2002 UTC",
+        "-",
+        "-",
+    )
+    assert_row_present(
+        result.output,
+        "Node2",
+        "Group1",
+        "Complete",
+        "Mon Mar  3 03:03:03 2003 UTC",
+        "-",
+        "-",
+    )
+    assert_row_present(result.output, "Node2", "Group2", "Complete", "-", "-", "-")
+
+
+def test_show_no_transfers(clidb, cli, assert_row_present):
+    """Test show --transfers with no transfers to show."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq, size_b=123)
+
+    result = cli(0, ["file", "show", "Acq/File", "--transfers"])
+
+    assert "No transfers" in result.output
+
+
+def test_show_all(clidb, cli, assert_row_present):
+    """Test show --all."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq, size_b=123)
+
+    group1 = StorageGroup.create(name="Group1")
+    node1a = StorageNode.create(name="Node1a", group=group1)
+    ArchiveFileCopy.create(
+        node=node1a, file=file, has_file="X", wants_file="Y", size_b=234
+    )
+    node1b = StorageNode.create(name="Node1b", group=group1)
+    ArchiveFileCopy.create(
+        node=node1b, file=file, has_file="M", wants_file="Y", size_b=345
+    )
+    group2 = StorageGroup.create(name="Group2")
+    node2 = StorageNode.create(name="Node2", group=group2)
+    ArchiveFileCopy.create(
+        node=node2, file=file, has_file="Y", wants_file="Y", size_b=456
+    )
+
+    ArchiveFileCopyRequest.create(
+        file=file,
+        node_from=node2,
+        group_to=group1,
+        completed=0,
+        cancelled=0,
+        timestamp=0,
+    )
+
+    result = cli(0, ["file", "show", "Acq/File", "--all"])
+
+    assert_row_present(result.output, "Group1", "Suspect", "Node1b")
+    assert_row_present(result.output, "Group2", "Present", "Node2")
+
+    assert_row_present(result.output, "Node1a", "Corrupt", "-")
+    assert_row_present(result.output, "Node1b", "Suspect", "345 B")
+    assert_row_present(result.output, "Node2", "Present", "456 B")
+
+    assert_row_present(result.output, "Node2", "Group1", "Pending", "-", "-", "-")

--- a/tests/db/test_storage.py
+++ b/tests/db/test_storage.py
@@ -125,34 +125,36 @@ def test_local(simplenode, hostname):
 
 
 def test_copy_state(simplenode, simpleacq, archivefile, archivefilecopy):
-    """Test group.filecopy_state()."""
+    """Test group.state_on_node()."""
     group = simplenode.group
 
+    # None is returned here with 'N', even though an ArchiveFileCopy
+    # exists with a specific node in the group.
     filen = archivefile(name="filen", acq=simpleacq, size_b=1)
     archivefilecopy(file=filen, node=simplenode, has_file="N")
-    assert group.filecopy_state(filen) == "N"
+    assert group.state_on_node(filen) == ("N", None)
 
     filey = archivefile(name="filey", acq=simpleacq, size_b=1)
     archivefilecopy(file=filey, node=simplenode, has_file="Y")
-    assert group.filecopy_state(filey) == "Y"
+    assert group.state_on_node(filey) == ("Y", simplenode)
 
     filex = archivefile(name="filex", acq=simpleacq, size_b=1)
     archivefilecopy(file=filex, node=simplenode, has_file="X")
-    assert group.filecopy_state(filex) == "X"
+    assert group.state_on_node(filex) == ("X", simplenode)
 
     filem = archivefile(name="filem", acq=simpleacq, size_b=1)
     archivefilecopy(file=filem, node=simplenode, has_file="M")
-    assert group.filecopy_state(filem) == "M"
+    assert group.state_on_node(filem) == ("M", simplenode)
 
     # Non-existent file returns 'N'
     missing = archivefile(name="missing", acq=simpleacq, size_b=1)
-    assert group.filecopy_state(missing) == "N"
+    assert group.state_on_node(missing) == ("N", None)
 
 
 def test_copy_state_multi(
     simplegroup, storagenode, simpleacq, archivefile, archivefilecopy
 ):
-    """Test group.filecopy_state() with mutliple copies on the node."""
+    """Test group.state_on_node() with mutliple copies on the node."""
 
     # Several nodes with different kinds of file copies
     nodeN = storagenode(name="N", group=simplegroup)
@@ -165,7 +167,7 @@ def test_copy_state_multi(
     archivefilecopy(file=fileXN, node=nodeN, has_file="N")
     archivefilecopy(file=fileXN, node=nodeX, has_file="X")
 
-    assert simplegroup.filecopy_state(fileXN) == "X"
+    assert simplegroup.state_on_node(fileXN) == ("X", nodeX)
 
     # M wins over M and N
     fileMXN = archivefile(name="MXN", acq=simpleacq)
@@ -173,7 +175,7 @@ def test_copy_state_multi(
     archivefilecopy(file=fileMXN, node=nodeX, has_file="X")
     archivefilecopy(file=fileMXN, node=nodeM, has_file="M")
 
-    assert simplegroup.filecopy_state(fileMXN) == "M"
+    assert simplegroup.state_on_node(fileMXN) == ("M", nodeM)
 
     # Y wins over X, M and N
     fileYMXN = archivefile(name="YMXN", acq=simpleacq)
@@ -182,7 +184,7 @@ def test_copy_state_multi(
     archivefilecopy(file=fileYMXN, node=nodeM, has_file="M")
     archivefilecopy(file=fileYMXN, node=nodeY, has_file="Y")
 
-    assert simplegroup.filecopy_state(fileYMXN) == "Y"
+    assert simplegroup.state_on_node(fileYMXN) == ("Y", nodeY)
 
 
 def test_archive_property(simplegroup, storagenode):


### PR DESCRIPTION
I've replaced `StorageGroup.filecopy_state()` with `StorageGroup.state_on_node()` which returns both the previous status `str`, but also the node on which the copy with the state was found, which I have then added to the `acq files` table as well as using it in the new `file show`.