### PR TITLE
feat(daemon): Minimise discretionary cleaning

### DIFF
--- a/tests/daemon/test_update_node.py
+++ b/tests/daemon/test_update_node.py
@@ -336,17 +336,54 @@ def test_update_delete_under_min(unode, simpleacq, archivefile, archivefilecopy)
         has_file="Y",
         wants_file="Y",
     )
-    copyM = archivefilecopy(
+    copyM1 = archivefilecopy(
         node=unode.db,
-        file=archivefile(name="fileM", acq=simpleacq),
+        file=archivefile(name="fileM1", acq=simpleacq),
         has_file="Y",
         wants_file="M",
+        size_b=2 * 2**30,
     )
-    copyN = archivefilecopy(
+    copyN1 = archivefilecopy(
         node=unode.db,
-        file=archivefile(name="fileN", acq=simpleacq),
+        file=archivefile(name="fileN1", acq=simpleacq),
         has_file="Y",
         wants_file="N",
+        size_b=2 * 2**30,
+    )
+    copyM2 = archivefilecopy(
+        node=unode.db,
+        file=archivefile(name="fileM2", acq=simpleacq),
+        has_file="Y",
+        wants_file="M",
+        size_b=2 * 2**30,
+    )
+    archivefilecopy(
+        node=unode.db,
+        file=archivefile(name="fileM3", acq=simpleacq),
+        has_file="Y",
+        wants_file="M",
+        size_b=2 * 2**30,
+    )
+    copyN2 = archivefilecopy(
+        node=unode.db,
+        file=archivefile(name="fileN2", acq=simpleacq),
+        has_file="Y",
+        wants_file="N",
+        size_b=2 * 2**30,
+    )
+    archivefilecopy(
+        node=unode.db,
+        file=archivefile(name="fileM4", acq=simpleacq),
+        has_file="Y",
+        wants_file="M",
+        size_b=2 * 2**30,
+    )
+    copyN3 = archivefilecopy(
+        node=unode.db,
+        file=archivefile(name="fileN3", acq=simpleacq),
+        has_file="Y",
+        wants_file="N",
+        size_b=2 * 2**30,
     )
 
     # Force under min and not archive
@@ -359,7 +396,8 @@ def test_update_delete_under_min(unode, simpleacq, archivefile, archivefilecopy)
     mock_delete = MagicMock()
     with patch.object(unode.io, "delete", mock_delete):
         unode.update_delete()
-    mock_delete.assert_called_once_with([copyM, copyN])
+    # copyY, copyM3 and copyM4 are not deleted
+    mock_delete.assert_called_once_with([copyM1, copyN1, copyM2, copyN2, copyN3])
 
 
 def test_update_delete_over_min(unode, simpleacq, archivefile, archivefilecopy):


### PR DESCRIPTION
This changes the logic of the deletion part of the node update loop when a node has dropped below `min_avail_gb`.  Previously, this condition would trigger deletion of all files marked for discretionary cleaning (wants_file=='M') on the node.

With this change, now only enough files are deleted to get back over `min_avail_gb`.

In CHIME, we have hardly ever used discretionary cleaning, and I think this behaviour which I want to change is the reason.  AFAIK, the idea behind `wants_file=='M'` was to produce something like what we do on `gong`: a way to have a node with a rolling spool of recent data before it gets shipped off to an archive somewhere.  The idea is files come into the spooling node and then are sent off to an archive.  When finally archived, the copy on the spool can be marked with `wants_file='M'` meaning it doesn't get immediately deleted, but will get deleted once space is needed on the spool for newer data.

Unfortunately, with the old deletion behaviour, what actually happens is when the spool fills up _every_ file marked for discretionary cleaning gets deleted.  The result is a sawtooth usage pattern: the node slowly fills up, eventually hits `min_avail` triggerring deletion of everything already archived, and then the node returns to slowly filling again.

This change makes it so that when `min_avail_gb` is hit, only enough files are deleted to get the free space back over the minimum.  This is very similar to how we manage `gong`.  (Note: even with this change, we wouldn't be able to use this on `gong`, because on `gong` we need to balance the node size and the size of the staging directory, which is outside of alpenhorn's control.)

Also note: because the discretionary cleaning and the forced cleaning are processed together in the same loop, any of these possibilites can happen:

* enough force-cleaning happens before the first `wants_file=='M'` file is found that no discretionary cleaning ends up happening
* enough discretionary cleaning occurs to satisfy the goal before any force-cleaned files are deleted, meaning more space than strictly necessary is removed
* any partial situation between these two extremes.

The net result is that how much actual discretionary cleaning happens when free space gets low isn't deterministic, but I think that's fine: it shouldn't make a whole lot of difference.

If we _did_ want to make it deterministic, we'd need two loops, one for `wants_file=='N'` and one for `wants_file=='M'`.