### PR TITLE
build: configure setuptools-git-versioning

### DIFF
--- a/alpenhorn/__init__.py
+++ b/alpenhorn/__init__.py
@@ -1,2 +1,25 @@
-# Specify version in Semantic style (with PEP 440 pre-release specification)
-__version__ = "2.0.0a1"
+"""Alpenhorn
+
+Submodules
+==========
+
+.. autosummary::
+    :toctree: _autosummary
+
+    cli
+    common
+    daemon
+    db
+    io
+    scheduler
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("alpenhorn")
+except PackageNotFoundError:
+    # package is not installed
+    pass
+
+del version, PackageNotFoundError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel"]
+requires = ["setuptools>=61.0.0", "wheel", "setuptools-git-versioning"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,10 +9,9 @@ authors = [
   {name = "J. Richard Shaw", email = "jrichardshaw@gmail.com"},
   {name = "D. V. Wiebe", email = "dvw@phas.ubc.ca"}
 ]
-version="2.0.0a1"
 description = "Data archive management software"
 requires-python = ">=3.11"
-dynamic = ["readme"]
+dynamic = ["readme", "version"]
 license = {file = "LICENSE"}
 dependencies = [
   "Click >= 6.0",
@@ -51,3 +50,6 @@ readme = {file = ["README.rst"], content-type = "text/x-rst"}
 
 [tool.pytest.ini_options]
 addopts = "--import-mode=importlib"
+
+[tool.setuptools-git-versioning]
+enabled = true


### PR DESCRIPTION
According to the TODO list for 2.0 (#14) all the features we wanted in 2.0 have been implemented, and we're just waiting on documentation for a full release, so I think it's time to make a `2.0.0rc1` release candidate.   We've been stuck at `2.0.0a1` for a _very_ long time.

In preparation for that, this PR gets `setuptools-git-versioning` working for this repository.