### PR TITLE
feat(daemon): Prometheus client

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,33 +56,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install pip dependencies
+    - name: Install with dependencies
       run: pip install -e .[test]
 
-    - name: Run tests
+    - name: Run tests without prometheus client
       run: pytest -v .
 
-  # run-docker-tests:
+    - name: Install prometheus client
+      run: pip install prometheus_client
 
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@v2
-
-  #   - name: Set up Python 3.9
-  #     uses: actions/setup-python@v1
-  #     with:
-  #       python-version: 3.9
-
-  #   - name: Install pip dependencies
-  #     run: |
-  #       pip install -r requirements.txt
-  #       pip install -r test-requirements.txt
-  #       python setup.py develop
-
-  #   - name: Build docker image
-  #     run: docker build -f tests/docker/Dockerfile.alpenhorn -t alpenhorn .
-
-  #   - name: Run docker tests
-  #     run: pytest tests/docker/test_docker.py
-  #     env:
-  #       RUN_DOCKER_TESTS: true
+    - name: Run tests with prometheus client
+      run: pytest -v .

--- a/alpenhorn/common/config.py
+++ b/alpenhorn/common/config.py
@@ -135,12 +135,20 @@ Example config:
         # job will rum forever if it doesn't exit; not recommended).
         pull_timeout_base: 300
         pull_bytes_per_second: 20000000
+
+        # Prometheus client port.  Setting this to a positive value will
+        # cause the daemon to start the prometheus client HTTP server to
+        # serve GET requests on that port (but only when not running in
+        # --exit-after-update mode).  If not set, or set to a non-positive
+        # value, then the prometheus client is not started.
+        prom_client_port: 8080
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from typing import Any
 
 import yaml
 from click import ClickException
@@ -155,6 +163,7 @@ _default_config = {
         "auto_import_interval": 30,
         "auto_verify_min_days": 7,
         "num_workers": 0,
+        "prom_client_port": 0,
         "serial_io_timeout": 900,
         "update_interval": 60,
     },
@@ -215,7 +224,7 @@ def load_config(cli_conf: os.PathLike, cli: bool) -> None:
         )
 
 
-def merge_dict_tree(a: dict, b: dict) -> dict:
+def merge_dict_tree(a: Any, b: Any) -> Any:
     """Merge two dictionaries recursively.
 
     The following rules applied:

--- a/alpenhorn/common/metrics.py
+++ b/alpenhorn/common/metrics.py
@@ -1,0 +1,358 @@
+"""Alpenhorn interface to prometheus_client
+
+This module provides an interface between alpenhorn
+and the prometheus client.
+
+Metrics should be created and accessed through the `Metric` class, which
+is a light-weight wrapper around the prometheus_client's Counter and
+Gauge metrics.
+
+The `Metric` class adds a restriction that all instances of a metric of a
+given name have the same set of labels.  The `Metric` class also provides a
+mechanism to bind particular labels, meaning repetition of common label
+values is not necessary.
+
+If the `prometheus_client` module cannot be imported, most of this module
+does nothing.
+"""
+
+from __future__ import annotations
+
+from ..common import config
+
+try:
+    import prometheus_client as prom
+except ModuleNotFoundError:
+    prom = None
+
+# A dict of all the metrics we're using.  Keys are names.
+# Values are two-tuples with elements:
+#  * the prometheus_client metric object
+#  * the set of all labelnames
+_metrics = {}
+
+
+class Metric:
+    """A wrapper for prometheus_client metrics."""
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        counter: bool = False,
+        unbound: list | tuple | set = (),
+        bound: dict = {},
+    ) -> None:
+        """Create a new metric.
+
+        Labels in the metric can be bound (set to a fixed value) or unbound
+        (with no fixed value).  Names of unbound labels are listed in `unbound`.
+        Bound labels with their values are set by the `bound` dict.
+
+        All instances of a metric of a given `name` must have the same set of
+        label names (but different instances may change which of those are bound
+        and which are unbound), They must also have the same type (i.e. the same
+        value for `counter`).  All instances with the same `name` control the same
+        underlying metric.
+
+        Newly-created metrics are implicitly set to zero, but, unless they have
+        no labels at all, they won't actually be reported until their value is
+        explicitly set/updated.
+
+        Parameters
+        ----------
+        name:
+            Name of the metric, excluding the initial `alpenhorn_`.
+        description:
+            A human-readable description of the data in the metric.
+        counter:
+            If True, create a Counter metric.  Otherwise a Gauge metric is created.
+        unbound:
+            A set (or list or tuple) of names of unbound labels.
+        bound:
+            A dict of label key-value pairs for bound labels.
+
+        Raises
+        ------
+        KeyError:
+            The same label name was specified in both `unbound` and `bound`.
+        TypeError:
+            An attempt was made to access an existing metric using the wrong
+            value for `counter`.
+        ValueError:
+            An attempt was made to access an existing metric using the wrong
+            set of label names.
+        """
+        global _metrics
+
+        # keys in "bound" can't also appear in "unbound"
+        for key in bound.keys():
+            if key in unbound:
+                raise KeyError(f'label "{key}" is both bound and unbound')
+
+        self._name = name
+        self._desc = description
+        self._unbound_labels = set(unbound)
+        self._bound_labels = bound
+        self._counter = counter
+
+        # We don't save any metrics, if we have no prometheus_client
+        if prom is None:
+            self._metric = None
+            return
+
+        # Metric type
+        _type = prom.Counter if counter else prom.Gauge
+
+        # Get or create the prom metric
+        if name in _metrics:
+            existing_metric, existing_labels = _metrics[name]
+            # Validate access: must be using the correct type and list of labels
+            if not isinstance(existing_metric, _type):
+                raise TypeError(f"wrong metric type for metric: {name}")
+            # Make sure labelnames is the same
+            if existing_labels != set(self.labelnames):
+                raise ValueError(
+                    f"wrong labels for metric.  Expected: {existing_labels}"
+                )
+            self._metric = existing_metric
+        else:
+            self._metric = _type(
+                "alpenhorn_" + name, description, labelnames=self.labelnames
+            )
+            _metrics[name] = (self._metric, set(self.labelnames))
+
+    def bind(self, **labels: str) -> Metric:
+        """Bind values to labels.
+
+        This method returns a _copy_ of the Metric with the currently unbound
+        labels newly bound to the values specified by the keywords.  Not all
+        unbound labels need be specified.  Unbound labels not specified remain
+        unbound in the returned copy.
+
+        The original Metric is left unchanged.
+
+        Raises
+        ------
+        TypeError:
+            A keyword parameter did not correspond to one of the unbound labels.
+        """
+        unbound = set(self._unbound_labels)
+        bound = self._bound_labels.copy()
+
+        # Bind the new label values
+        for key in labels.keys():
+            if key not in unbound:
+                raise TypeError(f'"{key}" is not an unbound label')
+            unbound.remove(key)
+            bound[key] = labels[key]
+
+        # Return the child
+        return Metric(
+            name=self._name,
+            description=self._desc,
+            counter=self._counter,
+            unbound=unbound,
+            bound=bound,
+        )
+
+    def _check_unbound_covered(self, labels: dict) -> None:
+        """Check cover of given labels.
+
+        Checks that `labels` provides a value for all unbound labels
+        (and nothing more).
+
+        Raises
+        ------
+        TypeError:
+            An extra label was included.
+        ValueError:
+            A label was missing.
+        """
+
+        keys = set(labels.keys())
+
+        missing_keys = self._unbound_labels - keys
+        if missing_keys:
+            raise ValueError("not bound: " + ", ".join(missing_keys))
+
+        extra_keys = keys - self._unbound_labels
+        if extra_keys:
+            raise TypeError("not unbound: " + ", ".join(extra_keys))
+
+    @property
+    def labelnames(self) -> list[str]:
+        """An ordered list of label names."""
+
+        return sorted(self._unbound_labels | set(self._bound_labels.keys()))
+
+    def labelvalues(self, **labels: str) -> list[str]:
+        """Return the list of label values.
+
+        Values for all unbound labels must be specified by keyword.
+
+        The returned list is guaranteed to be in the same order as the list
+        of label names given by `labelnames`.
+        """
+        self._check_unbound_covered(labels)
+
+        # Merge the labels
+        labels |= self._bound_labels
+
+        # Return values in the correct order
+        return [labels[key] for key in sorted(labels.keys())]
+
+    def _labelled_metric(self, labels: dict) -> prom.metrics.MetricWrapperBase:
+        """Returns the labelled metric.
+
+        Returns a `prometheus_client` child metric for the labelset resulting
+        from merging the unbound and bound labels.
+
+        Values for all unbound labels must be specified in the supplied `labels`
+        dict.
+        """
+        # Unlabelled metrics have no children, so we must return the parent
+        if not self._unbound_labels and not self._bound_labels:
+            return self._metric
+
+        self._check_unbound_covered(labels)
+
+        if self._metric:
+            return self._metric.labels(**labels, **self._bound_labels)
+        return None
+
+    def add(self, value: float, /, **labels: str) -> None:
+        """Add `value` to the metric.
+
+        For Counter metrics, `value` must be positive.
+
+        Values for all unbound labels must be specified in the supplied `labels`
+        dict.
+        """
+        if self._metric:
+            self._labelled_metric(labels).inc(value)
+
+    def inc(self, /, **labels: str) -> None:
+        """Increment the metric by one.
+
+        Values for all unbound labels must be specified in the supplied `labels`
+        dict.
+        """
+        self.add(1, **labels)
+
+    def dec(self, /, **labels: str) -> None:
+        """Decrement the metric by one.
+
+        Calling this metric on a counter will result in an error.
+
+        Values for all unbound labels must be specified in the supplied `labels`
+        dict.
+        """
+        # We'll let prometheus_client throw the exception for counters.
+        self.add(-1, **labels)
+
+    def set(self, value: float, /, **labels: str) -> None:
+        """Set the metric to `value`.
+
+        For counter metrics, the only allowed value is zero.
+
+        Values for all unbound labels must be specified in the supplied `labels`
+        dict.
+        """
+        if self._metric is None:
+            return
+
+        if self._counter:
+            # For counters, Metric.set(0) is converted into a `.reset()` call
+            if value:
+                raise ValueError("attempt to set counter to non-zero value")
+            self._labelled_metric(labels).reset()
+        else:
+            # Gauges have a .set() method.
+            self._labelled_metric(labels).set(value)
+
+    def remove(self, /, **labels: str) -> None:
+        """Remove a labelset from the metric.
+
+        Returns the child metric with the labelset resulting from merging the
+        unbound and bound labels.
+
+        Values for all unbound labels must be specified in the supplied `labels`
+        dict.
+
+        If no such metric exists, this function does nothing.
+
+        Paramters:
+        ----------
+        labels:
+            The key-value pairs of the unbound labels for the labelset.
+        """
+        if self._metric:
+            self._metric.remove(self.labelvalues(**labels))
+
+    def clear(self) -> None:
+        """Remove all labelsets from the metric.
+
+        The metric, per se, is not deleted.
+        """
+        if self._metric:
+            self._metric.clear()
+
+
+def by_name(name: str) -> Metric:
+    """Retrieve the pre-made Metric called `name`.
+
+    This function returns several pre-made Metric instances for use in cases
+    where there is no other natural place to define the metric.
+
+    Metrics returned by this function have no bound labels.  You may call
+    `.bind()` on the returned metric if you wish to bind some of them.
+
+    Parameters
+    ----------
+    name:
+        The name of the Metric to return
+
+    Raises
+    ------
+    ValueError:
+        No such Metric was found with the requested name.
+    """
+
+    if name == "requests_completed":
+        return Metric(
+            name,
+            "Count of completed requests",
+            counter=True,
+            unbound=("type", "result", "node", "group"),
+        )
+    if name == "transfers":
+        return Metric(
+            name,
+            "Count of transfer attempts",
+            counter=True,
+            unbound=("result", "node_from", "group_to"),
+        )
+
+    raise ValueError(f"no such metric: {name}")
+
+
+def start_promclient() -> None:
+    """Start the prometheus client
+
+    The client is only started if `daemon.prom_client_port`
+    is set to a positive value in the alpenhorn config.
+    """
+
+    # Get the port number.  If not found, we just return here.
+    try:
+        port = int(config.config["daemon"]["prom_client_port"])
+        if port <= 0:
+            return
+    except KeyError:
+        return
+
+    # Okay, we're good to start the http server, if we can
+    if prom is not None:
+        prom.disable_created_metrics()
+        prom.start_http_server(port)

--- a/alpenhorn/common/util.py
+++ b/alpenhorn/common/util.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 import click
 
 from . import config, extensions, logger
+from .metrics import Metric
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -314,7 +315,13 @@ def md5sum_file(filename: str, hr: bool = True) -> str | None:
     --------
     http://stackoverflow.com/questions/1131220/get-md5-hash-of-big-files-in-python
     """
-    return asyncio.run(_md5sum_file(filename, hr))
+    metric = Metric("hash_running_count", "Count of in-progress MD5 hashing")
+
+    metric.inc()
+    result = asyncio.run(_md5sum_file(filename, hr))
+    metric.dec()
+
+    return result
 
 
 def get_hostname() -> str:

--- a/alpenhorn/daemon/entry.py
+++ b/alpenhorn/daemon/entry.py
@@ -6,7 +6,7 @@ import sys
 import click
 
 from .. import db
-from ..common import config
+from ..common import config, metrics
 from ..common.util import help_config_option, start_alpenhorn, version_option
 from ..scheduler import FairMultiFIFOQueue, pool
 from . import auto_import, update
@@ -59,6 +59,10 @@ def entry(conf, once):
 
     # Connect to the database
     db.connect()
+
+    # Start the prometheus client, if appropriate.
+    if not once:
+        metrics.start_promclient()
 
     # Set up the task queue
     queue = FairMultiFIFOQueue()

--- a/alpenhorn/db/archive.py
+++ b/alpenhorn/db/archive.py
@@ -162,11 +162,3 @@ class ArchiveFileImportRequest(base_model):
     register = pw.BooleanField(default=False)
     completed = pw.BooleanField(default=False)
     timestamp = pw.DateTimeField(default=pw.utcnow, null=True)
-
-    def complete(self) -> None:
-        """Set this request to complete in the database."""
-
-        # If we're already complete, this function does nothing
-        if not self.completed:
-            self.completed = True
-            self.save(only=[ArchiveFileImportRequest.completed])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+prometheus = [
+  "prometheus_client",
+]
 test = [
   "chimedb @ git+https://github.com/chime-experiment/chimedb.git",
   "docker >= 3.0",

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -1,0 +1,373 @@
+"""Test common.metrics."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from alpenhorn.common import metrics
+
+prometheus_client = pytest.importorskip(
+    "prometheus_client", exc_type=ModuleNotFoundError
+)
+Counter = prometheus_client.metrics.Counter
+Gauge = prometheus_client.metrics.Gauge
+REGISTRY = prometheus_client.registry.REGISTRY
+
+
+@pytest.fixture
+def cleanup():
+    """Clean up after metric tests."""
+    yield
+
+    # Delete all metrics from the prometheus client registry and our dict
+    while metrics._metrics:
+        key, value = metrics._metrics.popitem()
+        REGISTRY.unregister(value[0])
+
+
+def test_nothing(cleanup):
+    """Test nothing.
+
+    The only point of this test is to trigger the cleanup fixture so
+    everything following starts with an empty _metric cache.
+    """
+    assert True
+
+
+def test_label_clash(cleanup):
+    """Can't both bind a label and leave it unbound."""
+    with pytest.raises(KeyError):
+        metrics.Metric("name", "desc", unbound={"a", "b", "c"}, bound={"c": "d"})
+
+
+def test_label_change(cleanup):
+    """Accessing the same metric with different labels shouldn't work."""
+
+    metrics.Metric("name", "desc", unbound={"a", "b", "c"})
+
+    with pytest.raises(ValueError):
+        # Missing a label
+        metrics.Metric("name", "desc", unbound={"a", "b"})
+
+    with pytest.raises(ValueError):
+        # Extra label
+        metrics.Metric("name", "desc", unbound={"a", "b", "c", "d"})
+
+    with pytest.raises(ValueError):
+        # Missing and extra label
+        metrics.Metric("name", "desc", unbound={"a", "b", "d"})
+
+
+def test_labelnames(cleanup):
+    """Test Metric.labelnames"""
+    metric = metrics.Metric("unbound", "desc", unbound={"h", "b", "c", "d", "f"})
+    assert metric.labelnames == ["b", "c", "d", "f", "h"]
+
+    metric = metrics.Metric(
+        "mixed", "desc", unbound={"a", "b", "c"}, bound={"d": "e", "f": "g"}
+    )
+    assert metric.labelnames == ["a", "b", "c", "d", "f"]
+
+    metric = metrics.Metric(
+        "bound", "desc", bound={"i": "a", "b": "b", "c": "c", "d": "e", "f": "g"}
+    )
+    assert metric.labelnames == ["b", "c", "d", "f", "i"]
+
+
+def test_labelvalues(cleanup):
+    """Test Metric.labelvalues"""
+    metric = metrics.Metric("unbound", "desc", unbound={"h", "b", "c", "d", "f"})
+    assert metric.labelvalues(h=1, b=2, c=3, d=4, f=5) == [2, 3, 4, 5, 1]
+
+    metric = metrics.Metric(
+        "mixed", "desc", unbound={"a", "b", "c"}, bound={"d": "e", "f": "g"}
+    )
+    assert metric.labelvalues(a=6, b=7, c=8) == [6, 7, 8, "e", "g"]
+
+    metric = metrics.Metric(
+        "bound", "desc", bound={"i": "a", "b": "b", "c": "c", "d": "e", "f": "g"}
+    )
+    assert metric.labelvalues() == ["b", "c", "e", "g", "a"]
+
+
+def test_labelvalues_bad(cleanup):
+    """Test invalid labels to labelvalues()"""
+    metric = metrics.Metric(
+        "name", "desc", unbound={"a", "b", "c"}, bound={"d": "e", "f": "g"}
+    )
+
+    # must bind all labels
+    with pytest.raises(ValueError):
+        metric.labelvalues(a=1)
+
+    # Can't add extra labels
+    with pytest.raises(TypeError):
+        metric.labelvalues(a=1, b=2, c=3, h=4)
+
+    # Can't re-bind bound labels
+    with pytest.raises(TypeError):
+        metric.labelvalues(a=1, b=2, c=3, d=4)
+
+
+def test_bind(cleanup):
+    """Test Metric.bind"""
+    base = metrics.Metric("name", "desc", unbound=["a", "b", "c"])
+
+    # All labels are unbound
+    assert base.labelvalues(a=1, b=2, c=3) == [1, 2, 3]
+
+    # Can't bind non-existent labels
+    with pytest.raises(TypeError):
+        base.bind(d=0)
+
+    # This is fine.  It just makes a copy.
+    copy = base.bind()
+
+    # All labels are still unbound
+    assert copy.labelvalues(a=1, b=2, c=3) == [1, 2, 3]
+
+    # Not the same instance as base
+    assert copy is not base
+
+    # Bind some labels
+    copy = base.bind(a=4)
+
+    # Only two unbound labels, now
+    assert copy.labelvalues(b=2, c=3) == [4, 2, 3]
+
+    # Fails because a is now bound
+    with pytest.raises(TypeError):
+        assert copy.labelvalues(a=1, b=2, c=3) == [1, 2, 3]
+
+    # But the base hasn't changed
+    assert base.labelvalues(a=1, b=2, c=3) == [1, 2, 3]
+
+    # Bind the remaining labels
+    copy2 = copy.bind(b=5, c=6)
+
+    # Now no unbound labels
+    assert copy2.labelvalues() == [4, 5, 6]
+
+
+def test_labelled_metric(cleanup):
+    """Test that _labelled_metric does return a prometheus metric."""
+    gauge = metrics.Metric(
+        "gauge", "desc", unbound={"a", "b", "c"}, bound={"d": "e", "f": "g"}
+    )
+
+    submetric = gauge._labelled_metric({"a": "a", "b": "b", "c": "c"})
+    assert isinstance(submetric, Gauge)
+
+    counter = metrics.Metric(
+        "counter",
+        "desc",
+        counter=True,
+        unbound={"a", "b", "c"},
+        bound={"d": "e", "f": "g"},
+    )
+    submetric = counter._labelled_metric({"a": "a", "b": "b", "c": "c"})
+    assert isinstance(submetric, Counter)
+
+
+def test_unlabelled_metric(cleanup):
+    """Test using an unlabelled metric."""
+
+    # In this case, Metric._labelled_metric _can't_ call the
+    # prom client metric's .label().  So, it just returns the parent
+    # metric, which is then used for the .set call
+
+    metric = metrics.Metric("name", "desc")
+
+    # _labelled_metric just returns _metric now
+    assert metric._labelled_metric(labels={}) is metric._metric
+
+
+def test_add(cleanup):
+    """Test Metric.add"""
+
+    gauge = metrics.Metric(
+        "gauge", "desc", unbound=["a", "b", "c"], bound={"d": "e", "f": "g"}
+    )
+
+    # Replace the internal prom metric with some mocks (childmock plays
+    # the role of the labelled child metric)
+    mock = MagicMock()
+    childmock = MagicMock()
+    mock.labels.return_value = childmock
+    gauge._metric = mock
+
+    gauge.add(1, a=1, b=2, c=3)
+
+    mock.labels.assert_called_with(a=1, b=2, c=3, d="e", f="g")
+    # .add is implemented via .inc on the prom metric
+    childmock.inc.assert_called_with(1)
+
+    # Not fully bound is an error
+    with pytest.raises(ValueError):
+        gauge.add(0, b=5, c=6)
+
+    gauge.add(-3, a=4, b=5, c=6)
+
+    mock.labels.assert_called_with(a=4, b=5, c=6, d="e", f="g")
+    childmock.inc.assert_called_with(-3)
+
+
+def test_inc(cleanup):
+    """Test Metric.inc"""
+
+    metric = metrics.Metric(
+        "name", "desc", unbound=["a", "b", "c"], bound={"d": "e", "f": "g"}
+    )
+
+    # Replace the internal prom metric with some mocks (childmock plays
+    # the role of the labelled child metric)
+    mock = MagicMock()
+    childmock = MagicMock()
+    mock.labels.return_value = childmock
+    metric._metric = mock
+
+    metric.inc(a=1, b=2, c=3)
+
+    mock.labels.assert_called_with(a=1, b=2, c=3, d="e", f="g")
+    # The passed .inc value is always explicit
+    childmock.inc.assert_called_with(1)
+
+    # Not fully bound is an error
+    with pytest.raises(ValueError):
+        metric.inc(b=5, c=6)
+
+
+def test_dec(cleanup):
+    """Test Metric.dec"""
+
+    metric = metrics.Metric(
+        "name", "desc", unbound=["a", "b", "c"], bound={"d": "e", "f": "g"}
+    )
+
+    # Replace the internal prom metric with some mocks (childmock plays
+    # the role of the labelled child metric)
+    mock = MagicMock()
+    childmock = MagicMock()
+    mock.labels.return_value = childmock
+    metric._metric = mock
+
+    metric.dec(a=1, b=2, c=3)
+
+    mock.labels.assert_called_with(a=1, b=2, c=3, d="e", f="g")
+    childmock.inc.assert_called_with(-1)
+
+    # Not fully bound is an error
+    with pytest.raises(ValueError):
+        metric.dec(b=5, c=6)
+
+
+def test_set_gauge(cleanup):
+    """Test Metric.set on a gauge"""
+
+    gauge = metrics.Metric(
+        "name", "desc", unbound=["a", "b", "c"], bound={"d": "e", "f": "g"}
+    )
+
+    # Replace the internal prom metric with some mocks (childmock plays
+    # the role of the labelled child metric)
+    mock = MagicMock()
+    childmock = MagicMock()
+    mock.labels.return_value = childmock
+    gauge._metric = mock
+
+    # Not fully bound is an error
+    with pytest.raises(ValueError):
+        gauge.set(-1, b=5, c=6)
+
+    gauge.set(-2, a=4, b=5, c=6)
+
+    # We always use the keyword calling convention with .labels
+    mock.labels.assert_called_with(a=4, b=5, c=6, d="e", f="g")
+    childmock.set.assert_called_with(-2)
+
+
+def test_set_counter(cleanup):
+    """Test Metric.set on a counter"""
+
+    counter = metrics.Metric(
+        "name",
+        "desc",
+        counter=True,
+        unbound=["a", "b", "c"],
+        bound={"d": "e", "f": "g"},
+    )
+
+    # Replace the internal prom metric with some mocks (childmock plays
+    # the role of the labelled child metric)
+    mock = MagicMock()
+    childmock = MagicMock()
+    mock.labels.return_value = childmock
+    counter._metric = mock
+
+    # Not fully bound is an error
+    with pytest.raises(ValueError):
+        counter.set(0, b=5, c=6)
+
+    # Can't use a non-zero value
+    with pytest.raises(ValueError):
+        counter.set(2, a=4, b=5, c=6)
+
+    # This resets the counter
+    counter.set(0, a=4, b=5, c=6)
+
+    mock.labels.assert_called_with(a=4, b=5, c=6, d="e", f="g")
+    childmock.reset.assert_called()
+    childmock.set.assert_not_called()
+
+
+def test_remove(cleanup):
+    """Test Metric.remove"""
+
+    metric = metrics.Metric(
+        "name", "desc", unbound=["a", "b", "c"], bound={"d": "e", "f": "g"}
+    )
+
+    # Replace the internal prom metric with a mock
+    mock = MagicMock()
+    metric._metric = mock
+
+    # Not fully bound is an error
+    with pytest.raises(ValueError):
+        metric.remove(b=5, c=6)
+
+    metric.remove(a=4, b=5, c=6)
+
+    # No keywords allowed here; must pass the ordered labelvalue list
+    mock.remove.assert_called_with([4, 5, 6, "e", "g"])
+
+
+def test_by_name(cleanup):
+    """Test by_name."""
+
+    metric = metrics.by_name("transfers")
+    assert isinstance(metric, metrics.Metric)
+
+    with pytest.raises(ValueError):
+        metrics.by_name("no_such_metric")
+
+
+@pytest.mark.alpenhorn_config({"daemon": {"prom_client_port": "0"}})
+def test_start_promclient_off(set_config):
+    """Test start_promclient with no port."""
+
+    mock = MagicMock()
+    with patch("prometheus_client.start_http_server", mock):
+        metrics.start_promclient()
+
+    mock.assert_not_called()
+
+
+@pytest.mark.alpenhorn_config({"daemon": {"prom_client_port": "1234"}})
+def test_start_promclient_on(set_config):
+    """Test start_promclient with a port."""
+
+    mock = MagicMock()
+    with patch("prometheus_client.start_http_server", mock):
+        metrics.start_promclient()
+
+    mock.assert_called_with(1234)

--- a/tests/daemon/test_auto_import.py
+++ b/tests/daemon/test_auto_import.py
@@ -11,8 +11,23 @@ from watchdog.observers.api import BaseObserver, ObservedWatch
 from alpenhorn.daemon import auto_import
 from alpenhorn.daemon.update import UpdateableNode
 from alpenhorn.db.acquisition import ArchiveAcq, ArchiveFile
-from alpenhorn.db.archive import ArchiveFileCopy
+from alpenhorn.db.archive import ArchiveFileCopy, ArchiveFileImportRequest
 from alpenhorn.io.lfs import HSMState
+
+
+def test_import_request_done(simpleimportrequest):
+    """Test import_request_done()."""
+
+    assert ArchiveFileImportRequest.get(id=simpleimportrequest.id).completed == 0
+
+    auto_import.import_request_done(simpleimportrequest, True)
+
+    assert ArchiveFileImportRequest.get(id=simpleimportrequest.id).completed == 1
+
+    # Can be called multiple times
+    auto_import.import_request_done(simpleimportrequest, True)
+
+    assert ArchiveFileImportRequest.get(id=simpleimportrequest.id).completed == 1
 
 
 def test_import_file_bad_paths(queue, unode):

--- a/tests/db/test_archive.py
+++ b/tests/db/test_archive.py
@@ -198,21 +198,3 @@ def test_archivefileimportrequest_model(
 
     # Not unique
     archivefileimportrequest(path="min_path", node=minnode)
-
-
-def test_importreqeust_complete(simpleimportrequest):
-    """Test ArchiveFileImportRequest.complete()."""
-
-    assert simpleimportrequest.completed == 0
-    assert ArchiveFileImportRequest.get(id=simpleimportrequest.id).completed == 0
-
-    simpleimportrequest.complete()
-
-    assert simpleimportrequest.completed == 1
-    assert ArchiveFileImportRequest.get(id=simpleimportrequest.id).completed == 1
-
-    # Can be called multiple times
-    simpleimportrequest.complete()
-
-    assert simpleimportrequest.completed == 1
-    assert ArchiveFileImportRequest.get(id=simpleimportrequest.id).completed == 1


### PR DESCRIPTION
This adds a prometheus client to the daemon which will be started if the port it should listen on is specified in the alpenhorn config.

I've added metrics here and there.  I suspect some changes will be necessary to what data is produced, but that can happen iteratively. It's difficult to know how we actually want to instrument the process without some testing.  If you see any glaring omission, feel free to suggest it.  In addition to the explicit metrics I've defined, some basic stats about the python process itself, e.g. CPU load, memory usage, &c. are automatically produced by the prom client server.

Metrics themselves are represented by a new `Metrics` class which mostly wraps `prometheus_client.Gauge` and `prometheus_client.Counter`. I've tried to make a system where we should only have to define a given metric once, even if we want to access it from various places.  (The biggest annoyance with defining metrics is the need to specify the description, which is completely unneeded once the metric has been defined once, but is still required for each `Counter` or `Gauge` instance.)

For a very few metrics, I couldn't find a natural place in the existing codebase to define them, so they've been put in the `metrics.by_name` function from which they can be retrieved.

I tried, at least, to come up with a set of metrics that could replace the metrics created by the `alpenmonitor` that creates metrics for alpenhorn on wind.  But I looked at that, and there's shockingly few metrics that it's actually producing (it's mostly just the top three panels in the Alpenhorn grafana page).

Note: all metrics that the daemon presents are about the running daemon. It does not provide any of the metrics currently produced by the CHIME `archive_stats` job (which summarises the data index by directly inspecting the database). There's no plan to add them, but it would probably be a good idea to migrate that script over to this repo as a genericly useful script, or maybe as some sort of `alpenhorn db stats` command.

The `prometheus_client` dependency is optional.  If it can't be found at runtime, most of the metric-handling in `common.metrics` code does nothing.  The rest of alpenhorn is agnostic as to whether the `prometheus_client` module was available or not.

Closes #166 