### PR TITLE
feat(CLI): "file create" command

### DIFF
--- a/alpenhorn/cli/file/__init__.py
+++ b/alpenhorn/cli/file/__init__.py
@@ -3,6 +3,7 @@
 import click
 import peewee as pw
 
+from .create import create
 from .import_ import import_
 from .show import show
 
@@ -12,5 +13,6 @@ def cli():
     """Manage Files."""
 
 
+cli.add_command(create, "create")
 cli.add_command(import_, "import")
 cli.add_command(show, "show")

--- a/alpenhorn/cli/file/create.py
+++ b/alpenhorn/cli/file/create.py
@@ -1,0 +1,170 @@
+"""alpenhorn file create command."""
+
+import click
+import pathlib
+import peewee as pw
+
+from ...common.util import md5sum_file
+from ...db import (
+    ArchiveAcq,
+    ArchiveFile,
+    database_proxy,
+)
+from ..cli import echo
+from ..options import both_or_neither, not_both, requires_other, resolve_acqs
+
+
+@click.command()
+@click.argument("name", metavar="NAME")
+@click.argument("acq_name", metavar="ACQ")
+@click.option(
+    "--from-file",
+    is_flag=True,
+    help="Scan a local copy of the file to compute MD5 and size.",
+)
+@click.option(
+    "--md5",
+    metavar="HASH",
+    help="The 128-bit MD5 hash of the file expressed as 32 hex digits.",
+)
+@click.option(
+    "--prefix",
+    metavar="PREFIX",
+    help="Use with --from-file to specify the location of the file to scan.",
+)
+@click.option(
+    "--size",
+    type=int,
+    default=None,
+    metavar="SIZE",
+    help="The size in bytes of the file.",
+)
+def create(name, acq_name, from_file, md5, prefix, size):
+    """Create a new File record.
+
+    This command adds a File named NAME to the Acquisition named ACQ.
+    ACQ must not already contain a File named NAME.
+
+    When creating the record, you must provide both the File's size in bytes
+    and its 128-bit MD5 hash value.  There are two ways of doing this:
+
+    The first way is to manually set them with the "--md5" and "--size"
+    options.
+
+    The second way is to use the "--from-file" flag to ask the CLI to
+    compute them by scanning a local copy of the file.  In this case you may,
+    optionally, use the "--prefix=PREFIX" option to tell alpenhorn where to
+    look for the file:
+
+    If "--prefix" is used, alpenhorn will assume the file is at the path
+    "PREFIX/ACQ/NAME".  PREFIX may be relative or absolute.  If relative,
+    it's taken to be relative to the current working directory.  If
+    PREFIX is not given, it's assumed to be "." (the current working directory).
+
+    If "--from-file" is used, but an error occurs trying to scan the file, no file
+    record will be created.
+
+    Note: this command does _not_ associate the new file with an Storage Node,
+    even if "--from-file" and "--prefix" were used to point alpenhorn to a copy of
+    the file inside a local Storage Node tree.
+
+    If the file _is_ already present in a Storage Node, it's generally easier to
+    request the daemon import the file, rather than manually creating the file entry
+    via command line, by runnning:
+
+    \b
+    file import ACQ/NAME NODE --register-new
+
+    instead of using this command.  Importing files is the recommended way to create
+    new File records in almost all cases.
+    """
+
+    # Usage checks
+
+    # Must have either --from-file or (--md5 AND --size), but not both
+    both_or_neither(md5, "md5", size, "size")
+    not_both(from_file, "from-file", md5, "md5")
+    if md5 is None and not from_file:
+        raise click.UsageError("missing either --from-file or both --md5 and --size")
+
+    # Can't use --prefix without --from-file
+    requires_other(prefix, "prefix", from_file, "from_file")
+
+    # Size must be non-negative
+    if size is not None and size < 0:
+        raise click.ClickException(f"negative file size.")
+
+    # Validate MD5 hash
+    if md5 is not None:
+        # The hash must be a 128-byte number specified as 32 hex digits
+        if len(md5) != 32:
+            raise click.ClickException(f"invalid hash: {md5}.  Expected 32 hex digits.")
+        try:
+            int(md5, base=16)
+        except ValueError:
+            raise click.ClickException(f"invalid hash: {md5}.  Expected 32 hex digits.")
+
+    # Scan a file, if requested
+    if from_file:
+        # This is an early check to make sure we can create the file to save us from
+        # MD5-ing the file and then failing to create the record because it already
+        # exists.  We'll have to do this check again when creating the file (to ensure
+        # database consistency).
+        with database_proxy.atomic():
+            # Resolve acq
+            acq = resolve_acqs([acq_name])[0]
+
+            # Check that "name" isn't already a file in acq
+            try:
+                ArchiveFile.get(name=name, acq=acq)
+                raise click.ClickException(
+                    f'the File "{acq_name}/{name}" already exists'
+                )
+            except pw.DoesNotExist:
+                pass
+
+        if prefix:
+            local_path = pathlib.Path(prefix).joinpath(acq_name).joinpath(name)
+        else:
+            local_path = pathlib.Path(acq_name).joinpath(name)
+
+        # Note: the CLI explicitly does NOT use the I/O framework.  The
+        # CLI always assumes it's reading a "normal" file on a "normal" filesystem.
+
+        # Reject weird stuff
+        if not local_path.exists():
+            raise click.ClickException(f"no such file: {local_path}")
+        if not local_path.is_file():
+            raise click.ClickException(f"{local_path} is not a regular file")
+
+        # Stat it to get the size.
+        try:
+            size = local_path.stat().st_size
+        except OSError as e:
+            raise click.ClickException(f"unable to stat {local_path}: {e}") from e
+
+        # Now MD5 it
+        try:
+            md5 = md5sum_file(str(local_path))
+        except OSError as e:
+            raise click.ClickException(f"failed to hash {local_path}: {e}") from e
+
+        if md5 is None:
+            raise click.ClickException(f"failed to hash {local_path}")
+
+    # Create the ArchiveFile
+    with database_proxy.atomic():
+        # Resolve acq
+        acq = resolve_acqs([acq_name])[0]
+
+        # Check that "name" isn't already a file in acq.  We _may_ have already
+        # done this once, but we need to do it again inside this transaction.
+        try:
+            ArchiveFile.get(name=name, acq=acq)
+            raise click.ClickException(f'the File "{acq_name}/{name}" already exists')
+        except pw.DoesNotExist:
+            pass
+
+        ArchiveFile.create(name=name, acq=acq, md5sum=md5, size_b=size)
+
+        echo(f"Registered File {acq_name}/{name}.")

--- a/tests/cli/file/test_create.py
+++ b/tests/cli/file/test_create.py
@@ -1,0 +1,293 @@
+"""Test CLI: alpenhorn file create"""
+
+from os import getcwd
+import datetime
+
+from alpenhorn.db import ArchiveAcq, ArchiveFile, utcnow
+
+
+def test_no_data(clidb, cli):
+    """Test providing not all data, in various ways."""
+
+    ArchiveAcq.create(name="Acq")
+
+    cli(2, ["file", "create", "name", "Acq"])
+    cli(2, ["file", "create", "name", "Acq", "--md5=0123456789ABCDEF0123456789ABCDEF"])
+    cli(2, ["file", "create", "name", "Acq", "--size=3"])
+
+
+def test_negative_size(clidb, cli):
+    """Test a negative size."""
+
+    ArchiveAcq.create(name="Acq")
+
+    cli(
+        1,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--md5=0123456789ABCDEF0123456789ABCDEF",
+            "--size=-3",
+        ],
+    )
+
+
+def test_bad_md5(clidb, cli):
+    """Test bad --md5 values."""
+
+    ArchiveAcq.create(name="Acq")
+
+    cli(
+        1,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--md5=123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+    cli(
+        1,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--md5=Q123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+    cli(
+        1,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--md5=F0123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+
+
+def test_prefix_no_scan(clidb, cli):
+    """Test --prefix without --from-file."""
+
+    ArchiveAcq.create(name="Acq")
+
+    cli(
+        2,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--prefix=.",
+            "--md5=0123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+
+
+def test_data_clash(clidb, cli):
+    """Test scanning and providing data together."""
+
+    ArchiveAcq.create(name="Acq")
+
+    cli(
+        2,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--from-file",
+            "--md5=0123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+    cli(
+        2,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--from-file",
+            "--md5=0123456789ABCDEF0123456789ABCDEF",
+        ],
+    )
+    cli(2, ["file", "create", "name", "Acq", "--from-file", "--size=3"])
+
+
+def test_no_acq(clidb, cli):
+    """Test with non-existent acq."""
+
+    cli(
+        1,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--md5=0123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+
+
+def test_exists(clidb, cli):
+    """Test with exising file."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="name", acq=acq)
+
+    cli(
+        1,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--md5=0123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+
+
+def test_with_data(clidb, cli):
+    """Test creation with data provided."""
+
+    before = utcnow().replace(microsecond=0)
+
+    acq = ArchiveAcq.create(name="Acq")
+
+    cli(
+        0,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--md5=0123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+
+    file = ArchiveFile.get(name="name")
+    assert file.acq == acq
+    assert file.md5sum.upper() == "0123456789ABCDEF0123456789ABCDEF"
+    assert file.size_b == 3
+    assert file.registered >= before
+
+
+def test_with_data(clidb, cli):
+    """Test creation with data provided."""
+
+    before = utcnow().replace(microsecond=0)
+
+    acq = ArchiveAcq.create(name="Acq")
+
+    cli(
+        0,
+        [
+            "file",
+            "create",
+            "name",
+            "Acq",
+            "--md5=0123456789ABCDEF0123456789ABCDEF",
+            "--size=3",
+        ],
+    )
+
+    file = ArchiveFile.get(name="name")
+    assert file.acq == acq
+    assert file.md5sum.upper() == "0123456789ABCDEF0123456789ABCDEF"
+    assert file.size_b == 3
+    assert file.registered >= before
+
+
+def test_file_not_found(clidb, cli, xfs):
+    """Test --from-file with missing file."""
+
+    acq = ArchiveAcq.create(name="Acq")
+
+    cli(1, ["file", "create", "name", "Acq", "--from-file"])
+
+
+def test_file_not_file(clidb, cli, xfs):
+    """Test --from-file with non-file."""
+
+    xfs.create_dir(getcwd() + "/Acq/name")
+
+    acq = ArchiveAcq.create(name="Acq")
+
+    cli(1, ["file", "create", "name", "Acq", "--from-file"])
+
+
+def test_file_access(clidb, cli, xfs):
+    """Test --from-file with unreadable file."""
+
+    xfs.create_file(getcwd() + "/Acq/name", st_mode=0)
+
+    acq = ArchiveAcq.create(name="Acq")
+
+    cli(1, ["file", "create", "name", "Acq", "--from-file"])
+
+
+def test_from_file(clidb, cli, xfs):
+    """Test creating --from-file."""
+
+    before = utcnow().replace(microsecond=0)
+
+    xfs.create_file(getcwd() + "/Acq/name", contents="contents")
+
+    acq = ArchiveAcq.create(name="Acq")
+
+    cli(0, ["file", "create", "name", "Acq", "--from-file"])
+
+    file = ArchiveFile.get(name="name")
+    assert file.acq == acq
+    assert file.md5sum.lower() == "98bf7d8c15784f0a3d63204441e1e2aa"
+    assert file.size_b == len("contents")
+    assert file.registered >= before
+
+
+def test_from_file_relprefix(clidb, cli, xfs):
+    """Test creating --from-file with relative --prefix."""
+
+    before = utcnow().replace(microsecond=0)
+
+    xfs.create_file(getcwd() + "/prefix/Acq/name", contents="contents")
+
+    acq = ArchiveAcq.create(name="Acq")
+
+    cli(0, ["file", "create", "name", "Acq", "--from-file", "--prefix=prefix"])
+
+    file = ArchiveFile.get(name="name")
+    assert file.acq == acq
+    assert file.md5sum.lower() == "98bf7d8c15784f0a3d63204441e1e2aa"
+    assert file.size_b == len("contents")
+    assert file.registered >= before
+
+
+def test_from_file_absprefix(clidb, cli, xfs):
+    """Test creating --from-file with absolute --prefix."""
+
+    before = utcnow().replace(microsecond=0)
+
+    xfs.create_file("/prefix/Acq/name", contents="contents")
+
+    acq = ArchiveAcq.create(name="Acq")
+
+    cli(0, ["file", "create", "name", "Acq", "--from-file", "--prefix=/prefix"])
+
+    file = ArchiveFile.get(name="name")
+    assert file.acq == acq
+    assert file.md5sum.lower() == "98bf7d8c15784f0a3d63204441e1e2aa"
+    assert file.size_b == len("contents")
+    assert file.registered >= before


### PR DESCRIPTION
Not the way you should be creating ArchiveFiles, but provided for completeness (like "acq create" was).

Has some actual I/O in it: it can scan a file to generate a MD5 hash if you want it to.  Other than that, this is another simple command: it just creates an ArchiveFile record.