### PR TITLE
feat(daemon): Run-once mode

### DIFF
--- a/alpenhorn/daemon/entry.py
+++ b/alpenhorn/daemon/entry.py
@@ -33,12 +33,25 @@ sys.excepthook = log_exception
     default=None,
     metavar="FILE",
 )
+@click.option(
+    "once",
+    "--exit-after-update",
+    "-o",
+    "--once",
+    is_flag=True,
+    help="Run the update loop once, wait for updates to complete, and then exit.",
+)
 @version_option
 @help_config_option
-def entry(conf):
-    """Alpenhorn data management daemon.
+def entry(conf, once):
+    """Alpenhornd: data management daemon.
 
-    This daemon can be used to manage Storage Nodes.
+    The alpenhorn daemon can be used to manage Storage Nodes.  See the alpenhorn
+    documentation for details on how to run the daemon.
+
+    By default, the daemon will keep running until killed, but you can instead tell
+    it to run only a single update pass and then exit after updates have completed
+    by using the "--exit-after-update" flag.
     """
 
     # Initialise alpenhorn
@@ -65,7 +78,7 @@ def entry(conf):
 
     # Enter main loop
     try:
-        update.update_loop(queue, wpool)
+        update.update_loop(queue, wpool, once)
     # Catch keyboard interrupt
     except KeyboardInterrupt:
         log.info("Exiting due to SIGINT")

--- a/tests/daemon/test_update.py
+++ b/tests/daemon/test_update.py
@@ -53,7 +53,7 @@ def test_update_abort():
 
     # This should do nothing except exit, so passing
     # a couple of Nones shouldn't be a problem
-    update.update_loop(None, None)
+    update.update_loop(None, None, False)
 
     # Reset
     pool.global_abort.clear()
@@ -64,7 +64,7 @@ def test_update_no_nodes(
 ):
     """Test update_loop with no active nodes."""
 
-    update.update_loop(queue, emptypool)
+    update.update_loop(queue, emptypool, False)
 
     mock_serial_io.assert_called_once_with(queue)
 
@@ -83,7 +83,7 @@ def test_update_node_not_idle(
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
-    update.update_loop(queue, emptypool)
+    update.update_loop(queue, emptypool, False)
 
     # Node update started
     mockio.node.before_update.assert_called_once()
@@ -107,7 +107,7 @@ def test_update_node_idle(
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
-    update.update_loop(queue, emptypool)
+    update.update_loop(queue, emptypool, False)
 
     # Node update started
     mockio.node.before_update.assert_called_once()
@@ -130,7 +130,7 @@ def test_update_node_cancelled(
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
-    update.update_loop(queue, emptypool)
+    update.update_loop(queue, emptypool, False)
 
     # Node update started
     mockio.node.before_update.assert_called_once()
@@ -221,7 +221,7 @@ def test_update_group_not_idle_node(
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
-    update.update_loop(queue, emptypool)
+    update.update_loop(queue, emptypool, False)
 
     # Node update started
     mockio.node.before_update.assert_called_once()
@@ -258,7 +258,7 @@ def test_update_group_not_idle_group(
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
-    update.update_loop(queue, emptypool)
+    update.update_loop(queue, emptypool, False)
 
     # Idle update didn't happen
     mockio.group.idle_update.assert_not_called()
@@ -280,7 +280,7 @@ def test_update_group_idle(
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
-    update.update_loop(queue, emptypool)
+    update.update_loop(queue, emptypool, False)
 
     # Group update started
     mockio.group.before_update.assert_called_once()
@@ -305,7 +305,7 @@ def test_update_group_cancelled(
 
     xfs.create_file("/mocknode/ALPENHORN_NODE", contents="mocknode")
 
-    update.update_loop(queue, emptypool)
+    update.update_loop(queue, emptypool, False)
 
     # Group update started
     mockio.group.before_update.assert_called_once()


### PR DESCRIPTION
Adds an option -o/--once/--exit-after-update to the daemon to make it run the update loop once, wait for all tasks to finish (including deferred ones), and then exit cleanly.

The end-to-end test in `tests/daemon/test_entry.py` has been updated to use this mode (rather than what we were doing before which was using the `loop_once` fixture that co-opts the global abort).

Requires #268 to prevent the end-to-end test from taking ten minutes to complete.

Closes #230 