### PR TITLE
fix(alpenhorn): Fix f-strings

### DIFF
--- a/alpenhorn/cli/file/clean.py
+++ b/alpenhorn/cli/file/clean.py
@@ -104,4 +104,4 @@ def clean(ctx, path, archive_ok, cancel, node, now):
         else:
             echo(f'Marked "{path}" for discretionary cleaning on Node "{node.name}".')
     else:
-        echo(f"No change.")
+        echo("No change.")

--- a/alpenhorn/cli/file/create.py
+++ b/alpenhorn/cli/file/create.py
@@ -89,7 +89,7 @@ def create(name, acq_name, from_file, md5, prefix, size):
 
     # Size must be non-negative
     if size is not None and size < 0:
-        raise click.ClickException(f"negative file size.")
+        raise click.ClickException("negative file size.")
 
     # Validate
     rejection_reason = invalid_import_path(name)

--- a/alpenhorn/cli/file/modify.py
+++ b/alpenhorn/cli/file/modify.py
@@ -37,7 +37,7 @@ def modify(ctx, path, md5, no_reverify, size):
 
     # Size must be non-negative
     if size is not None and size < 0:
-        raise click.ClickException(f"negative file size.")
+        raise click.ClickException("negative file size.")
 
     # Check MD5
     validate_md5(md5)
@@ -75,7 +75,7 @@ def modify(ctx, path, md5, no_reverify, size):
 
             if count:
                 copies = "copy" if count == 1 else "copies"
-                echo("File updated.  {count} {copies} will be re-verified.")
+                echo(f"File updated.  {count} {copies} will be re-verified.")
             else:
                 echo("File updated.  No additional copies need re-verification.")
         else:

--- a/alpenhorn/cli/group/sync.py
+++ b/alpenhorn/cli/group/sync.py
@@ -483,9 +483,9 @@ def sync(
 
     # Must supply NODE or --all, but not both
     if not all_ and node_name is None:
-        raise click.UsageError(f"NODE or --all must be provided.")
+        raise click.UsageError("NODE or --all must be provided.")
     if all_ and node_name is not None:
-        raise click.UsageError(f"Can't use --all with NODE.")
+        raise click.UsageError("Can't use --all with NODE.")
 
     # Run the check-confirm-update loop
     check_then_update(

--- a/alpenhorn/cli/node/sync.py
+++ b/alpenhorn/cli/node/sync.py
@@ -82,9 +82,9 @@ def sync(
 
     # Must supply GROUP or --all, but not both
     if not all_ and group_name is None:
-        raise click.UsageError(f"GROUP or --all must be provided.")
+        raise click.UsageError("GROUP or --all must be provided.")
     if all_ and group_name is not None:
-        raise click.UsageError(f"Can't use --all with GROUP.")
+        raise click.UsageError("Can't use --all with GROUP.")
 
     # We're using the "group sync" run_query function here, which is why
     # group_name and node_name are backwards

--- a/alpenhorn/daemon/update.py
+++ b/alpenhorn/daemon/update.py
@@ -497,7 +497,7 @@ class UpdateableNode(updateable_base):
                     fullpath = fullpath.resolve(strict=True)
                 except OSError as e:
                     log.warning(
-                        f"Ignoring import request of unresolvable scan path: {fullpath}"
+                        f"Ignoring import request of unresolvable scan path: {fullpath}: {e}"
                     )
                     req.complete()
                     continue

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -189,7 +189,7 @@ async def _size_from_stat(fullpath: pathlib.Path) -> int | None:
         async with asyncio.timeout(600):
             stat = await asyncio.to_thread(fullpath.stat)
     except TimeoutError:
-        log.error(f"Timeout trying to stat {copyname} on node {io.node.name}!")
+        log.error(f"Timeout trying to stat {fullpath}!")
         return None
 
     if stat:

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -427,7 +427,7 @@ def copy_request_done(
             stderr = "Unspecified error."
         if check_src:
             # If the copy didn't work, then the remote file may be corrupted.
-            log.error(f"Copy failed.  Marking source file suspect.")
+            log.error("Copy failed.  Marking source file suspect.")
             log.info(f"Output: {stderr}")
             ArchiveFileCopy.update(has_file="M", last_update=utcnow()).where(
                 ArchiveFileCopy.file == req.file,
@@ -435,7 +435,7 @@ def copy_request_done(
             ).execute()
         else:
             # An error occurred that can't be due to the source being corrupt
-            log.error(f"Copy failed")
+            log.error("Copy failed")
             log.info(f"Output: {stderr}")
         return False
 

--- a/alpenhorn/io/lfs.py
+++ b/alpenhorn/io/lfs.py
@@ -174,7 +174,7 @@ class LFS:
 
         # Timeout
         if ret is None:
-            log.warning(f"LFS command timed out: " + " ".join(args))
+            log.warning("LFS command timed out: " + " ".join(args))
             result["timeout"] = True
             return result
 
@@ -185,11 +185,11 @@ class LFS:
 
         # Failure, look for a "No such file" remark in stderr
         if stderr and "No such file or directory" in stderr:
-            log.debug(f"LFS missing file: " + " ".join(args))
+            log.debug("LFS missing file: " + " ".join(args))
             result["missing"] = True
         else:
             # Otherwise, report failure
-            log.warning(f"LFS command failed: " + " ".join(args))
+            log.warning("LFS command failed: " + " ".join(args))
             result["failed"] = True
 
         if stderr:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -938,6 +938,6 @@ def assert_row_present():
         regex = r"^\s*" + r"\s+".join(cells) + r"\s*$"
 
         if re.search(regex, text, flags=re.MULTILINE) is None:
-            pytest.fail(f"Row not found:\n   " + text_row)
+            pytest.fail("Row not found:\n   " + text_row)
 
     return _assert_row_present


### PR DESCRIPTION
They don't have substitutions, so they can be just regular strings.

Oh, except for the one in `_default_asyncs.py`.  That one was just wrong.