### PR TITLE
test: Ignore ALPENHORN_CONFIG_FILE in pytest's environment

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -402,10 +402,17 @@ def mock_observer():
 
 
 @pytest.fixture
-def xfs(fs, mock_observer, mock_statvfs, mock_exists):
+def xfs(monkeypatch, fs, mock_observer, mock_statvfs, mock_exists):
     """An extended pyfakefs.
 
     Patches more stuff for proper behaviour with alpenhorn unittests"""
+
+    # Run tests without a pre-set ALPENHORN_CONFIG_FILE envar
+    try:
+        monkeypatch.delenv("ALPENHORN_CONFIG_FILE")
+    except KeyError:
+        pass
+
     return fs
 
 


### PR DESCRIPTION
If the execution environment for `pytest` contains `ALPENHORN_CONFIG_FILE`, we want to ignore that while testing (because such a file probably isn't going to be available in the fake filesytem).

I've added this fix to the `xfs` fixture, since it's never going to be a valid envar when the fake filesystem is in use, but it could probably go elsewhere in the fixtures, if we can figure out a better place.