### PR TITLE
feat(CLI): "file list" command

### DIFF
--- a/alpenhorn/cli/file/__init__.py
+++ b/alpenhorn/cli/file/__init__.py
@@ -6,6 +6,7 @@ import peewee as pw
 from .clean import clean
 from .create import create
 from .import_ import import_
+from .list import list_
 from .modify import modify
 from .show import show
 from .sync import sync
@@ -19,6 +20,7 @@ def cli():
 cli.add_command(clean, "clean")
 cli.add_command(create, "create")
 cli.add_command(import_, "import")
+cli.add_command(list_, "list")
 cli.add_command(modify, "modify")
 cli.add_command(show, "show")
 cli.add_command(sync, "sync")

--- a/alpenhorn/cli/file/list.py
+++ b/alpenhorn/cli/file/list.py
@@ -116,14 +116,13 @@ def list_(
     Limit by location
     -----------------
 
-    To limit the list based on where files are or are not present, use
-    the --absent-node=NODE, --absent-group=GROUP, --node=NODE and/or --group=GROUP
+    To limit the list based on where a file is, or is not, present, use the
+    --absent-node=NODE, --absent-group=GROUP, --node=NODE and/or --group=GROUP
     options to list places to search.
 
-    The first two of these negative constraints (nodes and/or groups which must not
-    have the files) and the second two are positive constraints (nodes and/or groups
-    which must have the file).  For a file to be listed, it must satisfy both the
-    negative and positive constraints.
+    The first two of these options are negative constraints (indicating nodes or
+    groups which must not have the file) and the last two are positive constraints
+    (nodes or groups which must have the file).
 
     Normally, only one of the location constraints given need be satisfied for a
     file to be listed, but if you also use "--all", then a file will be listed only
@@ -203,10 +202,10 @@ def list_(
     # from DeMorgan's rule), and "not all_", as expected, for the positive ones.
     if absent_node:
         absent_nodes = resolve_node(absent_node)
-        absent_node_files = files_in_nodes(absent_nodes, state_expr, in_any=all_)
+        absent_node_files = files_in_nodes(absent_nodes, None, in_any=all_)
     if absent_group:
         absent_groups = resolve_group(absent_group)
-        absent_group_files = files_in_groups(absent_groups, state_expr, in_any=all_)
+        absent_group_files = files_in_groups(absent_groups, None, in_any=all_)
     if node:
         nodes = resolve_node(node)
         node_files = files_in_nodes(nodes, state_expr, in_any=not all_)
@@ -215,7 +214,7 @@ def list_(
         group_files = files_in_groups(groups, state_expr, in_any=not all_)
 
     # In --details mode, extra node or group details are provided in very
-    # restricted circumstatnces:
+    # restricted circumstances:
     #  1. exactly one --group or exactly one --node was specified
     #  2. not restricted by syncability (i.e. no --from or --to)
     detail_node = None

--- a/alpenhorn/cli/file/list.py
+++ b/alpenhorn/cli/file/list.py
@@ -1,0 +1,342 @@
+"""alpenhorn file list command."""
+
+import click
+import peewee as pw
+from tabulate import tabulate
+
+from ...common.util import pretty_bytes
+from ...db import (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    StorageGroup,
+    StorageNode,
+)
+from ..cli import echo, pretty_time
+from ..options import (
+    cli_option,
+    not_both,
+    both_or_neither,
+    files_in_nodes,
+    files_in_groups,
+    resolve_acqs,
+    resolve_group,
+    resolve_node,
+    state_constraint,
+)
+
+
+def _state_flag_help(name):
+    """Returns help for one of the state flags"""
+
+    return "Limit to " + name + "files.  Must be accompanied by at least one "
+    "--node or --group to provide a place to probe file state.",
+
+
+@click.command()
+@cli_option("acq")
+@cli_option("all_", help="Limit to files that exist on all NODEs and GROUPs provided.")
+@click.option("--corrupt", is_flag=True, help=_state_flag_help("corrupt"))
+@click.option("--details", is_flag=True, help="Show details for listed files.")
+@click.option(
+    "from_",
+    "--from",
+    metavar="SRC",
+    help="Must be specified with --to=DEST: limit to files that can be synced "
+    "from Node SRC to Group DEST",
+)
+@click.option(
+    "--group",
+    metavar="GROUP",
+    multiple=True,
+    help="Limit to files present (or not present) in GROUP.  "
+    "May be specified multiple times.",
+)
+@click.option("--healthy", is_flag=True, help=_state_flag_help("healthy"))
+@click.option("--missing", is_flag=True, help=_state_flag_help("missing"))
+@click.option(
+    "--node",
+    metavar="NODE",
+    multiple=True,
+    help="Limit to files present (or not present) on NODE.  "
+    "May be specified multiple times.",
+)
+@click.option(
+    "not_", "--not", is_flag=True, help="Limit to files absent from NODEs and GROUPs"
+)
+@click.option("--suspect", is_flag=True, help=_state_flag_help("suspect"))
+@click.option(
+    "--to",
+    metavar="DEST",
+    help="Must be specified with --from=SRC: limit to files that can be synced "
+    "from Node SRC to Group DEST",
+)
+@click.pass_context
+def list_(
+    ctx,
+    acq,
+    all_,
+    corrupt,
+    details,
+    from_,
+    group,
+    healthy,
+    missing,
+    node,
+    not_,
+    suspect,
+    to,
+):
+    """List Files.
+
+    Without options, lists all Files registered to the Data Index.
+    There are several ways to limit the list of files returned:
+
+    \b
+    Limit by acqusition
+    -------------------
+
+    It is always possible to limit the list to only files in acqusition(s)
+    specified in the --acq option.
+
+    \b
+    Limit by location
+    -----------------
+
+    To limit the list based on where files are or are not present, use
+    the --node=NODE and/or --group=GROUP options to list places to search.
+    How these are interpreted depend on the "--all" and "--not" options:
+
+    With neither option, files will be listed if they exist on at least one of
+    the NODEs or GROUPs.
+
+    With --all, files must exist on all the listed NODEs and GROUPs.
+
+    With --not, files must be absent from all the listed NODEs and GROUPs.
+
+    With --not and --all, files must be absent from at least one of the NODEs or
+    GROUPs.
+
+    \b
+    Limit by file state
+    -------------------
+
+    To limit the list based on file state, you can use the state flags:
+    --missing, --corrupt, --suspect, --healthy.  In this case, you must specify
+    at least one location (with --node or --group) to indicate where the file
+    state should be checked.  If multiple state flags are used, files with any
+    one of the specified state will be listed.
+
+    The --not flag cannot be used with the state flags.
+
+    Note: the "missing" state does not mean simply "absent".  The state "missing"
+    is a special state tracked by alpenhorn in the data index for files which are
+    absent from a node/group when they are expected to be present (i.e they haven't
+    been released).  So, these two commands produce (potentially) different results:
+
+    \b
+    group list --not --node=NODE
+    group list --missing --node=NODE
+
+    The first lists all files absent from NODE.  The second lists only files which are
+    absent but not released from the NODE (i.e. files which have been deleted by a
+    third-party without alpenhorn's knowledge).
+
+    \b
+    Limit based on syncability
+    --------------------------
+
+    Using both "--from=SRC" and "--to=DEST" will limit the list to files which
+    can be synced (copied) from the Node SRC to the Group DEST.  Specifically,
+    this restricts the list to files which are healthy on SRC and absent from
+    DEST.
+
+    You cannot simultaneously limit both by file state and syncability.
+    """
+
+    # Usage checks.
+
+    # Find a state flag to complain about, if any
+    if corrupt:
+        state_flag = "corrupt"
+    elif missing:
+        state_flag = "missing"
+    elif healthy:
+        state_flag = "healthy"
+    elif suspect:
+        state_flag = "suspect"
+    else:
+        state_flag = None
+
+    # Can't use a state flag with --not
+    not_both(not_, "not", state_flag, state_flag)
+    # Must use --to and --from together
+    both_or_neither(from_, "from", to, "to")
+    # Can't use a state with --from or --to
+    # (checking --from is enough, given the previous test)
+    not_both(from_, "from", state_flag, state_flag)
+
+    # Can't use --not or --all if we haven't used --node or --group
+    if not_ or all_:
+        if not node and not group:
+            raise click.UsageError(
+                ("--all" if all_ else "--not")
+                + " cannot be used without --node or --group"
+            )
+
+    # Figure out the state constraint from the flags
+    state_expr = state_constraint(
+        corrupt=corrupt, healthy=healthy, missing=missing, suspect=suspect
+    )
+
+    # Do we want the intersection or union of the nodes and groups?
+    # This is just XOR of --all and --not
+    intersect = all_ ^ not_
+
+    # Resolve nodes, and groups, if provided
+    if node:
+        nodes = resolve_node(node)
+        node_files = files_in_nodes(nodes, state_expr, in_any=not intersect)
+    if group:
+        groups = resolve_group(group)
+        group_files = files_in_groups(groups, state_expr, in_any=not intersect)
+
+    # Now make a master list from node and group lists
+    if node and group:
+        if intersect:
+            selected_files = node_files & group_files
+        else:
+            selected_files = node_files | group_files
+    elif node:
+        selected_files = node_files
+    elif group:
+        selected_files = group_files
+    else:
+        selected_files = None
+
+    # Apply syncability limit.  This is just a special kind of
+    # file selection where we find files in --from but not in --to.
+    if from_:
+        syncable_files = files_in_nodes([resolve_node(from_)]) - files_in_groups(
+            [resolve_group(to)]
+        )
+
+        if selected_files is not None:
+            # Merge with selected_files list
+            if not_:
+                # In not mode, we remove selected_files from the syncable ones,
+                selected_files = syncable_files - selected_files
+                # The above has converted the negative constraint to a positive one
+                not_ = False
+            else:
+                # Here we take the intersection of the two selections (ignoring --all)
+                selected_files &= syncable_files
+        else:
+            # Otherwise, we're just using the syncable files list
+            selected_files = syncable_files
+
+    # Handle no matching files
+    if selected_files is not None and len(selected_files) == 0:
+        if not_:
+            # Here we were asked to omit files in the selection, but
+            # there's nothing in the selection, so there's nothing to
+            # omit.
+            selected_files = None
+        else:
+            # Otherwise, we were going to list only the files in the
+            # selection, but there are none, so we're done.
+            ctx.exit()
+
+    # In --details mode, extra node or group details are provided in very
+    # restricted circumstatnces:
+    #  1. exactly one group or exactly one node was specified
+    #  2. --not wasn't used
+    #  3. not restricted by syncability (i.e. no --from or --to)
+    detail_node = None
+    detail_group = None
+    if details and not not_ and not from_:
+        if node and not group and len(nodes) == 1:
+            detail_node = nodes[0]
+        elif group and not node and len(groups) == 1:
+            detail_group = groups[0]
+
+    # The base query
+    query = (
+        ArchiveFile.select()
+        .join(ArchiveAcq)
+        .order_by(ArchiveAcq.name, ArchiveFile.name)
+    )
+
+    # Apply the --acq limit, if given
+    if acq:
+        query = query.where(ArchiveFile.acq << resolve_acqs(acq))
+
+    # Apply file selection, if any
+    if selected_files is not None:
+        if not_:
+            query = query.where(ArchiveFile.id.not_in(selected_files))
+        else:
+            query = query.where(ArchiveFile.id << selected_files)
+
+    if details:
+        # Headers
+        headers = ["File", "Size", "MD5 Hash", "Registration Time"]
+
+        # Data
+        file_data = {}
+        for file in query.execute():
+            file_data[file] = (
+                file.acq.name + "/" + file.name,
+                pretty_bytes(file.size_b),
+                "-" if file.md5sum is None else file.md5sum.lower(),
+                pretty_time(file.registered),
+            )
+
+        # Add extra details, if possible
+        if detail_group:
+            headers += ["State", "Node"]
+            data = []
+            for file in file_data:
+                state_name = {
+                    "Y": "Present",
+                    "M": "Suspect",
+                    "X": "Corrupt",
+                    "N": "Absent",
+                }
+                state, node = detail_group.state_on_node(file)
+                data.append(
+                    (
+                        *file_data[file],
+                        state_name[state],
+                        "-" if node is None else node.name,
+                    )
+                )
+        elif detail_node:
+            headers += ["State", "Size on Node"]
+
+            # Get all the ArchiveFileCopy data in a single query
+            copies = {
+                copy.file: copy
+                for copy in ArchiveFileCopy.select()
+                .where(ArchiveFileCopy.file << [file.id for file in file_data])
+                .execute()
+            }
+
+            data = []
+            for file in file_data:
+                copy = copies[file]
+                data.append(
+                    (
+                        *file_data[file],
+                        copies[file].state,
+                        pretty_bytes(copies[file].size_b),
+                    )
+                )
+        else:
+            data = file_data.values()
+
+        if data:
+            echo(tabulate(data, headers=headers))
+    else:
+        echo("\n".join(file.acq.name + "/" + file.name for file in query.execute()))

--- a/tests/cli/file/test_list.py
+++ b/tests/cli/file/test_list.py
@@ -1,0 +1,649 @@
+"""Test CLI: alpenhorn file show"""
+
+from datetime import datetime
+
+from alpenhorn.db import (
+    StorageGroup,
+    StorageNode,
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+)
+
+
+def test_only_from_to(clidb, cli):
+    """Can't only use --from or --to"""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(2, ["file", "list", "--from=Node"])
+    cli(2, ["file", "list", "--to=Group"])
+
+
+def test_state_not(clidb, cli):
+    """State flags and --not can't be used together."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    for state_flag in ["--corrupt", "--missing", "--healthy", "--suspect"]:
+        cli(2, ["file", "list", state_flag, "--not", "--node=Node"])
+
+
+def test_state_to_from(clidb, cli):
+    """state flags can't be used with --to or --from."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    for state_flag in ["--corrupt", "--missing", "--healthy", "--suspect"]:
+        cli(2, ["file", "list", state_flag, "--to=Group", "--from=Node"])
+
+
+def test_bare_not_all(clidb, cli):
+    """--all and --not must accompany a --node or --group"""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(2, ["file", "list", "--not"])
+    cli(2, ["file", "list", "--all"])
+    cli(2, ["file", "list", "--all", "--not"])
+
+
+def test_bad_acq(clidb, cli):
+    """Test a non-existent --acq"""
+
+    cli(1, ["file", "list", "--acq=MISSING"])
+
+
+def test_bad_node(clidb, cli):
+    """Test a non-existent --node"""
+
+    cli(1, ["file", "list", "--node=MISSING"])
+
+
+def test_bad_group(clidb, cli):
+    """Test a non-existent --group"""
+
+    cli(1, ["file", "list", "--group=MISSING"])
+
+
+def test_bad_from(clidb, cli):
+    """Test a non-existent --from target"""
+
+    StorageGroup.create(name="Group")
+
+    cli(1, ["file", "list", "--to=Group", "--from=MISSING"])
+
+
+def test_bad_to(clidb, cli):
+    """Test a non-existent --to target"""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["file", "list", "--to=MISSING", "--from=Node"])
+
+
+def test_list(clidb, cli):
+    """Test listing everything."""
+
+    acq = ArchiveAcq.create(name="acq1")
+    ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFile.create(name="file2", acq=acq)
+    acq = ArchiveAcq.create(name="acq2")
+    ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFile.create(name="file4", acq=acq)
+
+    result = cli(0, ["file", "list"])
+
+    assert "acq1/file1" in result.output
+    assert "acq1/file2" in result.output
+    assert "acq2/file3" in result.output
+    assert "acq2/file4" in result.output
+
+
+def test_list_acq(clidb, cli):
+    """Test limiting by --acq."""
+
+    acq = ArchiveAcq.create(name="acq1")
+    ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFile.create(name="file2", acq=acq)
+    acq = ArchiveAcq.create(name="acq2")
+    ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFile.create(name="file4", acq=acq)
+
+    result = cli(0, ["file", "list", "--acq=acq1"])
+
+    assert "acq1/file1" in result.output
+    assert "acq1/file2" in result.output
+    assert "acq2" not in result.output
+
+
+def test_list_details(clidb, cli, assert_row_present):
+    """Test listing details without node/group."""
+
+    acq = ArchiveAcq.create(name="acq1")
+    ArchiveFile.create(
+        name="file1",
+        acq=acq,
+        size_b=3456,
+        md5sum="d41d8cd98f00b204e9800998ecf8427e",
+        registered=datetime(2001, 1, 1, 1, 1, 1, 1),
+    )
+    ArchiveFile.create(
+        name="file2",
+        acq=acq,
+        size_b=4567,
+        md5sum="68b329da9893e34099c7d8ad5cb9c940",
+        registered=datetime(2002, 3, 2, 2, 2, 2, 2),
+    )
+    acq = ArchiveAcq.create(name="acq2")
+    ArchiveFile.create(
+        name="file3",
+        acq=acq,
+        size_b=5678,
+        md5sum="7309AF63395717D5B9F8AA6619301937",
+        registered=datetime(2003, 3, 3, 3, 3, 3, 3),
+    )
+    ArchiveFile.create(name="file4", acq=acq, registered=0)
+
+    result = cli(0, ["file", "list", "--details"])
+
+    assert_row_present(
+        result.output,
+        "acq1/file1",
+        "3.375 kiB",
+        "d41d8cd98f00b204e9800998ecf8427e",
+        "Mon Jan  1 01:01:01 2001 UTC",
+    )
+    assert_row_present(
+        result.output,
+        "acq1/file2",
+        "4.460 kiB",
+        "68b329da9893e34099c7d8ad5cb9c940",
+        "Sat Mar  2 02:02:02 2002 UTC",
+    )
+    assert_row_present(
+        result.output,
+        "acq2/file3",
+        "5.545 kiB",
+        "7309af63395717d5b9f8aa6619301937",
+        "Mon Mar  3 03:03:03 2003 UTC",
+    )
+    assert_row_present(result.output, "acq2/file4", "-", "-", "-")
+
+
+def test_list_node(clidb, cli):
+    """Test --node."""
+
+    group = StorageGroup.create(name="Group")
+    acq = ArchiveAcq.create(name="acq")
+
+    node1 = StorageNode.create(name="Node1", group=group)
+    node2 = StorageNode.create(name="Node2", group=group)
+    node3 = StorageNode.create(name="Node3", group=group)
+
+    file = ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file2", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="N", wants_file="N")
+
+    file = ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file4", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="X", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    result = cli(0, ["file", "list", "--node=Node1", "--node=Node2"])
+
+    assert "acq/file1" in result.output
+    assert "acq/file2" in result.output
+    assert "acq/file3" in result.output
+    assert "acq/file4" not in result.output
+
+
+def test_list_group(clidb, cli):
+    """Test --group."""
+
+    acq = ArchiveAcq.create(name="acq")
+
+    group1 = StorageGroup.create(name="Group1")
+    node1 = StorageNode.create(name="Node1", group=group1)
+
+    group2 = StorageGroup.create(name="Group2")
+    node2 = StorageNode.create(name="Node2", group=group2)
+
+    group3 = StorageGroup.create(name="Group3")
+    node3 = StorageNode.create(name="Node3", group=group3)
+
+    file = ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file2", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="N", wants_file="N")
+
+    file = ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file4", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="X", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    result = cli(0, ["file", "list", "--group=Group1", "--group=Group2"])
+
+    assert "acq/file1" in result.output
+    assert "acq/file2" in result.output
+    assert "acq/file3" in result.output
+    assert "acq/file4" not in result.output
+
+
+def test_list_node_group(clidb, cli):
+    """Test --node and --group together."""
+
+    acq = ArchiveAcq.create(name="acq")
+
+    group1 = StorageGroup.create(name="Group1")
+    node1 = StorageNode.create(name="Node1", group=group1)
+
+    group2 = StorageGroup.create(name="Group2")
+    node2 = StorageNode.create(name="Node2", group=group2)
+
+    group3 = StorageGroup.create(name="Group3")
+    node3 = StorageNode.create(name="Node3", group=group3)
+
+    file = ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file2", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="N", wants_file="N")
+
+    file = ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file4", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="X", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    result = cli(0, ["file", "list", "--group=Group1", "--node=Node1", "--node=Node2"])
+
+    assert "acq/file1" in result.output
+    assert "acq/file2" in result.output
+    assert "acq/file3" in result.output
+    assert "acq/file4" not in result.output
+
+    # i.e. no double listing
+    assert result.output.count("acq") == 3
+
+
+def test_list_all(clidb, cli):
+    """Test --all."""
+
+    group = StorageGroup.create(name="Group")
+    acq = ArchiveAcq.create(name="acq")
+
+    node1 = StorageNode.create(name="Node1", group=group)
+    node2 = StorageNode.create(name="Node2", group=group)
+    node3 = StorageNode.create(name="Node3", group=group)
+
+    file = ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file2", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="N", wants_file="N")
+
+    file = ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file4", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="X", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    result = cli(0, ["file", "list", "--node=Node1", "--node=Node2", "--all"])
+
+    assert "acq/file1" in result.output
+    assert "acq/file2" not in result.output
+    assert "acq/file3" not in result.output
+    assert "acq/file4" not in result.output
+
+
+def test_list_not(clidb, cli):
+    """Test --not."""
+
+    group = StorageGroup.create(name="Group")
+    acq = ArchiveAcq.create(name="acq")
+
+    node1 = StorageNode.create(name="Node1", group=group)
+    node2 = StorageNode.create(name="Node2", group=group)
+    node3 = StorageNode.create(name="Node3", group=group)
+
+    file = ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file2", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="N", wants_file="N")
+
+    file = ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file4", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="X", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    result = cli(0, ["file", "list", "--node=Node1", "--node=Node2", "--not"])
+
+    assert "acq/file1" not in result.output
+    assert "acq/file2" in result.output
+    assert "acq/file3" in result.output
+    assert "acq/file4" in result.output
+
+
+def test_list_not_all(clidb, cli):
+    """Test --not --all."""
+
+    group = StorageGroup.create(name="Group")
+    acq = ArchiveAcq.create(name="acq")
+
+    node1 = StorageNode.create(name="Node1", group=group)
+    node2 = StorageNode.create(name="Node2", group=group)
+    node3 = StorageNode.create(name="Node3", group=group)
+
+    file = ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file2", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="N", wants_file="N")
+
+    file = ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file4", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="X", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    result = cli(0, ["file", "list", "--node=Node1", "--node=Node2", "--not", "--all"])
+
+    assert "acq/file1" not in result.output
+    assert "acq/file2" not in result.output
+    assert "acq/file3" not in result.output
+    assert "acq/file4" in result.output
+
+
+def test_state(clidb, cli):
+    """Test the state flags."""
+
+    acq = ArchiveAcq.create(name="acq")
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
+
+    for has in ["Y", "M", "X", "N"]:
+        for wants in ["Y", "M", "N"]:
+            file = ArchiveFile.create(name="File" + has + wants, acq=acq)
+            ArchiveFileCopy.create(file=file, node=node, has_file=has, wants_file=wants)
+
+    # The files we want to find for each state
+    state_files = {
+        "corrupt": ["FileXY", "FileXM"],
+        "healthy": ["FileYY", "FileYM"],
+        "suspect": ["FileMY", "FileMM"],
+        "missing": ["FileNY"],
+    }
+
+    # Run through all the state combinations.  There are 2**4 of these:
+    for num in range(16):
+        corrupt = num & 1 == 0
+        healthy = num & 2 == 0
+        suspect = num & 4 == 0
+        missing = num & 8 == 0
+
+        # Build command and resultant file list
+        command = ["file", "list", "--node=Node"]
+        files = []
+        if corrupt:
+            command.append("--corrupt")
+            files += state_files["corrupt"]
+        if suspect:
+            command.append("--suspect")
+            files += state_files["suspect"]
+        if missing:
+            command.append("--missing")
+            files += state_files["missing"]
+        if healthy:
+            command.append("--healthy")
+            files += state_files["healthy"]
+        # The default when no state is chosen
+        if not files:
+            files = state_files["healthy"]
+
+        # Execute
+        result = cli(0, command)
+
+        # Check files
+        for file in files:
+            assert "acq/" + file in result.output
+        # Count files listed to make sure there aren't extras
+        assert result.output.count("acq") == len(files)
+
+
+def test_sync(clidb, cli):
+    """Test --from --to."""
+
+    group1 = StorageGroup.create(name="Group1")
+    node1 = StorageNode.create(name="Node1", group=group1)
+
+    group2 = StorageGroup.create(name="Group2")
+    node2 = StorageNode.create(name="Node2", group=group2)
+
+    acq = ArchiveAcq.create(name="acq")
+    file = ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file2", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file4", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="M")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="N", wants_file="Y")
+
+    result = cli(0, ["file", "list", "--from=Node1", "--to=Group2"])
+
+    assert "file1" in result.output
+    assert "file2" not in result.output
+    assert "file3" not in result.output
+    assert "file4" in result.output
+
+
+def test_sync_select(clidb, cli):
+    """Test --from --to with selection"""
+
+    group1 = StorageGroup.create(name="Group1")
+    node1 = StorageNode.create(name="Node1", group=group1)
+
+    group2 = StorageGroup.create(name="Group2")
+    node2 = StorageNode.create(name="Node2", group=group2)
+
+    group3 = StorageGroup.create(name="Group3")
+    node3 = StorageNode.create(name="Node3", group=group3)
+
+    acq = ArchiveAcq.create(name="acq")
+    file = ArchiveFile.create(name="file1", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file2", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file3", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node2, has_file="Y", wants_file="Y")
+
+    file = ArchiveFile.create(name="file4", acq=acq)
+    ArchiveFileCopy.create(file=file, node=node1, has_file="Y", wants_file="M")
+    ArchiveFileCopy.create(file=file, node=node2, has_file="N", wants_file="Y")
+    ArchiveFileCopy.create(file=file, node=node3, has_file="Y", wants_file="Y")
+
+    result = cli(0, ["file", "list", "--from=Node1", "--to=Group2", "--node=Node3"])
+
+    assert "file1" not in result.output
+    assert "file2" not in result.output
+    assert "file3" not in result.output
+    assert "file4" in result.output
+
+    result = cli(
+        0, ["file", "list", "--from=Node1", "--to=Group2", "--not", "--node=Node3"]
+    )
+
+    assert "file1" in result.output
+    assert "file2" not in result.output
+    assert "file3" not in result.output
+    assert "file4" not in result.output
+
+
+def test_detail_node(clidb, cli, assert_row_present):
+    """Test --details with extra details"""
+
+    group = StorageGroup.create(name="group")
+    node = StorageNode.create(name="node", group=group)
+
+    acq = ArchiveAcq.create(name="acq")
+
+    file = ArchiveFile.create(
+        name="file1",
+        acq=acq,
+        size_b=1234,
+        md5sum="d41d8cd98f00b204e9800998ecf8427e",
+        registered=0,
+    )
+    ArchiveFileCopy.create(
+        file=file, node=node, size_b=2345, has_file="Y", wants_file="M"
+    )
+
+    file = ArchiveFile.create(
+        name="file2",
+        acq=acq,
+        size_b=3456,
+        md5sum="68b329da9893e34099c7d8ad5cb9c940",
+        registered=0,
+    )
+    ArchiveFileCopy.create(
+        file=file, node=node, size_b=4567, has_file="M", wants_file="Y"
+    )
+
+    file = ArchiveFile.create(
+        name="file3",
+        acq=acq,
+        size_b=5678,
+        md5sum="7309AF63395717D5B9F8AA6619301937",
+        registered=0,
+    )
+    ArchiveFileCopy.create(
+        file=file, node=node, size_b=6789, has_file="N", wants_file="Y"
+    )
+
+    result = cli(
+        0,
+        [
+            "file",
+            "list",
+            "--node=node",
+            "--healthy",
+            "--missing",
+            "--suspect",
+            "--details",
+        ],
+    )
+
+    assert_row_present(
+        result.output,
+        "acq/file1",
+        "1.205 kiB",
+        "d41d8cd98f00b204e9800998ecf8427e",
+        "-",
+        "Removable",
+        "2.290 kiB",
+    )
+    assert_row_present(
+        result.output,
+        "acq/file2",
+        "3.375 kiB",
+        "68b329da9893e34099c7d8ad5cb9c940",
+        "-",
+        "Suspect",
+        "4.460 kiB",
+    )
+    assert_row_present(
+        result.output,
+        "acq/file3",
+        "5.545 kiB",
+        "7309af63395717d5b9f8aa6619301937",
+        "-",
+        "Missing",
+        "6.630 kiB",
+    )
+
+    result = cli(
+        0,
+        [
+            "file",
+            "list",
+            "--group=group",
+            "--healthy",
+            "--missing",
+            "--suspect",
+            "--details",
+        ],
+    )
+
+    assert_row_present(
+        result.output,
+        "acq/file1",
+        "1.205 kiB",
+        "d41d8cd98f00b204e9800998ecf8427e",
+        "-",
+        "Present",
+        "node",
+    )
+    assert_row_present(
+        result.output,
+        "acq/file2",
+        "3.375 kiB",
+        "68b329da9893e34099c7d8ad5cb9c940",
+        "-",
+        "Suspect",
+        "node",
+    )
+    assert_row_present(
+        result.output,
+        "acq/file3",
+        "5.545 kiB",
+        "7309af63395717d5b9f8aa6619301937",
+        "-",
+        "Absent",
+        "-",
+    )


### PR DESCRIPTION
Usage here is a little complex.  Might need better help to explain which options can be used together.  Also: is `--not` a too confusing for the flag which negates the node/group constraint?

I found it difficult to collapse this command into a single query, so instead there are three stages (excluding the various name-to-thing look-ups):

1. one or more query to handle location and state flag constraints
2. a query, maybe, for --from and --to
3. a final query that ties the above together with the --acq limit, and applies the --not, if necessary.

Closes #45 via:
```
file list --corrupt --node=<NODE>
```