### PR TITLE
fix(scheduler): Remove worker_idle metric for stopped workers

### DIFF
--- a/alpenhorn/common/metrics.py
+++ b/alpenhorn/common/metrics.py
@@ -274,13 +274,13 @@ class Metric:
     def remove(self, /, **labels: str) -> None:
         """Remove a labelset from the metric.
 
-        Returns the child metric with the labelset resulting from merging the
+        Deletes the child metric with the labelset resulting from merging the
         unbound and bound labels.
 
         Values for all unbound labels must be specified in the supplied `labels`
         dict.
 
-        If no such metric exists, this function does nothing.
+        If no such child metric exists, this function does nothing and succeeds.
 
         Paramters:
         ----------
@@ -288,7 +288,10 @@ class Metric:
             The key-value pairs of the unbound labels for the labelset.
         """
         if self._metric:
-            self._metric.remove(self.labelvalues(**labels))
+            try:
+                self._metric.remove(self.labelvalues(**labels))
+            except KeyError:
+                pass  # Child metric didn't exist
 
     def clear(self) -> None:
         """Remove all labelsets from the metric.


### PR DESCRIPTION
When a worker stops, this will delete the `worker_idle` child metric for that worker (i.e. deleting the metric vector from the prom data).

Closes #289