### PR TITLE
feat(CLI): "file clean" command

### DIFF
--- a/alpenhorn/cli/file/__init__.py
+++ b/alpenhorn/cli/file/__init__.py
@@ -3,6 +3,7 @@
 import click
 import peewee as pw
 
+from .clean import clean
 from .create import create
 from .import_ import import_
 from .show import show
@@ -13,6 +14,7 @@ def cli():
     """Manage Files."""
 
 
+cli.add_command(clean, "clean")
 cli.add_command(create, "create")
 cli.add_command(import_, "import")
 cli.add_command(show, "show")

--- a/alpenhorn/cli/file/clean.py
+++ b/alpenhorn/cli/file/clean.py
@@ -1,0 +1,107 @@
+"""alpenhorn file clean command."""
+
+import click
+import peewee as pw
+
+from ...db import ArchiveFileCopy, database_proxy
+from ..cli import echo
+from ..options import (
+    at_least_one,
+    cli_option,
+    file_from_path,
+    not_both,
+    resolve_group,
+    resolve_node,
+)
+
+
+@click.command()
+@click.argument("path", metavar="FILE")
+@cli_option("archive_ok")
+@cli_option("cancel", help="Cancel existing cleaning requests.")
+@cli_option("node", help="Update the file on Node NODE.")
+@click.option("--now", "-n", help="Force immediate removal.", is_flag=True)
+@click.pass_context
+def clean(ctx, path, archive_ok, cancel, node, now):
+    """Remove a File from a Node.
+
+    This command will schedule the File called FILE for cleaning, or cancel
+    an existing cleaning, if the --cancel flag is used.  FILE should be
+    specified as "<acq_name>/<filename>".
+
+    There are two ways alpenhorn can schedule a file for cleaning:
+
+    * Normally, files are cleaned by *marking* them for discretionary removal.
+      This tells the alpenhorn daemon that it may remove the marked files to
+      stay above the minimum free space set for NODE.  If NODE has no minimum
+      free space set, then these marked files will never be deleted.  The
+      minimum free space can be set using the "--min-avail" option to the
+      "node modify" command.
+
+    * The other option, which can be selected with the "--now" flag, is to
+      *release* files for immediate removal.  Released files will be removed
+      by the daemon as soon as possible.  In this case, files marked for
+      discretionary removal will also be released for immediate removal if
+      they satisfy the specified criteria.
+
+    Either way, if scheduled for cleaning, files will not be removed from a
+    Storage Node unless until they are available on at least two (other)
+    archive nodes.
+
+    By default, alpenhorn will refuse to clean files from an archive node.
+    This restriction may be overridden with the "--archive-ok" flag.
+
+    When using --cancel to cancel cleaning, both kinds of cleaning
+    (discretionary and immediate) will be cancelled, but only if FILE has not
+    yet been removed by the daemon.  When cancelling, --node may be omitted,
+    in which case all pending cleaning requests are cancelled for FILE.
+    """
+
+    # Usage checks: must use --node or --cancel (not exclusively)
+    at_least_one(cancel, "cancel", node, "node")
+    not_both(cancel, "cancel", now, "now")
+
+    # --cancel and --now set the target value of wants_file:
+    if cancel:
+        wants = "Y"
+    elif now:
+        wants = "N"
+    else:
+        wants = "M"
+
+    with database_proxy.atomic():
+        if node:
+            # Check node
+            node = resolve_node(node)
+
+            if node.archive and not cancel:
+                if archive_ok:
+                    echo(f'Node "{node.name}" is an archive node: forcing clean.')
+                else:
+                    echo(f'Not done: Node "{node.name}" is an archive node.')
+                    ctx.exit()
+
+        # Update
+        query = ArchiveFileCopy.update(wants_file=wants).where(
+            ArchiveFileCopy.file == file_from_path(path)
+        )
+
+        # Add node, which may be omitted in cancel mode
+        if node:
+            query = query.where(ArchiveFileCopy.node == node)
+
+        count = query.execute()
+
+    if count:
+        if cancel:
+            if node:
+                echo(f'Cancelled cleaning for "{path}" on Node "{node.name}".')
+            else:
+                requests = "request" if count == 1 else "requests"
+                echo(f'Cancelled {count} cleaning {requests} for "{path}".')
+        elif now:
+            echo(f'Released "{path}" for immediate removal on Node "{node.name}".')
+        else:
+            echo(f'Marked "{path}" for discretionary cleaning on Node "{node.name}".')
+    else:
+        echo(f"No change.")

--- a/alpenhorn/cli/node/clean.py
+++ b/alpenhorn/cli/node/clean.py
@@ -265,9 +265,7 @@ def _run_query(
 @click.command()
 @click.argument("name", metavar="NODE")
 @cli_option("acq")
-@click.option(
-    "--archive-ok", help="Run the clean, even if NODE is an archive node.", is_flag=True
-)
+@cli_option("archive_ok")
 @cli_option("cancel", help="Cancel existing cleaning requests.")
 @click.option(
     "--check",

--- a/alpenhorn/cli/options.py
+++ b/alpenhorn/cli/options.py
@@ -50,6 +50,12 @@ def cli_option(option: str, **extra_kwargs):
             "help": "Make node an archive node.  Incompatible with --field "
             "or --transport.",
         }
+    elif option == "archive_ok":
+        args = ("--archive-ok",)
+        kwargs = {
+            "is_flag": True,
+            "help": "Run the clean, even if NODE is an archive node.",
+        }
     elif option == "auto_verify":
         args = ("--auto-verify",)
         kwargs = {
@@ -202,15 +208,24 @@ def both_or_neither(
         raise click.UsageError(f"--{opt1_name} and --{opt2_name} must be used together")
 
 
+def at_least_one(
+    opt1_set: bool, opt1_name: str, opt2_set: bool, opt2_name: str
+) -> None:
+    """Check that at least one of two options were used.
+
+    If not, raise click.UsageError."""
+
+    if not (opt1_set or opt2_set):
+        raise click.UsageError(f"missing --{opt1_name} or --{opt2_name}")
+
+
 def exactly_one(opt1_set: bool, opt1_name: str, opt2_set: bool, opt2_name: str) -> None:
     """Check that exactly one of two incompatible options were used.
 
     If not, raise click.UsageError."""
 
     not_both(opt1_set, opt1_name, opt2_set, opt2_name)
-
-    if not (opt1_set or opt2_set):
-        raise click.UsageError(f"missing --{opt1_name} or --{opt2_name}")
+    at_least_one(opt1_set, opt1_name, opt2_set, opt2_name)
 
 
 def requires_other(

--- a/tests/cli/file/test_clean.py
+++ b/tests/cli/file/test_clean.py
@@ -1,0 +1,206 @@
+"""Test CLI: alpenhorn file clean"""
+
+from alpenhorn.db import (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    StorageGroup,
+    StorageNode,
+    utcnow,
+)
+
+
+def test_no_cancel_node(clidb, cli):
+    """Must have at least one of --cancel or --node"""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(2, ["file", "clean", "Acq/File"])
+
+
+def test_cancel_now(clidb, cli):
+    """Can't use --now and --cancel together"""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(2, ["file", "clean", "Acq/File", "--cancel", "--now"])
+
+
+def test_missing_file(clidb, cli):
+    """Test a bad path."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(1, ["file", "clean", "MIS/SING", "--node=Node"])
+
+
+def test_missing_node(clidb, cli):
+    """Test a bad node name."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(1, ["file", "clean", "Acq/File", "--node=MISSING"])
+
+
+def test_clean(clidb, cli):
+    """Test M-cleaning."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node2 = StorageNode.create(name="Node2", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+    ArchiveFileCopy.create(file=file_, node=node2, has_file="Y", wants_file="Y")
+
+    cli(0, ["file", "clean", "Acq/File", "--node=Node"])
+
+    assert ArchiveFileCopy.get(node=node).wants_file == "M"
+    assert ArchiveFileCopy.get(node=node2).wants_file == "Y"
+
+
+def test_no_change(clidb, cli):
+    """Test no change."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="M")
+
+    cli(0, ["file", "clean", "Acq/File", "--node=Node"])
+
+    assert ArchiveFileCopy.get(id=1).wants_file == "M"
+
+
+def test_now(clidb, cli):
+    """Test --now."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(0, ["file", "clean", "Acq/File", "--node=Node", "--now"])
+
+    assert ArchiveFileCopy.get(id=1).wants_file == "N"
+
+
+def test_archive(clidb, cli):
+    """Test archive node."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="A")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(0, ["file", "clean", "Acq/File", "--node=Node"])
+
+    # Not done
+    assert ArchiveFileCopy.get(id=1).wants_file == "Y"
+
+
+def test_archive_ok(clidb, cli):
+    """Test archive node forcing."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="A")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="Y")
+
+    cli(0, ["file", "clean", "Acq/File", "--node=Node", "--archive-ok"])
+
+    assert ArchiveFileCopy.get(id=1).wants_file == "M"
+
+
+def test_cancel(clidb, cli):
+    """Test archive node forcing."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="M")
+
+    cli(0, ["file", "clean", "Acq/File", "--node=Node", "--cancel"])
+
+    assert ArchiveFileCopy.get(id=1).wants_file == "Y"
+
+
+def test_cancel_no_node(clidb, cli):
+    """Test archive node forcing."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node2 = StorageNode.create(name="Node2", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node, has_file="Y", wants_file="M")
+    ArchiveFileCopy.create(file=file_, node=node2, has_file="Y", wants_file="N")
+
+    cli(0, ["file", "clean", "Acq/File", "--cancel"])
+
+    assert ArchiveFileCopy.get(id=1).wants_file == "Y"
+    assert ArchiveFileCopy.get(id=2).wants_file == "Y"
+
+
+def test_absent(clidb, cli):
+    """Test file absent from node."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node2 = StorageNode.create(name="Node2", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node2, has_file="Y", wants_file="Y")
+
+    cli(0, ["file", "clean", "Acq/File", "--node=Node"])
+
+    assert ArchiveFileCopy.get(id=1).wants_file == "Y"
+
+
+def test_cancel_absent(clidb, cli):
+    """Test cancel with file absent from node."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node2 = StorageNode.create(name="Node2", group=group, storage_type="F")
+
+    acq = ArchiveAcq.create(name="Acq")
+    file_ = ArchiveFile.create(name="File", acq=acq)
+    ArchiveFileCopy.create(file=file_, node=node2, has_file="Y", wants_file="N")
+
+    cli(0, ["file", "clean", "Acq/File", "--node=Node", "--cancel"])
+
+    assert ArchiveFileCopy.get(id=1).wants_file == "N"


### PR DESCRIPTION
The first of three ArchiveFileCopy-focused commands in this group.

This one manipulates the `wants_file` column.  I've tried to make it similar to the more familiar "node clean" command.

It's quite straightforward.