### PR TITLE
fix(cli): Handle negative sizes in DB

### DIFF
--- a/alpenhorn/cli/node/show.py
+++ b/alpenhorn/cli/node/show.py
@@ -55,17 +55,17 @@ def show(name, actions, all_, imports, stats, transfers):
     else:
         type_name = "-"
 
-    if node.max_total_gb:
+    if node.max_total_gb and node.max_total_gb > 0:
         max_total = pretty_bytes(node.max_total_gb * 2**30)
     else:
         max_total = "-"
 
-    if node.min_avail_gb:
+    if node.min_avail_gb and node.min_avail_gb > 0:
         min_avail = pretty_bytes(node.min_avail_gb * 2**30)
     else:
         min_avail = "-"
 
-    if node.avail_gb:
+    if node.avail_gb and node.avail_gb > 0:
         avail = pretty_bytes(node.avail_gb * 2**30)
     else:
         avail = "-"

--- a/alpenhorn/cli/node/stats.py
+++ b/alpenhorn/cli/node/stats.py
@@ -115,7 +115,7 @@ def get_stats(nodes: list[StorageNode], extra_stats: bool) -> dict[int, dict]:
             stats[node.id]["count"] = 0
 
         if node_stats.get("size"):
-            if node.max_total_gb:
+            if node.max_total_gb and node.max_total_gb > 0:
                 percent = 100.0 * node_stats["size"] / node.max_total_gb / 2**30
                 stats[node.id]["percent"] = f"{percent:5.2f}"
             else:

--- a/tests/cli/node/test_show.py
+++ b/tests/cli/node/test_show.py
@@ -38,7 +38,7 @@ def test_show_defaults(clidb, cli):
     assert "I/O Config" in result.output
 
 
-def test_show_empty_full(clidb, cli):
+def test_show_full(clidb, cli):
     """Test show most fields full."""
 
     now = utcnow()
@@ -76,6 +76,25 @@ def test_show_empty_full(clidb, cli):
     assert "3.333 GiB" in result.output
     assert "256.0 MiB" in result.output
     assert now.ctime() + " UTC" in result.output
+
+
+def test_negative_gb(clidb, cli):
+    """Test with negative sizes."""
+
+    group = StorageGroup.create(name="Group")
+    StorageNode.create(
+        name="Node",
+        group=group,
+        max_total_gb=-1,
+        min_avail_gb=-1,
+        avail_gb=-0.5,
+    )
+
+    result = cli(0, ["node", "show", "Node"])
+
+    assert "Max Total: -" in result.output
+    assert "Available: -" in result.output
+    assert "Min Available: -" in result.output
 
 
 def test_show_empty_io_config(clidb, cli):

--- a/tests/cli/node/test_stats.py
+++ b/tests/cli/node/test_stats.py
@@ -61,6 +61,17 @@ def test_list(some_nodes, cli, assert_row_present):
     assert_row_present(result.output, "Node4", 1, "1.000 GiB", "5.00")
 
 
+def test_negative_total(some_nodes, cli, assert_row_present):
+    """Test listing nodes with negative max_total_gb."""
+
+    # Set Node1's total to -1
+    StorageNode.update(max_total_gb=-1).where(StorageNode.name == "Node1").execute()
+
+    result = cli(0, ["node", "stats"])
+
+    assert_row_present(result.output, "Node1", 2, "3.000 GiB", "-")
+
+
 def test_active(some_nodes, cli, assert_row_present):
     """Test limit --active."""
 


### PR DESCRIPTION
The alpenhorn-1 way to indicate no maximum size for a node was to set `StorageNode.max_total_gb` to -1.  Alpenhorn-2 made things more intuitive by using Null/None in this case, but we still need to be able to handle negative sizes from the database.

Other than `max_total_gb`, there's no reason to expect the other `..._gb` fields in the database to have a negative value, but they're all just floats, so there's nothing to prevent it, so I've added a check for all the fields.