### PR TITLE
feat(auto_import): Reject files with leading dots

### DIFF
--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -174,7 +174,7 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
             else:
                 deltat = time.monotonic() - self._restore_start[copy.file.id]
                 log.info(
-                    f"{copy.file.path} restored on node {self.node.name}"
+                    f"{copy.file.path} restored on node {self.node.name} "
                     f"after {pretty_deltat(deltat)}"
                 )
                 del self._restore_start[copy.file.id]

--- a/demo/demo-script.md
+++ b/demo/demo-script.md
@@ -539,10 +539,18 @@ File                 Size    MD5 Hash                          Registration Time
 
 ### Auto-importing files and temporary names
 
-Another option for writing files to a node filesystem when auto-import is turned on, may be to
-write them to a path which the import detect extensions won't accept, although whether this
-is possible will depend on the particular import detect extensions being used.  For this demo,
-we can use any name which doesn't match the patterns which the `pattern_importer` will accept.
+Another option for writing files to a node filesystem when auto-import is turned on, is to
+use a temporary name for the file which will cause alpenhorn to decline to import the file.
+The import extensions which you're using may provide a namespace for such files, as is 
+the case with this demo and the `pattern_importer` which has been configured: any filename
+which does not match the patterns which were defined by the `pattern_importer.demo_init` function
+would work.
+
+Whether or not your import extensions don't have provisions for omitting files based on pathname,
+another option is to use a leading dot in the filename of a file you're creating: alpenhorn will
+never import a file whose first character is a (dot).  Note: this is only true of _file_ names:
+alpenhorn is still willing to import paths which contain _directories_ with leading dots in their
+names, assuming such names are acceptable to at least one of your import extensions.
 
 As an example, let's create a `.dat` file with a temporary name by appending, say, `.temp` to
 the name of the file we want to create:
@@ -558,6 +566,11 @@ alpen1-1  | Feb 21 23:51:59 INFO >> [Worker#1] Beginning task Import 2025/02/21/
 alpen1-1  | Feb 21 23:51:59 INFO >> [Worker#1] Not importing non-acquisition path: 2025/02/21/23/1324.dat.temp
 alpen1-1  | Feb 21 23:51:59 INFO >> [Worker#1] Finished task: Import 2025/02/21/23/1324.dat.temp on demo_storage1
 ```
+
+The message "Not importing non-acquisition path" means no import extension indicated to alpenhorn that
+the file should be imported.  If, instead, we had used a temporary filename with a leading dot, say,
+`/data/2025/02/21/23/.1324.dat`, an import task wouldn't have even been made, since alpenhorn would have
+rejected the file name earlier, before it got around to attempting to import the file.
 
 After file is fully written, it can be moved to the correct name.  On most filesystems, this is an
 atomic operation:


### PR DESCRIPTION
While working on the demo script, I realised it's very tricky to talk about creating files on a StorageNode which has auto-import turned on which aren't going to be imported, because, by default, `alpenhorn` has no criteria to reject certain filenames.  I've been mulling this over, and I think this is likely a good way of dealing with this idea.

This changes the daemon import to refuse to register any file whose filename starts with a leading dot.  While this does put a mild restriction on users' ability to name their data files, the benefit is there is always a portion of the namespace that can be used without worring about running afoul of alpenhorn.

As a side benefit, this removes the confusion over what a lockfile for a file with a leading dot would be;  i.e. would the lockfile for a file named `.name.h5` be `.name.h5.lock` or `..name.h5.lock`? (Answer: it's the second one.)

Note: this is only _filenames_ which may not have a leading dot; directory names, including one used as an `ArchiveAcq.name` may still start with a leading dot.

There are two parts to this change:
* A check in `_import_file` will reject any file with a leading dot in its name.
* A change to the RegisterFile watchdog event handler which means events for files with leading dots are no longer forwarded on to the import machinery.

Also: fixed the `test_auto_import.py::test_import_file_locked` test, which was not testing what it was meant to be testing.