### PR TITLE
fix(db): Better DB-connection failure handling

### DIFF
--- a/alpenhorn/cli/acq/__init__.py
+++ b/alpenhorn/cli/acq/__init__.py
@@ -5,6 +5,7 @@ import sys
 import click
 import peewee as pw
 
+from ..cli import dbconnect
 from .create import create
 from .files import files
 from .list import list_
@@ -14,6 +15,8 @@ from .show import show
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def cli():
     """Manage Acquisitions."""
+
+    dbconnect()
 
 
 cli.add_command(create, "create")

--- a/alpenhorn/cli/cli.py
+++ b/alpenhorn/cli/cli.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from ..common.logger import echo as echo
 from ..db import (
+    connect as dbconnect,
     ArchiveAcq,
     ArchiveFile,
     ArchiveFileCopy,

--- a/alpenhorn/cli/db/__init__.py
+++ b/alpenhorn/cli/db/__init__.py
@@ -2,12 +2,15 @@
 
 import click
 
+from ..cli import dbconnect
 from .init import init
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def cli():
     """Manage the Data Index."""
+
+    dbconnect()
 
 
 cli.add_command(init, "init")

--- a/alpenhorn/cli/entry.py
+++ b/alpenhorn/cli/entry.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import click
 
-from .. import db
 from ..common.util import help_config_option, start_alpenhorn, version_option
 
 from . import acq, db, file, group, node

--- a/alpenhorn/cli/file/__init__.py
+++ b/alpenhorn/cli/file/__init__.py
@@ -3,6 +3,7 @@
 import click
 import peewee as pw
 
+from ..cli import dbconnect
 from .clean import clean
 from .create import create
 from .import_ import import_
@@ -15,6 +16,8 @@ from .sync import sync
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def cli():
     """Manage Files."""
+
+    dbconnect()
 
 
 cli.add_command(clean, "clean")

--- a/alpenhorn/cli/group/__init__.py
+++ b/alpenhorn/cli/group/__init__.py
@@ -3,8 +3,7 @@
 import click
 import peewee as pw
 
-from ...db import StorageGroup, StorageNode
-
+from ..cli import dbconnect
 from .autosync import autosync
 from .create import create
 from .list import list_
@@ -17,6 +16,8 @@ from .sync import sync
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def cli():
     """Manage Storage Groups."""
+
+    dbconnect()
 
 
 cli.add_command(autosync, "autosync")

--- a/alpenhorn/cli/node/__init__.py
+++ b/alpenhorn/cli/node/__init__.py
@@ -2,6 +2,7 @@
 
 import click
 
+from ..cli import dbconnect
 from .activate import activate
 from .autoclean import autoclean
 from .clean import clean
@@ -21,6 +22,8 @@ from .verify import verify
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 def cli():
     """Manage Storage Nodes."""
+
+    dbconnect()
 
 
 cli.add_command(activate, "activate")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -441,7 +441,7 @@ def hostname(set_config):
     Returns the hostname."""
 
     config.config = config.merge_dict_tree(
-        set_config, {"base": {"hostname": "alpenhost"}}
+        config.config, {"base": {"hostname": "alpenhost"}}
     )
 
     return "alpenhost"
@@ -471,7 +471,7 @@ def use_chimedb(set_config):
     cdb.test_enable()
 
     config.config = config.merge_dict_tree(
-        set_config, {"extensions": ["chimedb.core.alpenhorn"]}
+        config.config, {"extensions": ["chimedb.core.alpenhorn"]}
     )
 
 
@@ -483,6 +483,11 @@ def dbproxy(set_config):
     """
     # Load extensions
     extensions.load_extensions()
+
+    # Set database.url if not already present
+    config.config = config.merge_dict_tree(
+        {"database": {"url": "sqlite:///:memory:"}}, config.config
+    )
 
     # DB start
     db.connect()
@@ -712,6 +717,18 @@ def clidb_noinit(clidb_uri):
 
     yield db
 
+    # Drop all the tables after the test
+    for table in [
+        StorageGroup,
+        StorageNode,
+        StorageTransferAction,
+        ArchiveAcq,
+        ArchiveFile,
+        ArchiveFileCopy,
+        ArchiveFileCopyRequest,
+        ArchiveFileImportRequest,
+    ]:
+        db.execute_sql(f"DROP TABLE IF EXISTS {table._meta.table_name};")
     db.close()
 
 


### PR DESCRIPTION
My goal here was to deal with #244 but that's led me to do some general (and well-needed) clean-up of how the database connections are handled in the test suite as well.

## Changes to the DB connection code

The first thing I've done is in `alpenhorn.db._base` where I've removed the the fallback in-memory DB in the default `_connect` function which used to be instantiated when no DB connection data was present in the config.  I think this was here to make testing alpenhorn easier, but it causes trouble in production environments by hiding instances where the config is not available.

Had we required all productions systems to use a database extension for production database access, this might have been fine to leave as-is, but in practice I don't see how we can do that.

Secondly, a connection error in `db.connect()` will now raise a `click.ClickException` resulting in program exit.  Before, adding this what would usually happen was a crash later when first trying to use the uninitialised database proxy.

## DB connection in the CLI

It appears I never actually had the CLI conencting to the database and the test-suite ran because the fixtures were doing that on the side for the client.

But now the connection is explicit.  I've added the connection attempt to the command group stubs, rather than the top-level CLI entry point, which allows users to still do, say
```
  alpenhorn node --help
```
with an unconfigured database.  I don't know if this is really necessary; it was nice for looking at the usage output while developing, but it might be better to complain as early as possible.  Wherever we put it, the user won't be able to do anything useful without a properly configured database.

Closes #244 

## Test-suite fixes

These two changes have forced me to address the somewhat slap-dash way I was creating and accessing test databases in the test-suite.  The default in-memory DB that was automatically created by an unconfigrued `alpenhornd` is now made explicitly in the `dbproxy` fixture.  Also, the persistent in-memory database used by the client tests explicitly drop all tables between tests to keep things isolated.