### PR TITLE
feat(cli): Read file list via command-line option

### DIFF
--- a/alpenhorn/cli/cli.py
+++ b/alpenhorn/cli/cli.py
@@ -26,7 +26,7 @@ def check_then_update(
     1. If `do_check` is False, skips to step 6
     2. Calls `func` in "check" mode.
     3. If `do_update` is False, program exits
-    4. `click.confirm("Continue?")
+    4. Asks user for confirmation.
     5. If user declines confirmation, program exits
     6. If `do_update` is True, calls `func` in "update" mode.
 
@@ -36,7 +36,7 @@ def check_then_update(
         "update" mode (step 6)
     2. `ctx`: the click context object
     3. any positional parameters given in in `args`
-    4. `first_time`: a bool keyword arguemnt which is True the first time
+    4. `first_time`: a bool keyword argument which is True the first time
         `func` is called, and False the second time (if called twice).
 
     Anything returned by `func` is ignored.

--- a/alpenhorn/cli/group/sync.py
+++ b/alpenhorn/cli/group/sync.py
@@ -58,7 +58,7 @@ def _run_cancel(
     acqs:
         list of ArchiveAcqs to limit to.  May be the empty list for no limit
     listed_files:
-        set of ArchiveFiles listed in a --from-file file.
+        set of ArchiveFiles listed in a --file-list file.
     show_acqs:
         List acqusitions affected by the command
     show_files:
@@ -173,7 +173,7 @@ def _run_sync(
     acqs:
         list of ArchiveAcqs to limit to.  May be the empty list for no limit
     listed_files:
-        set of ArchiveFiles listed in a --from-file file.
+        set of ArchiveFiles listed in a --file-list file.
     show_acqs:
         List acqusitions affected by the command
     show_files:
@@ -376,7 +376,7 @@ def run_query(
     cancel:
         True if we're cancelling transfers.
     listed_files:
-        set of ArchiveFiles listed in a --from-file file.
+        set of ArchiveFiles listed in a --file-list file.
     show_acqs:
         List acqusitions affected by the command
     show_files:
@@ -452,12 +452,12 @@ def run_query(
     "  Incompatible with --force",
     is_flag=True,
 )
+@cli_option("file_list")
 @click.option(
     "--force",
     help="Force update (skips confirmation).  Incompatible with --check",
     is_flag=True,
 )
-@cli_option("from_file")
 @click.option("--show-acqs", help="List acquisitions to be copied.", is_flag=True)
 @click.option("--show-files", help="List files to be copied.", is_flag=True)
 @cli_option(
@@ -475,7 +475,7 @@ def sync(
     cancel,
     check,
     force,
-    from_file,
+    file_list,
     show_acqs,
     show_files,
     target,
@@ -487,7 +487,7 @@ def sync(
     running on the desination.  Only files which are not already in GROUP will
     be copied.
 
-    Which files are copied may be further limited with the --acq, --from-file and
+    Which files are copied may be further limited with the --acq, --file-list and
     --target options.
 
     \b
@@ -498,7 +498,7 @@ def sync(
     transfers into GROUP.  With a NODE, transfers from NODE to GROUP are cancelled,
     but you can instead of NODE use the special flag --all to cancel all inbound
     transfers into GROUP.  Cancelling can still be further limited by --acq and
-    --from-file, but not --target.
+    --file-list, but not --target.
     """
 
     # Usage checks
@@ -512,11 +512,11 @@ def sync(
     if all_ and node_name is not None:
         raise click.UsageError("Can't use --all with NODE.")
 
-    # Set check mode if --from-file=- was used to redirect stdin and no --force
-    check = check_if_from_stdin(from_file, check, force)
+    # Set check mode if --file-list=- was used to redirect stdin and no --force
+    check = check_if_from_stdin(file_list, check, force)
 
     # Load file list, if any
-    listed_files = files_from_file(from_file)
+    listed_files = files_from_file(file_list)
 
     # Run the check-confirm-update loop
     check_then_update(

--- a/alpenhorn/cli/node/clean.py
+++ b/alpenhorn/cli/node/clean.py
@@ -11,7 +11,9 @@ from ...common.util import pretty_bytes
 from ...db import ArchiveFile, ArchiveFileCopy, database_proxy, utcnow
 from ..cli import check_then_update, echo
 from ..options import (
+    check_if_from_stdin,
     cli_option,
+    files_from_file,
     files_in_groups,
     not_both,
     resolve_acq,
@@ -28,6 +30,7 @@ def _run_query(
     archive_ok,
     days: datetime.datetime,
     has_file: pw.Expression,
+    listed_files: set[ArchiveFile],
     size: int,
     target,
     clean_goal: str,
@@ -62,6 +65,8 @@ def _run_query(
         That is: an object which is the result of evaluating, say,
         (ArchiveFileCopy.has_file == 'Y'), which we'll pass on to the where()
         clause in the query.
+    listed_files:
+        set of ArchiveFiles listed in a --from-file file.
     size:
         Converted to bytes
     first_time:
@@ -100,10 +105,11 @@ def _run_query(
         if acqs or days or size:
             query = query.join(ArchiveFile)
 
-        # Add a wants_file constraint, if appropriate (with --size)
-        # we need to skip this: we need to scan through all the files
-        # so the totals are correct.  In that case, this constraint
-        # is handled when looping through copies.
+        # Add a wants_file constraint, if appropriate
+        #
+        # If --size is used, we need to skip this because we need to
+        # scan through all the files so the totals are correct.  In
+        # that case, this constraint is handled when looping through copies.
         if not size:
             # Without a size, we filter out everything that's not a
             # candidate for update
@@ -119,6 +125,10 @@ def _run_query(
         # Limit to acquisitions, if any
         if acqs:
             query = query.where(ArchiveFile.acq << acqs)
+
+        # Limit by from-file, if given
+        if listed_files:
+            query = query.where(ArchiveFileCopy.file << listed_files)
 
         # Limit to registration time, if requested.  This will implicitly
         # drop any file copies where the registration time is unknown.
@@ -291,6 +301,7 @@ def _run_query(
     help="Force cleaning (skips confirmation).  Incompatible with --check",
     is_flag=True,
 )
+@cli_option("from_file")
 @click.option(
     "--include-bad",
     help="Include suspect and corrupt files in the operation.",
@@ -302,7 +313,7 @@ def _run_query(
     "-s",
     metavar="SIZE",
     type=float,
-    help="Stop cleaning files once the total size cleaned reaces SIZE GiB.",
+    help="Stop cleaning files once the total size cleaned reaches SIZE GiB.",
 )
 @cli_option("target")
 @click.pass_context
@@ -315,6 +326,7 @@ def clean(
     check,
     days,
     force,
+    from_file,
     include_bad,
     now,
     size,
@@ -347,7 +359,7 @@ def clean(
 
     In normal operation, this command will schedule *all* files on NODE for
     cleaning, but the operation may be limited with the "--acq", "--days",
-    "--size", and "--target" options.
+    "--from-file", "--size", and "--target" options.
 
     Multiple --acq options may be given to provide a list of acquisitions to
     restrict cleaning to.  Files not in one of the specified acqusitions will
@@ -375,8 +387,8 @@ def clean(
     -------------------
 
     You may unschedule files for cleaning using the "--cancel" flag, which can
-    be similarly restricted with "--acq", "--days", and "--target", but not
-    "--size".
+    be similarly restricted with "--acq", "--days", "--from-file", and
+    "--target", but not "--size".
 
     Both kinds of cleaning (discretionary and immediate) will be cancelled,
     but only for files not yet removed from the NODE by the daemon.
@@ -389,6 +401,9 @@ def clean(
         raise click.UsageError("--days must be positive")
     if size is not None and size <= 0:
         raise click.UsageError("--size must be positive")
+
+    # Set check mode if --from-file=- was used to redirect stdin and no --force
+    check = check_if_from_stdin(from_file, check, force)
 
     # Convert days to a datetime
     if days:
@@ -413,11 +428,24 @@ def clean(
     else:
         has_file = ArchiveFileCopy.has_file == "Y"
 
+    # Load file list, if any
+    listed_files = files_from_file(from_file)
+
     # Do a check-then-update with the `_run_query` function.
     check_then_update(
         not force,
         not check,
         _run_query,
         ctx,
-        args=[name, acq, archive_ok, days, has_file, size, target, clean_goal],
+        args=[
+            name,
+            acq,
+            archive_ok,
+            days,
+            has_file,
+            listed_files,
+            size,
+            target,
+            clean_goal,
+        ],
     )

--- a/alpenhorn/cli/node/clean.py
+++ b/alpenhorn/cli/node/clean.py
@@ -66,7 +66,7 @@ def _run_query(
         (ArchiveFileCopy.has_file == 'Y'), which we'll pass on to the where()
         clause in the query.
     listed_files:
-        set of ArchiveFiles listed in a --from-file file.
+        set of ArchiveFiles listed in a --file-list file.
     size:
         Converted to bytes
     first_time:
@@ -126,7 +126,7 @@ def _run_query(
         if acqs:
             query = query.where(ArchiveFile.acq << acqs)
 
-        # Limit by from-file, if given
+        # Limit by file-list, if given
         if listed_files:
             query = query.where(ArchiveFileCopy.file << listed_files)
 
@@ -296,12 +296,12 @@ def _run_query(
     type=int,
     help="Only clean files registered more than COUNT days ago.",
 )
+@cli_option("file_list")
 @click.option(
     "--force",
     help="Force cleaning (skips confirmation).  Incompatible with --check",
     is_flag=True,
 )
-@cli_option("from_file")
 @click.option(
     "--include-bad",
     help="Include suspect and corrupt files in the operation.",
@@ -326,7 +326,7 @@ def clean(
     check,
     days,
     force,
-    from_file,
+    file_list,
     include_bad,
     now,
     size,
@@ -359,7 +359,7 @@ def clean(
 
     In normal operation, this command will schedule *all* files on NODE for
     cleaning, but the operation may be limited with the "--acq", "--days",
-    "--from-file", "--size", and "--target" options.
+    "--file-list", "--size", and "--target" options.
 
     Multiple --acq options may be given to provide a list of acquisitions to
     restrict cleaning to.  Files not in one of the specified acqusitions will
@@ -387,7 +387,7 @@ def clean(
     -------------------
 
     You may unschedule files for cleaning using the "--cancel" flag, which can
-    be similarly restricted with "--acq", "--days", "--from-file", and
+    be similarly restricted with "--acq", "--days", "--file-list", and
     "--target", but not "--size".
 
     Both kinds of cleaning (discretionary and immediate) will be cancelled,
@@ -402,8 +402,8 @@ def clean(
     if size is not None and size <= 0:
         raise click.UsageError("--size must be positive")
 
-    # Set check mode if --from-file=- was used to redirect stdin and no --force
-    check = check_if_from_stdin(from_file, check, force)
+    # Set check mode if --file-list=- was used to redirect stdin and no --force
+    check = check_if_from_stdin(file_list, check, force)
 
     # Convert days to a datetime
     if days:
@@ -429,7 +429,7 @@ def clean(
         has_file = ArchiveFileCopy.has_file == "Y"
 
     # Load file list, if any
-    listed_files = files_from_file(from_file)
+    listed_files = files_from_file(file_list)
 
     # Do a check-then-update with the `_run_query` function.
     check_then_update(

--- a/alpenhorn/cli/node/sync.py
+++ b/alpenhorn/cli/node/sync.py
@@ -7,7 +7,13 @@ import click
 
 from ..cli import check_then_update
 from ..group.sync import run_query
-from ..options import cli_option, not_both, requires_other
+from ..options import (
+    check_if_from_stdin,
+    cli_option,
+    files_from_file,
+    not_both,
+    requires_other,
+)
 
 
 @click.command()
@@ -33,6 +39,7 @@ from ..options import cli_option, not_both, requires_other
     help="Force update (skips confirmation).  Incompatible with --check",
     is_flag=True,
 )
+@cli_option("from_file")
 @click.option("--show-acqs", help="List acquisitions to be copied.", is_flag=True)
 @click.option("--show-files", help="List files to be copied.", is_flag=True)
 @cli_option(
@@ -50,6 +57,7 @@ def sync(
     cancel,
     check,
     force,
+    from_file,
     show_acqs,
     show_files,
     target,
@@ -61,7 +69,7 @@ def sync(
     running on the desination.  Only files which are not already in GROUP will
     be copied.
 
-    Which files are copied may be further limited with the --acq and
+    Which files are copied may be further limited with the --acq, --from-file, and
     --target options.
 
     \b
@@ -71,8 +79,8 @@ def sync(
     Using the --cancel flag, this command can also be used to cancel pending
     transfers out of NODE.  With a GROUP, transfers from NODE to GROUP are cancelled,
     but you can instead of GROUP use the special flag --all to cancel all outbound
-    transfers from NODE.  Cancelling can still be further limited by --acq,
-    but not --target.
+    transfers from NODE.  Cancelling can still be further limited by --acq and
+    --from-file, but not --target.
     """
 
     # Usage checks
@@ -86,6 +94,12 @@ def sync(
     if all_ and group_name is not None:
         raise click.UsageError("Can't use --all with GROUP.")
 
+    # Set check mode if --from-file=- was used to redirect stdin and no --force
+    check = check_if_from_stdin(from_file, check, force)
+
+    # Load file list, if any
+    listed_files = files_from_file(from_file)
+
     # We're using the "group sync" run_query function here, which is why
     # group_name and node_name are backwards
     check_then_update(
@@ -93,5 +107,14 @@ def sync(
         not check,
         run_query,
         ctx,
-        args=[group_name, node_name, acq, cancel, show_acqs, show_files, target],
+        args=[
+            group_name,
+            node_name,
+            acq,
+            cancel,
+            listed_files,
+            show_acqs,
+            show_files,
+            target,
+        ],
     )

--- a/alpenhorn/cli/node/sync.py
+++ b/alpenhorn/cli/node/sync.py
@@ -34,12 +34,12 @@ from ..options import (
     "  Incompatible with --force",
     is_flag=True,
 )
+@cli_option("file_list")
 @click.option(
     "--force",
     help="Force update (skips confirmation).  Incompatible with --check",
     is_flag=True,
 )
-@cli_option("from_file")
 @click.option("--show-acqs", help="List acquisitions to be copied.", is_flag=True)
 @click.option("--show-files", help="List files to be copied.", is_flag=True)
 @cli_option(
@@ -57,7 +57,7 @@ def sync(
     cancel,
     check,
     force,
-    from_file,
+    file_list,
     show_acqs,
     show_files,
     target,
@@ -69,7 +69,7 @@ def sync(
     running on the desination.  Only files which are not already in GROUP will
     be copied.
 
-    Which files are copied may be further limited with the --acq, --from-file, and
+    Which files are copied may be further limited with the --acq, --file-list, and
     --target options.
 
     \b
@@ -80,7 +80,7 @@ def sync(
     transfers out of NODE.  With a GROUP, transfers from NODE to GROUP are cancelled,
     but you can instead of GROUP use the special flag --all to cancel all outbound
     transfers from NODE.  Cancelling can still be further limited by --acq and
-    --from-file, but not --target.
+    --file-list, but not --target.
     """
 
     # Usage checks
@@ -94,11 +94,11 @@ def sync(
     if all_ and group_name is not None:
         raise click.UsageError("Can't use --all with GROUP.")
 
-    # Set check mode if --from-file=- was used to redirect stdin and no --force
-    check = check_if_from_stdin(from_file, check, force)
+    # Set check mode if --file-list=- was used to redirect stdin and no --force
+    check = check_if_from_stdin(file_list, check, force)
 
     # Load file list, if any
-    listed_files = files_from_file(from_file)
+    listed_files = files_from_file(file_list)
 
     # We're using the "group sync" run_query function here, which is why
     # group_name and node_name are backwards

--- a/alpenhorn/cli/node/verify.py
+++ b/alpenhorn/cli/node/verify.py
@@ -8,7 +8,15 @@ import peewee as pw
 from ...common.util import pretty_bytes
 from ...db import ArchiveFile, ArchiveFileCopy, database_proxy
 from ..cli import check_then_update, echo
-from ..options import cli_option, not_both, resolve_acq, resolve_node, state_constraint
+from ..options import (
+    check_if_from_stdin,
+    cli_option,
+    files_from_file,
+    not_both,
+    resolve_acq,
+    resolve_node,
+    state_constraint,
+)
 
 
 def _run_query(
@@ -17,10 +25,11 @@ def _run_query(
     name: str,
     acq: list,
     file_selection: pw.Expression,
+    listed_files: set[ArchiveFile],
     verify_goal: str,
     first_time: bool,
 ):
-    """Run the veroify query, either in check mode or update mode.
+    """Run the verify query, either in check mode or update mode.
 
     Must be done twice because the DB contents can change while we wait
     for the user's confirmation.
@@ -28,7 +37,7 @@ def _run_query(
     Parameters:
     -----------
     update:
-        True if in "update" mode.  False in "count" mode.
+        True if in "update" mode.  False in "check" mode.
     ctx:
         click context object
     name:
@@ -39,6 +48,8 @@ def _run_query(
         a peewee.Expression encapsulating the --corrupt, --missing, and
         --healthy optons.  This is a constraint which will be applied to
         the `where` clause of the `ArchiveFileCopy` query.
+    listed_files:
+        set of ArchiveFiles listed in a --from-file file.
     verify_goal:
         The value we want to set has_file to.  This is 'M' except in
         --cancel mode.
@@ -58,6 +69,10 @@ def _run_query(
         # Limit to acquisitions, if any
         if acqs:
             query = query.join(ArchiveFile).where(ArchiveFile.acq << acqs)
+
+        # Limit by from-file, if given
+        if listed_files:
+            query = query.where(ArchiveFileCopy.file << listed_files)
 
         # Perform the query
         copies = list(query.execute())
@@ -129,7 +144,7 @@ def _run_query(
     help="Cancel existing verifcation requests by explicitly setting their status",
 )
 @click.option(
-    "--count",
+    "--check",
     is_flag=True,
     help="Don't actually perform the operation, just print how many files "
     "would be affected",
@@ -142,9 +157,10 @@ def _run_query(
 )
 @click.option(
     "--force",
-    help="Force update (skips confirmation).  Incompatible with --count",
+    help="Force update (skips confirmation).  Incompatible with --check",
     is_flag=True,
 )
+@cli_option("from_file")
 @click.option(
     "--healthy",
     help="With --cancel, set file status to healthy.  Without --cancel, "
@@ -158,7 +174,9 @@ def _run_query(
     is_flag=True,
 )
 @click.pass_context
-def verify(ctx, name, acq, all_, cancel, count, corrupt, force, healthy, missing):
+def verify(
+    ctx, name, acq, all_, cancel, check, corrupt, force, from_file, healthy, missing
+):
     """Verify files on a Storage Node.
 
     Use this command to request verification of files on NODE, or to
@@ -177,10 +195,9 @@ def verify(ctx, name, acq, all_, cancel, count, corrupt, force, healthy, missing
     --all, --corrupt, --healthy, and --missing flags.  If any of these flags
     are used, the default selection is ignored.
 
-    Files to verify may be further restricted by specifying one or
-    more acqusitions to limit the operation to (via the --acq option).
-    Files which have been released for immediate removal (via, say, the
-    "node clean" command) are always skipped.
+    Files to verify may be further restricted using the --acq and --from-file
+    options.  Files which have been released for immediate removal (via, say,
+    the "node clean" command) are always skipped.
 
     NOTE: Be careful when you request re-verification.  After this command
     sets an affected file to "suspect", that file will not be available for
@@ -205,7 +222,10 @@ def verify(ctx, name, acq, all_, cancel, count, corrupt, force, healthy, missing
     will override whatever status you set manually.
     """
     # usage checks
-    not_both(count, "count", force, "force")
+    not_both(check, "check", force, "force")
+
+    # Set check mode if --from-file=- was used to redirect stdin and no --force
+    check = check_if_from_stdin(from_file, check, force)
 
     # Cancel and non-cancel modes are fairly different about what most
     # of the flags mean
@@ -252,11 +272,14 @@ def verify(ctx, name, acq, all_, cancel, count, corrupt, force, healthy, missing
         if file_selection is None:
             raise RuntimeError("Something went wrong!  Selection expression is empty.")
 
+    # Load file list, if any
+    listed_files = files_from_file(from_file)
+
     # Do a check-then-update with the `_run_query` function.
     check_then_update(
         not force,
-        not count,
+        not check,
         _run_query,
         ctx,
-        args=[name, acq, file_selection, verify_goal],
+        args=[name, acq, file_selection, listed_files, verify_goal],
     )

--- a/alpenhorn/cli/node/verify.py
+++ b/alpenhorn/cli/node/verify.py
@@ -49,7 +49,7 @@ def _run_query(
         --healthy optons.  This is a constraint which will be applied to
         the `where` clause of the `ArchiveFileCopy` query.
     listed_files:
-        set of ArchiveFiles listed in a --from-file file.
+        set of ArchiveFiles listed in a --file-list file.
     verify_goal:
         The value we want to set has_file to.  This is 'M' except in
         --cancel mode.
@@ -70,7 +70,7 @@ def _run_query(
         if acqs:
             query = query.join(ArchiveFile).where(ArchiveFile.acq << acqs)
 
-        # Limit by from-file, if given
+        # Limit by file-list, if given
         if listed_files:
             query = query.where(ArchiveFileCopy.file << listed_files)
 
@@ -155,12 +155,12 @@ def _run_query(
     "verify known corrupt files",
     is_flag=True,
 )
+@cli_option("file_list")
 @click.option(
     "--force",
     help="Force update (skips confirmation).  Incompatible with --check",
     is_flag=True,
 )
-@cli_option("from_file")
 @click.option(
     "--healthy",
     help="With --cancel, set file status to healthy.  Without --cancel, "
@@ -175,7 +175,7 @@ def _run_query(
 )
 @click.pass_context
 def verify(
-    ctx, name, acq, all_, cancel, check, corrupt, force, from_file, healthy, missing
+    ctx, name, acq, all_, cancel, check, corrupt, force, file_list, healthy, missing
 ):
     """Verify files on a Storage Node.
 
@@ -195,7 +195,7 @@ def verify(
     --all, --corrupt, --healthy, and --missing flags.  If any of these flags
     are used, the default selection is ignored.
 
-    Files to verify may be further restricted using the --acq and --from-file
+    Files to verify may be further restricted using the --acq and --file-list
     options.  Files which have been released for immediate removal (via, say,
     the "node clean" command) are always skipped.
 
@@ -224,8 +224,8 @@ def verify(
     # usage checks
     not_both(check, "check", force, "force")
 
-    # Set check mode if --from-file=- was used to redirect stdin and no --force
-    check = check_if_from_stdin(from_file, check, force)
+    # Set check mode if --file-list=- was used to redirect stdin and no --force
+    check = check_if_from_stdin(file_list, check, force)
 
     # Cancel and non-cancel modes are fairly different about what most
     # of the flags mean
@@ -273,7 +273,7 @@ def verify(
             raise RuntimeError("Something went wrong!  Selection expression is empty.")
 
     # Load file list, if any
-    listed_files = files_from_file(from_file)
+    listed_files = files_from_file(file_list)
 
     # Do a check-then-update with the `_run_query` function.
     check_then_update(

--- a/alpenhorn/cli/options.py
+++ b/alpenhorn/cli/options.py
@@ -76,11 +76,8 @@ def cli_option(option: str, **extra_kwargs):
             "help": "Make node a field node (i.e. neither an archive node "
             "nor a transport node).  Incompatible with --archive or --transport.",
         }
-    elif option == "from_":
-        args = ("from_", "--from")
-        kwargs = {"metavar": "SOURCE_NODE", "help": "Source Node for the transfer."}
-    elif option == "from_file":
-        args = ("-F", "--from-file")
+    elif option == "file_list":
+        args = ("-F", "--file-list")
         kwargs = {
             "metavar": "PATH",
             "type": click.Path(
@@ -92,6 +89,9 @@ def cli_option(option: str, **extra_kwargs):
                 "assumed if --force isn't used."
             ),
         }
+    elif option == "from_":
+        args = ("from_", "--from")
+        kwargs = {"metavar": "SOURCE_NODE", "help": "Source Node for the transfer."}
     elif option == "group":
         args = ("--group",)
         kwargs = {
@@ -719,7 +719,7 @@ def check_if_from_stdin(path: str, check: bool, force: bool) -> bool:
     Parameters
     ----------
     path:
-        the argument to --from_file
+        the argument to --file-list
     check:
         the state of the --check flag
     force:
@@ -750,7 +750,7 @@ def check_if_from_stdin(path: str, check: bool, force: bool) -> bool:
 
 
 def files_from_file(path: str) -> None:
-    """Read a file list from a file given with --from-file
+    """Read a file list from a file given with --file-list
 
     Returns a set of ArchiveFiles.  If path is None, the empty set is returned.
     """

--- a/alpenhorn/cli/options.py
+++ b/alpenhorn/cli/options.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import fileinput
 import json
+import logging
 import pathlib
 
 import click
@@ -77,6 +79,19 @@ def cli_option(option: str, **extra_kwargs):
     elif option == "from_":
         args = ("from_", "--from")
         kwargs = {"metavar": "SOURCE_NODE", "help": "Source Node for the transfer."}
+    elif option == "from_file":
+        args = ("-F", "--from-file")
+        kwargs = {
+            "metavar": "PATH",
+            "type": click.Path(
+                exists=True, dir_okay=False, readable=True, allow_dash=True
+            ),
+            "help": (
+                "Limit operation to files listed in text file at PATH.  "
+                "If PATH is -, stdin will be read.  In that case, --check will be "
+                "assumed if --force isn't used."
+            ),
+        }
     elif option == "group":
         args = ("--group",)
         kwargs = {
@@ -634,20 +649,36 @@ def set_io_config(
     return new_config if new_config else None
 
 
-def file_from_path(path: str) -> ArchiveFile:
+def file_from_path(path: str, source: str | None = None) -> ArchiveFile:
     """Get file record given a path
 
     Given an "acqname/filename" path-like string, find and return
     the file name.
 
-    If a file cannot be found, raises click.ClickException.
+    Parameters
+    ----------
+    path:
+        The path to resolve into an ArchiveFile
+    source:
+        If not None, a location (i.e. a line in a file) added
+        to an error string.
+
+    Raises:
+    -------
+    click.ClickException:
+        A record for `path` could not be found.
     """
 
     path = pathlib.PurePath(path)
 
+    if source:
+        errstr = "No such file " + source + ": " + str(path)
+    else:
+        errstr = "No such file: " + str(path)
+
     # An absolute path is not allowed
     if path.is_absolute():
-        raise click.ClickException("No such file: " + str(path))
+        raise click.ClickException(errstr)
 
     # The trick here is path can have multiple path components: a/b/c/d/e
     # and we don't know which components are part of the acq_name and which
@@ -676,7 +707,87 @@ def file_from_path(path: str) -> ArchiveFile:
         except pw.DoesNotExist:
             pass
 
-    raise click.ClickException("No such file: " + str(path))
+    raise click.ClickException(errstr)
+
+
+def check_if_from_stdin(path: str, check: bool, force: bool) -> bool:
+    """Check whether to automatically turn on check mode
+
+    The intent here is that the output of this function will be assigned to
+    `check` in the caller.  Emits a warning if check mode is to be turned on.
+
+    Parameters
+    ----------
+    path:
+        the argument to --from_file
+    check:
+        the state of the --check flag
+    force:
+        the state of the --force flag
+
+    Returns
+    -------
+    check:
+        True if `check` is True or if `check` and `force` are False
+        and `path` is "-".  False otherwise.
+    """
+
+    # If mode is already selected, just return the input `check` value
+    if check or force:
+        return check
+
+    # Warn in turning on check mode
+    if path == "-":
+        log = logging.getLogger(__name__)
+        log.warning(
+            "stdin has been redirected without --force.  "
+            "Automatically enabling --check mode."
+        )
+        return True
+
+    # Otherwise, continue
+    return False
+
+
+def files_from_file(path: str) -> None:
+    """Read a file list from a file given with --from-file
+
+    Returns a set of ArchiveFiles.  If path is None, the empty set is returned.
+    """
+
+    files = set()
+
+    # Not given; return empty set
+    if not path:
+        return files
+
+    name = "stdin" if path == "-" else path
+
+    try:
+        for line in fileinput.input(files=[path]):
+            # Skip comment lines.  Note this check happens before whiespace
+            # stripping, meaning the "#" _must_ appear in the first column
+            # and may not have whitespace before it.
+            if line[0] == "#":
+                continue
+
+            # Strip leading and trailing whitespace
+            line = line.strip()
+
+            # Skip empty lines
+            if not line:
+                continue
+
+            files.add(
+                file_from_path(
+                    line,
+                    source=f"on line {fileinput.filelineno()} of {name}",
+                )
+            )
+    except OSError as e:
+        raise click.ClickException("error reading {name}: {e}") from e
+
+    return files
 
 
 def validate_md5(md5: str | None) -> None:

--- a/tests/cli/group/test_sync.py
+++ b/tests/cli/group/test_sync.py
@@ -496,17 +496,17 @@ def test_sync_show_files(clidb, cli):
     assert "Acq2/File4" in result.output
 
 
-def test_from_file_missing(clidb, cli):
-    """Test sync --from_file with non-existent file."""
+def test_file_list_missing(clidb, cli):
+    """Test sync --file-list with non-existent file."""
 
     group = StorageGroup.create(name="Group")
     StorageNode.create(name="Node", group=group)
 
-    cli(2, ["group", "sync", "Group", "Node", "--from-file=missing"])
+    cli(2, ["group", "sync", "Group", "Node", "--file-list=missing"])
 
 
-def test_from_file_bad_file(clidb, cli, xfs):
-    """Test sync --from_file with a bad entry."""
+def test_file_list_bad_file(clidb, cli, xfs):
+    """Test sync --file-list with a bad entry."""
 
     group_from = StorageGroup.create(name="GroupFrom")
     node_from = StorageNode.create(name="NodeFrom", group=group_from)
@@ -522,7 +522,7 @@ def test_from_file_bad_file(clidb, cli, xfs):
     file2 = ArchiveFile.create(name="File2", acq=acq, size_b=1234)
     ArchiveFileCopy.create(file=file2, node=node_from, has_file="Y", wants_file="Y")
 
-    xfs.create_file("/from_file", contents="Acq/File1\n# Comment\nAcq/File3")
+    xfs.create_file("/file_list", contents="Acq/File1\n# Comment\nAcq/File3")
 
     cli(
         1,
@@ -532,7 +532,7 @@ def test_from_file_bad_file(clidb, cli, xfs):
             "GroupTo",
             "NodeFrom",
             "--force",
-            "--from-file=/from_file",
+            "--file-list=/file_list",
         ],
     )
 
@@ -540,8 +540,8 @@ def test_from_file_bad_file(clidb, cli, xfs):
     assert ArchiveFileCopyRequest.select().count() == 0
 
 
-def test_from_file(clidb, cli, xfs):
-    """Test sync --from_file."""
+def test_file_list(clidb, cli, xfs):
+    """Test sync --file-list."""
 
     group_from = StorageGroup.create(name="GroupFrom")
     node_from = StorageNode.create(name="NodeFrom", group=group_from)
@@ -561,7 +561,7 @@ def test_from_file(clidb, cli, xfs):
     ArchiveFileCopy.create(file=file3, node=node_from, has_file="Y", wants_file="Y")
 
     # No newline at the end of this file
-    xfs.create_file("/from_file", contents="Acq/File1\n# Comment\nAcq/File3")
+    xfs.create_file("/file_list", contents="Acq/File1\n# Comment\nAcq/File3")
 
     cli(
         0,
@@ -571,7 +571,7 @@ def test_from_file(clidb, cli, xfs):
             "GroupTo",
             "NodeFrom",
             "--force",
-            "--from-file=/from_file",
+            "--file-list=/file_list",
         ],
     )
 
@@ -582,7 +582,7 @@ def test_from_file(clidb, cli, xfs):
 
 
 def test_from_stdin(clidb, cli):
-    """Test sync --from_file=-."""
+    """Test sync --file-list=-."""
 
     group_from = StorageGroup.create(name="GroupFrom")
     node_from = StorageNode.create(name="NodeFrom", group=group_from)
@@ -608,8 +608,8 @@ def test_from_stdin(clidb, cli):
             "sync",
             "GroupTo",
             "NodeFrom",
+            "--file-list=-",
             "--force",
-            "--from-file=-",
         ],
         input="Acq/File1\n# Comment\nAcq/File3",
     )
@@ -621,7 +621,7 @@ def test_from_stdin(clidb, cli):
 
 
 def test_from_stdin_unforced(clidb, cli):
-    """Test sync --from_file=-. without --force"""
+    """Test sync --file-list=-. without --force"""
 
     group_from = StorageGroup.create(name="GroupFrom")
     node_from = StorageNode.create(name="NodeFrom", group=group_from)
@@ -647,7 +647,7 @@ def test_from_stdin_unforced(clidb, cli):
             "sync",
             "GroupTo",
             "NodeFrom",
-            "--from-file=-",
+            "--file-list=-",
         ],
         input="Acq/File1\n# Comment\nAcq/File3",
     )

--- a/tests/cli/group/test_sync_cancel.py
+++ b/tests/cli/group/test_sync_cancel.py
@@ -374,8 +374,8 @@ def test_all(clidb, cli):
     assert ArchiveFileCopyRequest.get(id=2).cancelled == 1
 
 
-def test_from_file(clidb, cli, xfs):
-    """Test sync --cancel --from_file."""
+def test_file_list(clidb, cli, xfs):
+    """Test sync --cancel --file-list."""
 
     group_to = StorageGroup.create(name="GroupTo")
     StorageNode.create(name="NodeTo", group=group_to)
@@ -398,11 +398,11 @@ def test_from_file(clidb, cli, xfs):
         file=file3, node_from=node, group_to=group_to, cancelled=0, completed=0
     )
 
-    xfs.create_file("/from_file", contents="Acq/File1\n# Comment\nAcq/File3")
+    xfs.create_file("/file_list", contents="Acq/File1\n# Comment\nAcq/File3")
 
     cli(
         0,
-        ["group", "sync", "GroupTo", "--cancel", "--all", "--from-file=/from_file"],
+        ["group", "sync", "GroupTo", "--cancel", "--all", "--file-list=/file_list"],
         input="Y\n",
     )
 

--- a/tests/cli/node/test_clean.py
+++ b/tests/cli/node/test_clean.py
@@ -492,8 +492,8 @@ def test_include_bad(clidb, cli):
     assert ArchiveFileCopy.get(node=node, file=fileX).wants_file == "N"
 
 
-def test_from_file(clidb, cli, xfs):
-    """Test clean with --from-file"""
+def test_file_list(clidb, cli, xfs):
+    """Test clean with --file-list"""
 
     group = StorageGroup.create(name="Group1")
     node = StorageNode.create(name="NODE", group=group, storage_type="F")
@@ -509,9 +509,9 @@ def test_from_file(clidb, cli, xfs):
     file4 = ArchiveFile.create(name="File4", acq=acq)
     ArchiveFileCopy.create(node=node, file=file4, has_file="Y", wants_file="Y")
 
-    xfs.create_file("/from_file", contents="Acq/File1\n\n# Comment\nAcq/File3\n")
+    xfs.create_file("/file_list", contents="Acq/File1\n\n# Comment\nAcq/File3\n")
 
-    cli(0, ["node", "clean", "NODE", "--force", "--from-file=/from_file"])
+    cli(0, ["node", "clean", "NODE", "--force", "--file-list=/file_list"])
 
     # Only File1 and File3 were cleaned
     assert ArchiveFileCopy.get(node=node, file=file1).wants_file == "M"

--- a/tests/cli/node/test_sync.py
+++ b/tests/cli/node/test_sync.py
@@ -146,8 +146,8 @@ def test_all(clidb, cli):
     assert ArchiveFileCopyRequest.get(id=2).cancelled == 1
 
 
-def test_from_file(clidb, cli, xfs):
-    """Test sync --from_file."""
+def test_file_list(clidb, cli, xfs):
+    """Test sync --file-list."""
 
     group_from = StorageGroup.create(name="GroupFrom")
     node_from = StorageNode.create(name="NodeFrom", group=group_from)
@@ -167,7 +167,7 @@ def test_from_file(clidb, cli, xfs):
     ArchiveFileCopy.create(file=file3, node=node_from, has_file="Y", wants_file="Y")
 
     # No newline at the end of this file
-    xfs.create_file("/from_file", contents="Acq/File1\n# Comment\nAcq/File3")
+    xfs.create_file("/file_list", contents="Acq/File1\n# Comment\nAcq/File3")
 
     cli(
         0,
@@ -177,7 +177,7 @@ def test_from_file(clidb, cli, xfs):
             "NodeFrom",
             "GroupTo",
             "--force",
-            "--from-file=/from_file",
+            "--file-list=/file_list",
         ],
     )
 

--- a/tests/cli/node/test_verify.py
+++ b/tests/cli/node/test_verify.py
@@ -360,3 +360,26 @@ def test_verify_acq(clidb, cli):
     assert ArchiveFileCopy.get(node=node, file=file1).has_file == "M"
     assert ArchiveFileCopy.get(node=node, file=file2).has_file == "M"
     assert ArchiveFileCopy.get(node=node, file=file3).has_file == "X"
+
+
+def test_from_file(clidb, cli, xfs):
+    """Test verify with --from-file."""
+
+    group = StorageGroup.create(name="Group")
+    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    acq = ArchiveAcq.create(name="Acq")
+    file1 = ArchiveFile.create(name="File1", acq=acq)
+    ArchiveFileCopy.create(node=node, file=file1, has_file="X", wants_file="Y")
+    file2 = ArchiveFile.create(name="File2", acq=acq)
+    ArchiveFileCopy.create(node=node, file=file2, has_file="X", wants_file="Y")
+    file3 = ArchiveFile.create(name="File3", acq=acq)
+    ArchiveFileCopy.create(node=node, file=file3, has_file="X", wants_file="Y")
+
+    xfs.create_file("/from_file", contents="Acq/File1\nAcq/File3\n")
+
+    cli(0, ["node", "verify", "NODE", "--from-file=/from_file"], input="Y\n")
+
+    # only 1 and 3 should be updated
+    assert ArchiveFileCopy.get(node=node, file=file1).has_file == "M"
+    assert ArchiveFileCopy.get(node=node, file=file2).has_file == "X"
+    assert ArchiveFileCopy.get(node=node, file=file3).has_file == "M"

--- a/tests/cli/node/test_verify.py
+++ b/tests/cli/node/test_verify.py
@@ -362,8 +362,8 @@ def test_verify_acq(clidb, cli):
     assert ArchiveFileCopy.get(node=node, file=file3).has_file == "X"
 
 
-def test_from_file(clidb, cli, xfs):
-    """Test verify with --from-file."""
+def test_file_list(clidb, cli, xfs):
+    """Test verify with --file-list."""
 
     group = StorageGroup.create(name="Group")
     node = StorageNode.create(name="NODE", group=group, storage_type="F")
@@ -375,9 +375,9 @@ def test_from_file(clidb, cli, xfs):
     file3 = ArchiveFile.create(name="File3", acq=acq)
     ArchiveFileCopy.create(node=node, file=file3, has_file="X", wants_file="Y")
 
-    xfs.create_file("/from_file", contents="Acq/File1\nAcq/File3\n")
+    xfs.create_file("/file_list", contents="Acq/File1\nAcq/File3\n")
 
-    cli(0, ["node", "verify", "NODE", "--from-file=/from_file"], input="Y\n")
+    cli(0, ["node", "verify", "NODE", "--file-list=/file_list"], input="Y\n")
 
     # only 1 and 3 should be updated
     assert ArchiveFileCopy.get(node=node, file=file1).has_file == "M"

--- a/tests/cli/test_options.py
+++ b/tests/cli/test_options.py
@@ -3,7 +3,7 @@
 import click
 import pytest
 
-from alpenhorn.cli.options import set_io_config
+from alpenhorn.cli.options import check_if_from_stdin, set_io_config
 
 
 def test_sic_empty():
@@ -96,3 +96,17 @@ def test_sic_default_decode_override():
     io_config = set_io_config("", ("a=29",), "rawr")
 
     assert io_config == {"a": 29}
+
+
+def test_check_if_from_stdin():
+    """Test check_if_from_stdin"""
+
+    assert check_if_from_stdin("path", True, True) is True
+    assert check_if_from_stdin("path", True, False) is True
+    assert check_if_from_stdin("path", False, True) is False
+    assert check_if_from_stdin("path", False, False) is False
+
+    assert check_if_from_stdin("-", True, True) is True
+    assert check_if_from_stdin("-", True, False) is True
+    assert check_if_from_stdin("-", False, True) is False
+    assert check_if_from_stdin("-", False, False) is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,11 @@
 """Common fixtures"""
 
+import fileinput
 import logging
 import os
 import re
 import shutil
+import traceback
 from unittest.mock import MagicMock, patch
 from urllib.parse import quote as urlquote
 
@@ -616,13 +618,14 @@ def cli(request, xfs, cli_config):
     runner = CliRunner(**kwargs)
 
     def _cli_wrapper(expected_result, *args, **kwargs):
-        nonlocal runner
-
-        import traceback
-
         from alpenhorn.cli import entry
 
+        nonlocal runner
+
         result = runner.invoke(entry, *args, **kwargs)
+
+        # Clean up fileinput
+        fileinput.close()
 
         # Show traceback if one was created
         if (


### PR DESCRIPTION
This adds a `--file-list` option to various commands to allow limiting the command to a list of ArchiveFiles specified in a text file.

The intention is that, say,
```
        alpenhorn node sync cedar_nearline cedar_online --file-list=<FILE>
```
should do the same thing as
```
        recall_filelist <FILE>
```
is currently doing on cedar.

Can also read from stdin (via `--file-list=-`), in which case `--check` mode will be automatically turned on if the user doesn't invoke `--force`. (Because the file-reading code will consume all the input, making it impossible for the user to interactively confirm the operation, in that case.)

The commands which accept this option are:

* `node clean`
* `node sync` (AKA `group sync`)
* `node verify`

Also: renamed the `--count` flag in `node verify` to `--check` to make it the same as all the other commands with a check/confirm/update flow. Not sure why it was different; the `node verify` tests seem to indicate I had been assuming this rename already.

Closes #285 