### PR TITLE
fix(daemon): Fix daemon exit status

### DIFF
--- a/alpenhorn/daemon/entry.py
+++ b/alpenhorn/daemon/entry.py
@@ -51,7 +51,8 @@ sys.excepthook = log_exception
 )
 @version_option
 @help_config_option
-def entry(conf, once, test_isolation):
+@click.pass_context
+def entry(ctx, conf, once, test_isolation):
     """Alpenhornd: data management daemon.
 
     The alpenhorn daemon can be used to manage Storage Nodes.  See the alpenhorn
@@ -93,11 +94,15 @@ def entry(conf, once, test_isolation):
 
     # Enter main loop
     try:
-        update.update_loop(queue, wpool, once)
+        result = update.update_loop(queue, wpool, once)
     # Catch keyboard interrupt
     except KeyboardInterrupt:
         log.info("Exiting due to SIGINT")
+        result = 1
 
     # Attempt to exit cleanly
     auto_import.stop_observers()
     wpool.shutdown()
+
+    # Exit with result
+    ctx.exit(result)

--- a/alpenhorn/daemon/update.py
+++ b/alpenhorn/daemon/update.py
@@ -923,20 +923,10 @@ class UpdateableGroup(updateable_base):
 
 def update_loop(
     queue: FairMultiFIFOQueue, pool: WorkerPool | EmptyPool, once: bool
-) -> None:
+) -> int:
     """Main loop of alepnhornd.
 
     This is the main update loop for the alpenhorn daemon.
-
-    Parameters
-    ----------
-    queue : FairMultiFIFOQueue
-        the task manager
-    pool : WorkerPool
-        the pool of worker threads (may be empty)
-    once : bool
-        If True, only run the loop once, wait for the queue to empty,
-        and then exit.  If False, loop forever.
 
     If `once` is false, the daemon cycles through the update loop until it is
     terminated in one of three ways:
@@ -949,6 +939,21 @@ def update_loop(
 
     During a clean exit, alpenhornd will try to finish in-progress tasks before
     shutting down.
+
+    Parameters
+    ----------
+    queue : FairMultiFIFOQueue
+        the task manager
+    pool : WorkerPool
+        the pool of worker threads (may be empty)
+    once : bool
+        If True, only run the loop once, wait for the queue to empty,
+        and then exit.  If False, loop forever.
+
+    Return
+    ------
+    result:
+        0 if exiting after running once.  1 otherwise.
     """
 
     # Get the name of this host
@@ -1134,7 +1139,7 @@ def update_loop(
             while True:
                 if queue.qsize + queue.inprogress_size + queue.deferred_size == 0:
                     log.info("Update complete.  Exiting.")
-                    return
+                    return 0
 
                 if first_time:
                     first_time = False
@@ -1155,6 +1160,7 @@ def update_loop(
 
     # Warn on abnormal exit
     log.warning("Exiting due to global abort")
+    return 1
 
 
 def serial_io(queue: FairMultiFIFOQueue) -> None:


### PR DESCRIPTION
I think systemd is failing to restart alpenhorn on wind due to it not properly setting its exit code.

This will cause the daemon to exit with exit code 1 in all cases, except when exiting successfully after being invoked in run-once mode.