### PR TITLE
fix(tests): Fix mock_stat fixture for pyfakefs>=5.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ prometheus = [
 ]
 test = [
   "chimedb @ git+https://github.com/chime-experiment/chimedb.git",
-  "docker >= 3.0",
   "pyfakefs >= 5.4",
   "pytest >= 7.0"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ prometheus = [
 test = [
   "chimedb @ git+https://github.com/chime-experiment/chimedb.git",
   "docker >= 3.0",
-  "pyfakefs >= 5.0",
+  "pyfakefs >= 5.4",
   "pytest >= 7.0"
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -355,32 +355,6 @@ def mock_statvfs(fs):
 
 
 @pytest.fixture
-def mock_stat(fs):
-    """Mocks pathlib.PosixPath.stat to work with pyfakefs."""
-
-    def _mocked_stat(path, follow_symlinks=False):
-        """Mock of pathlib.PosixPath.stat to report the size of pyfakefs files."""
-        nonlocal fs
-
-        from math import ceil
-
-        file = fs.get_object(path, check_read_perm=False)
-        size = file.size
-
-        # Anything with a __dict__ works here.
-        class Result:
-            # stat reports sizes in 512-byte blocks
-            st_blocks = ceil(size / 512)
-            st_size = size
-            st_mode = file.st_mode
-
-        return Result
-
-    with patch("pathlib.PosixPath.stat", _mocked_stat):
-        yield
-
-
-@pytest.fixture
 def mock_exists(fs):
     """Mocks pathlib.PosixPath.exists to work with pyfakefs."""
 
@@ -426,7 +400,7 @@ def mock_observer():
 
 
 @pytest.fixture
-def xfs(fs, mock_observer, mock_statvfs, mock_stat, mock_exists):
+def xfs(fs, mock_observer, mock_statvfs, mock_exists):
     """An extended pyfakefs.
 
     Patches more stuff for proper behaviour with alpenhorn unittests"""

--- a/tests/io/test_defaultnode.py
+++ b/tests/io/test_defaultnode.py
@@ -60,8 +60,8 @@ def test_filesize(unode, xfs):
 
     assert unode.io.filesize("dir/file1") == 1000
     assert unode.io.filesize("/node/dir/file1") == 1000
-    assert unode.io.filesize("/node/dir/file1", actual=True) == 1024
-    assert unode.io.filesize("dir/file1", actual=True) == 1024
+    assert unode.io.filesize("/node/dir/file1", actual=True) == 4096
+    assert unode.io.filesize("dir/file1", actual=True) == 4096
 
 
 def test_file_walk(unode, xfs):


### PR DESCRIPTION
And by "fix" I mean delete.

This fixture was mocking `pathlib.PosixPath.stat` within the fake filesystem.  But that method has worked, by default, within the fake filesystem since `pyfakefs-5.4`.

And now `pyfakefs-5.8` has broken the implementation that we were using in the `mock_stat` fixture.

So, the solution here is to delete the fixutre and require `pyfakefs>=5.4`.

Also: since I'm messing about in the dependencies, I've dropped the `docker` dependency from the test requirements: we don't use docker for testing anymore.