### PR TITLE
fix(node stats): Handle large node totals

### DIFF
--- a/alpenhorn/cli/node/stats.py
+++ b/alpenhorn/cli/node/stats.py
@@ -116,7 +116,7 @@ def get_stats(nodes: list[StorageNode], extra_stats: bool) -> dict[int, dict]:
 
         if node_stats.get("size"):
             if node.max_total_gb and node.max_total_gb > 0:
-                percent = 100.0 * node_stats["size"] / node.max_total_gb / 2**30
+                percent = float(100 * node_stats["size"] / 2**30) / node.max_total_gb
                 stats[node.id]["percent"] = f"{percent:5.2f}"
             else:
                 stats[node.id]["percent"] = "-"


### PR DESCRIPTION
It appears that when (a) using a MySQL database and (b) the total size of a node is above some threshold, then the resulting total size is reported as a `decimal.Decimal` rather than a simple `int`.  In this case, the number can't be multiplied or divided by a `float`.

So, I've re-arranged this calculation and done an explicit cast to get around this.

Unfortunately, I can't seem to reproduce this using Sqlite, so I don't have a unit test for it at the momemt.  Perhaps an argument for doing a pass of the test suite with MySQL...