### PR TITLE
refactor(CLI): Centralise common functionality

### DIFF
--- a/alpenhorn/cli/group/autosync.py
+++ b/alpenhorn/cli/group/autosync.py
@@ -3,8 +3,9 @@
 import click
 import peewee as pw
 
-from ...db import StorageGroup, StorageNode, StorageTransferAction, database_proxy
+from ...db import StorageTransferAction, database_proxy
 from ..cli import echo
+from ..options import resolve_group, resolve_node
 
 
 @click.command()
@@ -20,7 +21,7 @@ def autosync(ctx, group_name, node_name, remove):
     """Manage autosync sources for this group.
 
     This allows you to add (the default) or remove (using --remove)
-    the StorageNode named NODE as a an autosync souce for the Storage
+    the Storage Node named NODE as a an autosync souce for the Storage
     Group named GROUP.
 
     If NODE is added as an autosync source for GROUP, then, whenever
@@ -29,15 +30,8 @@ def autosync(ctx, group_name, node_name, remove):
     """
 
     with database_proxy.atomic():
-        try:
-            group = StorageGroup.get(name=group_name)
-        except pw.DoesNotExist:
-            raise click.ClickException(f"no such group: {group_name}")
-
-        try:
-            node = StorageNode.get(name=node_name)
-        except pw.DoesNotExist:
-            raise click.ClickException(f"no such node: {node_name}")
+        group = resolve_group(group_name)
+        node = resolve_node(node_name)
 
         # Sanity check: can't autosync within a group
         if group == node.group and not remove:

--- a/alpenhorn/cli/group/show.py
+++ b/alpenhorn/cli/group/show.py
@@ -15,7 +15,7 @@ from ...db import (
 )
 from ..cli import echo
 from ..node.stats import get_stats
-from ..options import cli_option
+from ..options import cli_option, resolve_group
 
 
 @click.command()
@@ -41,10 +41,7 @@ def show(group_name, actions, all_, node_details, node_stats, transfers):
         transfers = True
         actions = True
 
-    try:
-        group = StorageGroup.get(name=group_name)
-    except pw.DoesNotExist:
-        raise click.ClickException(f"no such group: {group_name}")
+    group = resolve_group(group_name)
 
     # Print a report
     echo("Storage Group: " + group.name)

--- a/alpenhorn/cli/group/sync.py
+++ b/alpenhorn/cli/group/sync.py
@@ -19,10 +19,11 @@ from ...db import (
 from ..cli import check_then_update, echo
 from ..options import (
     cli_option,
-    files_in_target,
+    files_in_groups,
     not_both,
     requires_other,
     resolve_acqs,
+    resolve_group,
 )
 
 
@@ -171,7 +172,7 @@ def _run_sync(
     """
 
     # Get list of target files
-    skipped_files = files_in_target(target, in_any=True)
+    skipped_files = files_in_groups(resolve_group(target), in_any=True)
 
     # If there are no target files, set it to the empty list
     if skipped_files is None:

--- a/alpenhorn/cli/node/activate.py
+++ b/alpenhorn/cli/node/activate.py
@@ -4,9 +4,15 @@ import click
 import json
 import peewee as pw
 
-from ...db import database_proxy, StorageGroup, StorageNode
+from ...db import database_proxy, StorageNode
 from ..cli import echo, update_or_remove
-from ..options import cli_option, exactly_one, set_storage_type, set_io_config
+from ..options import (
+    cli_option,
+    exactly_one,
+    resolve_node,
+    set_storage_type,
+    set_io_config,
+)
 
 
 @click.command()
@@ -26,11 +32,7 @@ def activate(name, address, host, root, username):
     """
 
     with database_proxy.atomic():
-        # Check name
-        try:
-            node = StorageNode.get(name=name)
-        except pw.DoesNotExist:
-            raise click.ClickException("no such node: " + name)
+        node = resolve_node(name)
 
         # If the node is already active, we don't do an update, even if different
         # metadata was specified

--- a/alpenhorn/cli/node/create.py
+++ b/alpenhorn/cli/node/create.py
@@ -5,8 +5,14 @@ import json
 import peewee as pw
 
 from ...db import database_proxy, StorageGroup, StorageNode, ArchiveFileImportRequest
-from ..options import cli_option, exactly_one, set_storage_type, set_io_config
 from ..cli import echo
+from ..options import (
+    cli_option,
+    exactly_one,
+    resolve_group,
+    set_storage_type,
+    set_io_config,
+)
 
 
 @click.command()
@@ -130,10 +136,7 @@ def create(
             except pw.DoesNotExist:
                 group = StorageGroup.create(name=node_name)
         else:
-            try:
-                group = StorageGroup.get(name=group)
-            except pw.DoesNotExist:
-                raise click.ClickException("no such group: " + group)
+            group = resolve_group(group)
 
         node = StorageNode.create(
             name=node_name,

--- a/alpenhorn/cli/node/deactivate.py
+++ b/alpenhorn/cli/node/deactivate.py
@@ -5,6 +5,7 @@ import peewee as pw
 
 from ...db import database_proxy, StorageNode
 from ..cli import echo
+from ..options import resolve_node
 
 
 @click.command()
@@ -17,11 +18,7 @@ def deactivate(name):
     """
 
     with database_proxy.atomic():
-        # Check name
-        try:
-            node = StorageNode.get(name=name)
-        except pw.DoesNotExist:
-            raise click.ClickException("no such node: " + name)
+        node = resolve_node(name)
 
         if not node.active:
             echo(f'No change: node "{name}" already inactive.')

--- a/alpenhorn/cli/node/init.py
+++ b/alpenhorn/cli/node/init.py
@@ -3,8 +3,9 @@
 import click
 import peewee as pw
 
-from ...db import database_proxy, ArchiveFileImportRequest, StorageNode
+from ...db import database_proxy, ArchiveFileImportRequest
 from ..cli import echo
+from ..options import resolve_node
 
 
 @click.command()
@@ -25,10 +26,7 @@ def init(name):
     """
 
     with database_proxy.atomic():
-        try:
-            node = StorageNode.get(name=name)
-        except pw.DoesNotExist:
-            raise click.ClickException("no such node: " + name)
+        node = resolve_node(name)
 
         # Add request
         ArchiveFileImportRequest.create(node=node, path="ALPENHORN_NODE")

--- a/alpenhorn/cli/node/list.py
+++ b/alpenhorn/cli/node/list.py
@@ -5,7 +5,7 @@ import peewee as pw
 from tabulate import tabulate
 
 from ...db import StorageGroup, StorageNode
-from ..options import cli_option
+from ..options import cli_option, resolve_group
 from ..cli import echo
 
 
@@ -30,11 +30,7 @@ def list_(active, group, host):
     if active is not None:
         nodes = nodes.where(StorageNode.active == active)
     if group:
-        try:
-            group = StorageGroup.get(name=group)
-        except pw.DoesNotExist:
-            raise click.ClickException("no such group: " + group)
-        nodes = nodes.where(StorageNode.group == group)
+        nodes = nodes.where(StorageNode.group == resolve_group(group))
     if host:
         nodes = nodes.where(StorageNode.host == host)
 

--- a/alpenhorn/cli/node/modify.py
+++ b/alpenhorn/cli/node/modify.py
@@ -4,9 +4,16 @@ import click
 import json
 import peewee as pw
 
-from ...db import database_proxy, StorageGroup, StorageNode
-from ..options import cli_option, not_both, set_storage_type, set_io_config
+from ...db import database_proxy, StorageNode
 from ..cli import echo, update_or_remove
+from ..options import (
+    cli_option,
+    not_both,
+    resolve_group,
+    resolve_node,
+    set_storage_type,
+    set_io_config,
+)
 
 
 @click.command()
@@ -84,18 +91,11 @@ def modify(
     storage_type = set_storage_type(archive, field, transport, none_ok=True)
 
     with database_proxy.atomic():
-        # Check name
-        try:
-            node = StorageNode.get(name=name)
-        except pw.DoesNotExist:
-            raise click.ClickException("no such node: " + name)
+        node = resolve_node(name)
 
         # Get group
         if group:
-            try:
-                group = StorageGroup.get(name=group)
-            except pw.DoesNotExist:
-                raise click.ClickException("no such group: " + group)
+            group = resolve_group(group)
 
         io_config = set_io_config(io_config, io_var, node.io_config)
         if io_config:

--- a/alpenhorn/cli/node/scan.py
+++ b/alpenhorn/cli/node/scan.py
@@ -4,8 +4,9 @@ import click
 import pathlib
 import peewee as pw
 
-from ...db import ArchiveFileImportRequest, StorageNode, database_proxy
+from ...db import ArchiveFileImportRequest, database_proxy
 from ..cli import echo
+from ..options import resolve_node
 
 
 @click.command()
@@ -33,10 +34,7 @@ def scan(name, path, register_new):
     """
 
     with database_proxy.atomic():
-        try:
-            node = StorageNode.get(name=name)
-        except pw.DoesNotExist:
-            raise click.ClickException("no such node: " + name)
+        node = resolve_node(name)
 
         # Strip node root, if absolute
         path = pathlib.PurePath(path)

--- a/alpenhorn/cli/node/show.py
+++ b/alpenhorn/cli/node/show.py
@@ -8,13 +8,12 @@ from tabulate import tabulate
 from ...common.util import pretty_bytes
 from ...db import (
     StorageGroup,
-    StorageNode,
     StorageTransferAction,
     ArchiveFileCopyRequest,
     ArchiveFile,
 )
 from ..cli import echo, pretty_time
-from ..options import cli_option
+from ..options import cli_option, resolve_node
 from .stats import get_stats
 
 
@@ -41,10 +40,7 @@ def show(name, actions, all_, stats, transfers):
         stats = True
         transfers = True
 
-    try:
-        node = StorageNode.get(name=name)
-    except pw.DoesNotExist:
-        raise click.ClickException(f"no such node: {name}")
+    node = resolve_node(name)
 
     if node.storage_type == "A":
         type_name = "Archive"

--- a/alpenhorn/cli/node/stats.py
+++ b/alpenhorn/cli/node/stats.py
@@ -7,9 +7,9 @@ import peewee as pw
 from tabulate import tabulate
 from collections import defaultdict
 
-from ...db import StorageGroup, StorageNode, ArchiveFile, ArchiveFileCopy
+from ...db import StorageNode, ArchiveFile, ArchiveFileCopy
 from ...common.util import pretty_bytes
-from ..options import cli_option
+from ..options import cli_option, resolve_group
 from ..cli import echo
 
 
@@ -165,11 +165,7 @@ def stats(active, group, host, extra_stats):
     if active is not None:
         query = query.where(StorageNode.active == active)
     if group:
-        try:
-            group = StorageGroup.get(name=group)
-        except pw.DoesNotExist:
-            raise click.ClickException("no such group: " + group)
-        query = query.where(StorageNode.group == group)
+        query = query.where(StorageNode.group == resolve_group(group))
     if host:
         query = query.where(StorageNode.host == host)
 


### PR DESCRIPTION
Creates some helper functions in `cli.options` for common name-to-thing lookups:

* resolve_group
* resolve_node

And then to generalise files-in-thing lookups (replacing files_in_target):

* files_in_nodes
* files_in_groups

Finally, another usage check helper:

* both_or_neither

Existing CLI commands updated to use the new common functions.