### PR TITLE
feat(cli): Allow node.root in file-list

### DIFF
--- a/alpenhorn/cli/group/sync.py
+++ b/alpenhorn/cli/group/sync.py
@@ -516,7 +516,7 @@ def sync(
     check = check_if_from_stdin(file_list, check, force)
 
     # Load file list, if any
-    listed_files = files_from_file(file_list)
+    listed_files = files_from_file(file_list, node_name)
 
     # Run the check-confirm-update loop
     check_then_update(

--- a/alpenhorn/cli/node/clean.py
+++ b/alpenhorn/cli/node/clean.py
@@ -429,7 +429,7 @@ def clean(
         has_file = ArchiveFileCopy.has_file == "Y"
 
     # Load file list, if any
-    listed_files = files_from_file(file_list)
+    listed_files = files_from_file(file_list, name)
 
     # Do a check-then-update with the `_run_query` function.
     check_then_update(

--- a/alpenhorn/cli/node/sync.py
+++ b/alpenhorn/cli/node/sync.py
@@ -98,7 +98,7 @@ def sync(
     check = check_if_from_stdin(file_list, check, force)
 
     # Load file list, if any
-    listed_files = files_from_file(file_list)
+    listed_files = files_from_file(file_list, node_name)
 
     # We're using the "group sync" run_query function here, which is why
     # group_name and node_name are backwards

--- a/alpenhorn/cli/node/verify.py
+++ b/alpenhorn/cli/node/verify.py
@@ -273,7 +273,7 @@ def verify(
             raise RuntimeError("Something went wrong!  Selection expression is empty.")
 
     # Load file list, if any
-    listed_files = files_from_file(file_list)
+    listed_files = files_from_file(file_list, name)
 
     # Do a check-then-update with the `_run_query` function.
     check_then_update(

--- a/tests/cli/node/test_clean.py
+++ b/tests/cli/node/test_clean.py
@@ -496,7 +496,7 @@ def test_file_list(clidb, cli, xfs):
     """Test clean with --file-list"""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, storage_type="F", root="/NODE")
 
     acq = ArchiveAcq.create(name="Acq")
 
@@ -509,7 +509,7 @@ def test_file_list(clidb, cli, xfs):
     file4 = ArchiveFile.create(name="File4", acq=acq)
     ArchiveFileCopy.create(node=node, file=file4, has_file="Y", wants_file="Y")
 
-    xfs.create_file("/file_list", contents="Acq/File1\n\n# Comment\nAcq/File3\n")
+    xfs.create_file("/file_list", contents="Acq/File1\n\n# Comment\n/NODE/Acq/File3\n")
 
     cli(0, ["node", "clean", "NODE", "--force", "--file-list=/file_list"])
 

--- a/tests/cli/node/test_verify.py
+++ b/tests/cli/node/test_verify.py
@@ -366,7 +366,7 @@ def test_file_list(clidb, cli, xfs):
     """Test verify with --file-list."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, storage_type="F", root="/NODE")
     acq = ArchiveAcq.create(name="Acq")
     file1 = ArchiveFile.create(name="File1", acq=acq)
     ArchiveFileCopy.create(node=node, file=file1, has_file="X", wants_file="Y")
@@ -375,7 +375,7 @@ def test_file_list(clidb, cli, xfs):
     file3 = ArchiveFile.create(name="File3", acq=acq)
     ArchiveFileCopy.create(node=node, file=file3, has_file="X", wants_file="Y")
 
-    xfs.create_file("/file_list", contents="Acq/File1\nAcq/File3\n")
+    xfs.create_file("/file_list", contents="Acq/File1\n/NODE/Acq/File3\n")
 
     cli(0, ["node", "verify", "NODE", "--file-list=/file_list"], input="Y\n")
 


### PR DESCRIPTION
This is an attempt to make file-list parsing a little more forgiving. Removes `node.root` from files listed in the file-list, if that is present.

For transfers, this will only allow the source `node.root` (because the destination node can't be determined by the CLI).  In cases where no node is given (e.g. `group sync --cancel --all --file-list=...`) no such path removal is attempted.