### PR TITLE
feat(CLI): "file modify" command

### DIFF
--- a/alpenhorn/cli/file/__init__.py
+++ b/alpenhorn/cli/file/__init__.py
@@ -5,6 +5,7 @@ import peewee as pw
 
 from .create import create
 from .import_ import import_
+from .modify import modify
 from .show import show
 
 
@@ -15,4 +16,5 @@ def cli():
 
 cli.add_command(create, "create")
 cli.add_command(import_, "import")
+cli.add_command(modify, "modify")
 cli.add_command(show, "show")

--- a/alpenhorn/cli/file/create.py
+++ b/alpenhorn/cli/file/create.py
@@ -11,7 +11,14 @@ from ...db import (
     database_proxy,
 )
 from ..cli import echo
-from ..options import both_or_neither, not_both, requires_other, resolve_acqs
+from ..options import (
+    both_or_neither,
+    cli_option,
+    not_both,
+    requires_other,
+    resolve_acqs,
+    validate_md5,
+)
 
 
 @click.command()
@@ -22,23 +29,13 @@ from ..options import both_or_neither, not_both, requires_other, resolve_acqs
     is_flag=True,
     help="Scan a local copy of the file to compute MD5 and size.",
 )
-@click.option(
-    "--md5",
-    metavar="HASH",
-    help="The 128-bit MD5 hash of the file expressed as 32 hex digits.",
-)
+@cli_option("md5")
 @click.option(
     "--prefix",
     metavar="PREFIX",
     help="Use with --from-file to specify the location of the file to scan.",
 )
-@click.option(
-    "--size",
-    type=int,
-    default=None,
-    metavar="SIZE",
-    help="The size in bytes of the file.",
-)
+@cli_option("size")
 def create(name, acq_name, from_file, md5, prefix, size):
     """Create a new File record.
 
@@ -94,15 +91,7 @@ def create(name, acq_name, from_file, md5, prefix, size):
     if size is not None and size < 0:
         raise click.ClickException(f"negative file size.")
 
-    # Validate MD5 hash
-    if md5 is not None:
-        # The hash must be a 128-byte number specified as 32 hex digits
-        if len(md5) != 32:
-            raise click.ClickException(f"invalid hash: {md5}.  Expected 32 hex digits.")
-        try:
-            int(md5, base=16)
-        except ValueError:
-            raise click.ClickException(f"invalid hash: {md5}.  Expected 32 hex digits.")
+    validate_md5(md5)
 
     # Scan a file, if requested
     if from_file:

--- a/alpenhorn/cli/file/modify.py
+++ b/alpenhorn/cli/file/modify.py
@@ -1,0 +1,82 @@
+"""alpenhorn file show command."""
+
+import click
+import peewee as pw
+
+from ...db import ArchiveFile, ArchiveFileCopy, database_proxy
+from ..cli import echo, update_or_remove
+from ..options import cli_option, file_from_path, validate_md5
+
+
+@click.command()
+@click.argument("path", metavar="FILE")
+@cli_option("md5")
+@click.option("--no-reverify", is_flag=True, help="Don't reverify File copies on Nodes")
+@cli_option("size")
+@click.pass_context
+def modify(ctx, path, md5, no_reverify, size):
+    """Change File details.
+
+    This command can be used to change the MD5 hash
+    and/or recorded size of the File given by the path FILE
+    in the data index.  FILE should be specified as
+    "acq-name/filename".
+
+    By default, after updating a File record, all extant
+    copies of the File will be marked as needing reverification.
+    This is to ensure that all copies of the File marked as
+    healthy have the correct new MD5/size.
+
+    You can skip this re-verification step if necessary by
+    using the -no-reverify flag.
+    """
+
+    # It's a usage error to not provide anything to modify
+    if md5 is None and size is None:
+        raise click.UsageError("at least of --md5 or --size must be used.")
+
+    # Size must be non-negative
+    if size is not None and size < 0:
+        raise click.ClickException(f"negative file size.")
+
+    # Check MD5
+    validate_md5(md5)
+
+    with database_proxy.atomic():
+        file_ = file_from_path(path)
+
+        updates = {}
+        if md5 is not None:
+            # The "remove" part can't happen because an empty string will fail
+            # the validate_md5 check.
+            updates |= update_or_remove("md5sum", md5, file_.md5sum)
+        if size != file_.size_b:
+            updates["size_b"] = size
+
+        if not updates:
+            echo("No change.")
+            ctx.exit()
+
+        # Do the update
+        ArchiveFile.update(**updates).where(ArchiveFile.id == file_.id).execute()
+
+        # Re-verfiy if, not prohibited
+        if not no_reverify:
+            # This re-verifies both good ('Y') copies and corrupt ('X') ones.
+            count = (
+                ArchiveFileCopy.update(has_file="M")
+                .where(
+                    ArchiveFileCopy.file == file_,
+                    ArchiveFileCopy.has_file != "N",
+                    ArchiveFileCopy.wants_file != "N",
+                )
+                .execute()
+            )
+
+            if count:
+                copies = "copy" if count == 1 else "copies"
+                echo("File updated.  {count} {copies} will be re-verified.")
+            else:
+                echo("File updated.  No additional copies need re-verification.")
+        else:
+            echo("File updated.  Re-verification skipped.")

--- a/alpenhorn/cli/options.py
+++ b/alpenhorn/cli/options.py
@@ -120,6 +120,12 @@ def cli_option(option: str, **extra_kwargs):
             "type": float,
             "help": "The maximum allowed size of the node, in GiB",
         }
+    elif option == "md5":
+        args = ("--md5",)
+        kwargs = {
+            "metavar": "HASH",
+            "help": "The 128-bit MD5 hash of the file expressed as 32 hex digits.",
+        }
     elif option == "min_avail":
         args = ("--min-avail",)
         kwargs = {
@@ -140,6 +146,14 @@ def cli_option(option: str, **extra_kwargs):
     elif option == "root":
         args = ("--root",)
         kwargs = {"metavar": "ROOT", "help": "The node root or mount point."}
+    elif option == "size":
+        args = ("--size",)
+        kwargs = {
+            "type": int,
+            "default": None,
+            "metavar": "SIZE",
+            "help": "The size in bytes of the file.",
+        }
     elif option == "target":
         args = ("--target",)
         kwargs = {
@@ -633,3 +647,25 @@ def file_from_path(path: str) -> ArchiveFile:
             pass
 
     raise click.ClickException("No such file: " + str(path))
+
+
+def validate_md5(md5: str | None) -> None:
+    """Vet a user-provided MD5 hash
+
+    The MD5 may be None.
+
+    raises click.ClickException if validation fails.
+    """
+
+    # None is fine.
+    if md5 is None:
+        return
+
+    # The hash must be a 128-byte number specified as 32 hex digits
+    if len(md5) != 32:
+        raise click.ClickException(f"invalid hash: {md5}.  Expected 32 hex digits.")
+
+    try:
+        int(md5, base=16)
+    except ValueError:
+        raise click.ClickException(f"invalid hash: {md5}.  Expected 32 hex digits.")

--- a/tests/cli/file/test_modify.py
+++ b/tests/cli/file/test_modify.py
@@ -1,0 +1,159 @@
+"""Test CLI: alpenhorn file modify"""
+
+from alpenhorn.db import (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    StorageGroup,
+    StorageNode,
+    utcnow,
+)
+
+
+def test_no_data(clidb, cli):
+    """Test providing no data."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="Name", acq=acq)
+
+    cli(2, ["file", "modify", "Acq/Name"])
+
+
+def test_bad_size(clidb, cli):
+    """Test a negative size."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="Name", acq=acq)
+
+    cli(1, ["file", "modify", "Acq/Name", "--size=-3"])
+
+
+def test_bad_md5(clidb, cli):
+    """Test a bad MD5s."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="Name", acq=acq)
+
+    cli(1, ["file", "modify", "Acq/Name", "--md5="])
+    cli(1, ["file", "modify", "Acq/Name", "--md5=FEDCBA9876543210FEDCBA987654321"])
+    cli(1, ["file", "modify", "Acq/Name", "--md5=FEDCBA9876543210FEDCBA987654321Q"])
+    cli(1, ["file", "modify", "Acq/Name", "--md5=FEDCBA9876543210FEDCBA9876543210F"])
+
+
+def test_bad_path(clidb, cli):
+    """Test a bad path."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="Name", acq=acq)
+
+    cli(1, ["file", "modify", "Acq/MISSING", "--size=3"])
+
+
+def test_update(clidb, cli):
+    """Test an update."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="Name", acq=acq, size_b=4)
+
+    group = StorageGroup.create(name="Group")
+    node1 = StorageNode.create(name="Node1", group=group)
+    node2 = StorageNode.create(name="Node2", group=group)
+    node3 = StorageNode.create(name="Node3", group=group)
+    node4 = StorageNode.create(name="Node4", group=group)
+    node5 = StorageNode.create(name="Node5", group=group)
+    node6 = StorageNode.create(name="Node6", group=group)
+
+    ArchiveFileCopy.create(file=file_, node=node1, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file_, node=node2, has_file="X", wants_file="Y")
+    ArchiveFileCopy.create(file=file_, node=node3, has_file="M", wants_file="Y")
+    ArchiveFileCopy.create(file=file_, node=node4, has_file="N", wants_file="Y")
+    ArchiveFileCopy.create(file=file_, node=node5, has_file="Y", wants_file="M")
+    ArchiveFileCopy.create(file=file_, node=node6, has_file="X", wants_file="N")
+
+    cli(
+        0,
+        [
+            "file",
+            "modify",
+            "Acq/Name",
+            "--size=3",
+            "--md5=FEDCBA9876543210FEDCBA9876543210",
+        ],
+    )
+
+    file_ = ArchiveFile.get(name="Name", acq=acq)
+
+    assert file_.md5sum.upper() == "FEDCBA9876543210FEDCBA9876543210"
+    assert file_.size_b == 3
+
+    # Check file copies
+
+    assert ArchiveFileCopy.get(node=node1).has_file == "M"
+    assert ArchiveFileCopy.get(node=node2).has_file == "M"
+    assert ArchiveFileCopy.get(node=node3).has_file == "M"
+    assert ArchiveFileCopy.get(node=node4).has_file == "N"
+    assert ArchiveFileCopy.get(node=node5).has_file == "M"
+    assert ArchiveFileCopy.get(node=node6).has_file == "X"
+
+
+def test_update_no_change(clidb, cli):
+    """Test no change for update."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(
+        name="Name", acq=acq, md5sum="FEDCBA9876543210FEDCBA9876543210", size_b=4
+    )
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
+
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(
+        0,
+        [
+            "file",
+            "modify",
+            "Acq/Name",
+            "--size=4",
+            "--md5=FEDCBA9876543210FEDCBA9876543210",
+        ],
+    )
+
+    file_ = ArchiveFile.get(name="Name", acq=acq)
+    assert file_.md5sum.upper() == "FEDCBA9876543210FEDCBA9876543210"
+    assert file_.size_b == 4
+
+    # File copies haven't changed
+    assert ArchiveFileCopy.get(node=node).has_file == "Y"
+
+
+def test_update_noreverify(clidb, cli):
+    """Test an update with --no-reverify."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="Name", acq=acq, size_b=3)
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
+
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(
+        0,
+        [
+            "file",
+            "modify",
+            "Acq/Name",
+            "--no-reverify",
+            "--size=4",
+            "--md5=FEDCBA9876543210FEDCBA9876543210",
+        ],
+    )
+
+    file_ = ArchiveFile.get(name="Name", acq=acq)
+    assert file_.md5sum.upper() == "FEDCBA9876543210FEDCBA9876543210"
+    assert file_.size_b == 4
+
+    # File copies haven't changed
+    assert ArchiveFileCopy.get(node=node).has_file == "Y"


### PR DESCRIPTION
All this lets you do is modify the md5sum or size_b of an ArchiveFile record.

If a record is modified, by default, it will mark all the copies as needing check because we don't want to get into a situation where the has_file value is wrong.