### PR TITLE
feat(cli): file verify command

### DIFF
--- a/alpenhorn/cli/file/__init__.py
+++ b/alpenhorn/cli/file/__init__.py
@@ -12,6 +12,7 @@ from .modify import modify
 from .show import show
 from .state import state
 from .sync import sync
+from .verify import verify
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
@@ -30,3 +31,4 @@ cli.add_command(modify, "modify")
 cli.add_command(show, "show")
 cli.add_command(state, "state")
 cli.add_command(sync, "sync")
+cli.add_command(verify, "verify")

--- a/alpenhorn/cli/file/verify.py
+++ b/alpenhorn/cli/file/verify.py
@@ -1,0 +1,56 @@
+"""alpenhorn file verify command."""
+
+import click
+import peewee as pw
+
+from ...db import ArchiveFileCopy, database_proxy
+from ..cli import echo
+from ..options import file_from_path, resolve_node
+
+
+@click.command()
+@click.argument("path", metavar="FILE")
+@click.argument("node_name", metavar="NODE")
+@click.pass_context
+def verify(ctx, path, node_name):
+    """Request verification of a File.
+
+    This command requests that the copy of FILE on NODE be re-verified to
+    check it for corruption.  FILE should be specified as
+    "<acq_name>/<file_name>".
+
+    If there is no copy of FILE on NODE, an error is returned.
+    """
+    with database_proxy.atomic():
+        file = file_from_path(path)
+        node = resolve_node(node_name)
+
+        # Find the existing record, if any
+        try:
+            copy = ArchiveFileCopy.get(file=file, node=node)
+        except pw.DoesNotExist:
+            raise click.ClickException("File not present on node.")
+
+        # We allow verify requests on missing files
+        if copy.has_file == "N" and copy.wants_file != "Y":
+            raise click.ClickException("File not present on node.")
+
+        if copy.has_file == "M":
+            # Nothing to do.
+            echo("File already scheduled for verification.")
+            ctx.exit()
+
+        # Verbiage
+        if copy.has_file == "N":
+            descriptor = "missing "
+        elif copy.has_file == "X":
+            descriptor = "corrupt "
+        else:
+            descriptor = ""
+
+        # Update
+        ArchiveFileCopy.update(has_file="M").where(
+            ArchiveFileCopy.id == copy.id
+        ).execute()
+
+    echo(f'Requesting verification of {descriptor}file "{path}".')

--- a/tests/cli/file/test_verify.py
+++ b/tests/cli/file/test_verify.py
@@ -1,0 +1,129 @@
+"""Test CLI: alpenhorn file create"""
+
+from alpenhorn.db import (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    StorageGroup,
+    StorageNode,
+)
+
+
+def test_bad_file(clidb, cli):
+    """Test bad file."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    cli(1, ["file", "verify", "MIS/SING", "Node"])
+
+
+def test_bad_node(clidb, cli):
+    """Test bad node."""
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="File", acq=acq)
+
+    cli(1, ["file", "verify", "Acq/File", "MISSING"])
+
+
+def test_no_copy(clidb, cli):
+    """Test verify with no copy record."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(name="Node", group=group)
+
+    acq = ArchiveAcq.create(name="Acq")
+    ArchiveFile.create(name="File", acq=acq)
+
+    cli(1, ["file", "verify", "Acq/File", "Node"])
+
+
+def test_removed(clidb, cli):
+    """Test verify after removal."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq)
+
+    ArchiveFileCopy.create(file=file, node=node, has_file="N", wants_file="N")
+
+    cli(1, ["file", "verify", "Acq/File", "Node"])
+
+
+def test_missing(clidb, cli):
+    """Test verify of missing file."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq)
+
+    ArchiveFileCopy.create(file=file, node=node, has_file="N", wants_file="Y")
+
+    cli(0, ["file", "verify", "Acq/File", "Node"])
+
+    # Now copy is suspect, not missing
+    copy = ArchiveFileCopy.get(id=1)
+    assert copy.has_file == "M"
+    assert copy.wants_file == "Y"
+
+
+def test_corrupt(clidb, cli):
+    """Test verify of corrupt file."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq)
+
+    ArchiveFileCopy.create(file=file, node=node, has_file="X", wants_file="Y")
+
+    cli(0, ["file", "verify", "Acq/File", "Node"])
+
+    # Now copy is suspect, not corrupt
+    copy = ArchiveFileCopy.get(id=1)
+    assert copy.has_file == "M"
+    assert copy.wants_file == "Y"
+
+
+def test_suspect(clidb, cli):
+    """Test verify of suspect file."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq)
+
+    ArchiveFileCopy.create(file=file, node=node, has_file="M", wants_file="Y")
+
+    cli(0, ["file", "verify", "Acq/File", "Node"])
+
+    # No change, I suppose
+    copy = ArchiveFileCopy.get(id=1)
+    assert copy.has_file == "M"
+    assert copy.wants_file == "Y"
+
+
+def test_good(clidb, cli):
+    """Test verify of good file."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="Node", group=group)
+
+    acq = ArchiveAcq.create(name="Acq")
+    file = ArchiveFile.create(name="File", acq=acq)
+
+    ArchiveFileCopy.create(file=file, node=node, has_file="Y", wants_file="Y")
+
+    cli(0, ["file", "verify", "Acq/File", "Node"])
+
+    # Now copy is suspect, not good
+    copy = ArchiveFileCopy.get(id=1)
+    assert copy.has_file == "M"
+    assert copy.wants_file == "Y"


### PR DESCRIPTION
This functionality already exists; the command:
```
  alpenhorn file verify FILE NODE
```
is equivalent to:
```
  alpenhorn file state --set=suspect FILE NODE
```
(mostly: `file state` can create new ArchiveFileCopy records, `file verify` cannot.)

However, I think it's more intuitive to ask users who want to re-verify a single file to use a command like this than force them to understand which state they need in `file state`.