### PR TITLE
feat(common.config): Test isolation

### DIFF
--- a/alpenhorn/cli/entry.py
+++ b/alpenhorn/cli/entry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import click
 
+from ..common import config
 from ..common.util import help_config_option, start_alpenhorn, version_option
 from . import acq, db, file, group, node
 from .options import not_both
@@ -49,6 +50,14 @@ def _verbosity_from_cli(verbose: int, debug: bool, quiet: int) -> int:
     count=True,
 )
 @click.option(
+    "--test-isolation",
+    is_flag=True,
+    help=(
+        "Enable test isolation.  Using this option prevents alpenhorn "
+        "from reading config from the standard config paths."
+    ),
+)
+@click.option(
     "--verbose",
     "-v",
     help="Increase verbosity.  May be specified mulitple times: "
@@ -64,11 +73,14 @@ def _verbosity_from_cli(verbose: int, debug: bool, quiet: int) -> int:
     default=False,
 )
 @help_config_option
-def entry(conf, quiet, verbose, debug):
+def entry(conf, quiet, test_isolation, verbose, debug):
     """Alpenhorn data management system.
 
     This is the command-line interface to the alpenhorn data index.
     """
+
+    # Turn on test isolation, if requested
+    config.test_isolation(enable=test_isolation)
 
     # Initialise alpenhorn
     start_alpenhorn(

--- a/alpenhorn/common/config.py
+++ b/alpenhorn/common/config.py
@@ -169,21 +169,47 @@ _default_config = {
     },
 }
 
+_test_isolation = False
+
+
+def test_isolation(enable: bool = True) -> None:
+    """Enable or disable test isolation.
+
+    Test isolation disables the reading of config files installed
+    in the standard paths, but still allows specifying a config
+    file via command line or environmental variable.
+
+    For this function to have an effect, it must be called before
+    the first `load_config` call.  Ideally, put it in an early
+    test fixture in your test suite.
+
+    Parameters:
+    -----------
+    enable : bool
+        Whether to enable (the default) or disable test
+        isolation.
+    """
+    global _test_isolation
+    _test_isolation = enable
+
 
 def load_config(cli_conf: os.PathLike, cli: bool) -> None:
     """Find and load the configuration from a file."""
 
-    global config
+    global config, _test_isolation
 
     # Initialise with the default configuration
     config = _default_config.copy()
 
     # Construct the configuration file path
-    config_files = [
-        "/etc/alpenhorn/alpenhorn.conf",
-        "/etc/xdg/alpenhorn/alpenhorn.conf",
-        "~/.config/alpenhorn/alpenhorn.conf",
-    ]
+    if _test_isolation:
+        config_files = []
+    else:
+        config_files = [
+            "/etc/alpenhorn/alpenhorn.conf",
+            "/etc/xdg/alpenhorn/alpenhorn.conf",
+            "~/.config/alpenhorn/alpenhorn.conf",
+        ]
 
     enviro_conf = os.environ.get("ALPENHORN_CONFIG_FILE", None)
     if enviro_conf:

--- a/alpenhorn/daemon/entry.py
+++ b/alpenhorn/daemon/entry.py
@@ -41,9 +41,17 @@ sys.excepthook = log_exception
     is_flag=True,
     help="Run the update loop once, wait for updates to complete, and then exit.",
 )
+@click.option(
+    "--test-isolation",
+    is_flag=True,
+    help=(
+        "Enable test isolation.  Using this option prevents alpenhornd "
+        "from reading config from the standard config paths."
+    ),
+)
 @version_option
 @help_config_option
-def entry(conf, once):
+def entry(conf, once, test_isolation):
     """Alpenhornd: data management daemon.
 
     The alpenhorn daemon can be used to manage Storage Nodes.  See the alpenhorn
@@ -53,6 +61,9 @@ def entry(conf, once):
     it to run only a single update pass and then exit after updates have completed
     by using the "--exit-after-update" flag.
     """
+
+    # Turn on test isolation, if requested
+    config.test_isolation(enable=test_isolation)
 
     # Initialise alpenhorn
     start_alpenhorn(conf, cli=False)


### PR DESCRIPTION
This is not the cause of the test failures in https://github.com/chime-experiment/alpenhorn-chime/pull/5, but while debugging those failures on `wind` I discovered that installed `alpenhorn.conf` files will mess up those tests.

So we need a way to tell alpenhorn to ignore installed config files so that tests can run in isolation.

Adds a `--test-isolation` flag to both CLI and daemon that will cause alpenhorn to skip loading config from the standard paths (envar and --conf still work).  And also a function in `common.config` to accomplish the same.

Note: this is not needed in the alpenhorn test suite itself, because everything in the test suite that looks for config files runs in a fake filesystem.