### PR TITLE
refactor(pattern_importer): Don't extend alpenhorn tables

### DIFF
--- a/demo/demo-script.md
+++ b/demo/demo-script.md
@@ -217,6 +217,20 @@ root@alpen1:/#
 
 Once at the root prompt, we can build the data index and start populating it.
 
+### Setting up the data index
+
+Creating the data index is simple, and can be accomplished with the alpenhorn CLI command:
+```
+  alpenhorn db init
+```
+Remember that all these alpenhorn commands need to be run inside the `alpen1` container that we
+started in the last section.  On successful completion, the `db init` command will report the version
+of the database schema used to create the Data Index:
+```(console)
+root@alpen1:/# alpenhorn db init
+Data Index version 2 initialised.
+```
+
 ### Setting up the import extension
 
 Because alpenhorn is data agnostic, it doesn't have any facilities out-of-the-box to import files.
@@ -225,10 +239,11 @@ For the purposes of this demo, we'll use the simple `pattern_importer` example e
 the `/examples` directory.  This extension has already been incorporated into the alpenhorn
 container image that we're running, and alpenhorn has been set up to use it.
 
-As explained in the documentation for the `pattern_importer` example, the extension adds fields to
-two alpenhorn tables: `ArchiveAcq` and `ArchiveFile`, as well as creating some of its own tables in
-the Data Index.  Because of this, we need to run the extension initialisation before we can create
-the rest of the data index proper.
+As explained in the documentation for the `pattern_importer` example, the extension adds four new
+tables to the alpenhorn Data Index: `AcqData`, `AcqType`, `FileData`, and `FileType`.  Adding extra
+tables to the Data Index is permitted, but caution must be used to prevent name clashes with
+alpenhorn's own tables, and tables from other potential extensions.  Fortunately, for the simple
+case in this demo, we don't have to worry about that.
 
 To initialise the database for the extension, run the `demo_init` function provided by the
 extension:
@@ -242,21 +257,6 @@ You should see a success message:
 ```(console)
 root@alpen1:/# python -c 'import pattern_importer; pattern_importer.demo_init()'
 Plugin init complete complete.
-```
-
-### Setting up the data index
-
-Once the pattern importer has been set up, set up the rest of the data index using the alpenhorn
-CLI:
-```
-  alpenhorn db init
-```
-Remember that all these alpenhorn commands need to be run inside the `alpen1` container that we
-started in the last section.  On successful completion, the `db init` command will report the version
-of the database schema used to create the Data Index:
-```(console)
-root@alpen1:/# alpenhorn db init
-Data Index version 2 initialised.
 ```
 
 ### Create the first StorageNode

--- a/examples/pattern_importer.py
+++ b/examples/pattern_importer.py
@@ -6,11 +6,10 @@ new data files which need import, both as part of the auto-import
 functionality, but also when requesting manual imports with the
 alpenhorn CLI.
 
-This creates two tables: AcqType and FileType which provide
+This creates four tables: AcqType and FileType which provide
 configuration data for matching the acq/file name against one or
-more patterns.  It also adds columns to the alpenhorn tables
-ArchiveAcq and ArchiveFile (see the `ExtendedAcq` and `ExtendedFile`
-classes).
+more patterns, and AcqData and FileData which contain additional
+metadata for ArchiveAcq and ArchiveFile entries.
 
 The detection function is `detect`.  This function is provided to
 alpenhorn via `register_extension`.  The `detect` function loops
@@ -19,8 +18,7 @@ supplied by alpenhorn to the patterns listed in the tables.
 
 On a successful match, the import callback function `register_file`
 will be called by alpenhorn, which then stores the matched AcqType
-in an extended ArchiveAcq table and the matched FileType in an
-extended ArchiveFile table.
+in the AcqData table and the matched FileType in the FileData table.
 """
 
 from __future__ import annotations
@@ -119,33 +117,34 @@ class FileType(TypeBase):
     pass
 
 
-class ExtendedAcq(ArchiveAcq):
-    """Extend ArchiveAcq record.
+class AcqData(base_model):
+    """Extra metadata for ArchiveAcqs
 
-    Adds a "type" attribute to hold a refernce to the AcqType.
+    Attributes
+    ----------
+    acq: foreign key
+        Points to the corresponding ArchiveAcq record
+    type : foreign key
+        The AcqType for this Acqusition
     """
 
+    acq = pw.ForeignKeyField(ArchiveAcq, backref="data", unique=True)
     type = pw.ForeignKeyField(AcqType, backref="acqs", null=True)
 
-    # Use the same table name
-    class Meta:
-        table_name = ArchiveAcq._meta.table_name
 
+class FileData(base_model):
+    """Extra metadata for ArchiveFiles
 
-class ExtendedFile(ArchiveFile):
-    """Extend ArchiveFile record.
-
-    Adds a "type" attribute to hold a refernce to the FileType.
-    Also re-implements the "acq" field to point it to the
-    `ExtendedAcq` record.
+    Attributes
+    ----------
+    file: foreign key
+        Points to the corresponding ArchiveFile record
+    type : foreign key
+        The FileType for this File
     """
 
-    acq = pw.ForeignKeyField(ExtendedAcq, backref="files")
+    file = pw.ForeignKeyField(ArchiveFile, backref="data", unique=True)
     type = pw.ForeignKeyField(FileType, backref="files", null=True)
-
-    # Use the same table name
-    class Meta:
-        table_name = ArchiveFile._meta.table_name
 
 
 def register_file(
@@ -165,6 +164,9 @@ def register_file(
     add extra data to the database, or do anything else we want with the newly
     imported file.
 
+    Here, this callback adds rows to the AcqData and/or FileData tables when
+    new ArchiveAcq and/or ArchiveFile records are created by alpenhorn.
+
     Parameters
     ----------
     filecopy: ArchiveFileCopy
@@ -181,6 +183,9 @@ def register_file(
         If this import created a new `ArchiveAcq` record, this is
         it (equivalent to `filecopy.file.acq`).  If a new `ArchiveAcq` was
         not created, this is None.
+    node : UpdateableNode,
+        The node on which the import happened.  The `node.io` attribute
+        can be used to access alpenhorn's I/O framework for the node.
     acq_type : AcqType
         The type of the acquisition.
     file_type : FileType
@@ -200,18 +205,13 @@ def register_file(
     `new_acq` _can_ be None when `new_file` is not.
     """
 
-    # Store the acqtype in the acq records.  This only needs to happen
-    # if the record is new.
-    if new_acq is not None:
-        acq = ExtendedAcq.get(id=new_acq.id)
-        acq.type = acq_type
-        acq.save()
+    # Create new AcqData record if a new ArchiveAcq was created
+    if new_acq:
+        AcqData.create(acq=new_acq, type=acq_type)
 
-    # Ditto for file type
-    if new_file is not None:
-        file = ExtendedFile.get(id=new_file.id)
-        file.type = file_type
-        file.save()
+    # Ditto for ArchiveFile
+    if new_file:
+        FileData.create(file=new_file, type=file_type)
 
 
 def detect(
@@ -286,13 +286,9 @@ def demo_init() -> None:
     This function initialises the alpenhorn data index to support this extension
     when used in the the alpenhorn demo (see alpenhorn/dmeo/demo-script.md).
 
-    It creates the AcqType, FileType and extended ArchiveAcq and ArchiveFile
-    tables and then populates the AcqType and FileType tables to allow the
-    demo alpenhorn instances to find the demo data.
-
-    Because this function creates extended versions of the alpenhorn
-    ArchiveAcq and ArchiveFile tables, it must be called before
-    "alpenhorn db init" is run to create the alpenhorn data index.
+    It creates the AcqType, FileType, AcqData, and FileData tables and
+    then populates the AcqType and FileType tables to allow the demo
+    alpenhorn instances to find the demo data.
     """
 
     # Load the alpenhorn config to find the database connection details
@@ -302,9 +298,7 @@ def demo_init() -> None:
     connect()
 
     # Create the tables, if necessary
-    database_proxy.create_tables(
-        [AcqType, FileType, ExtendedAcq, ExtendedFile], safe=True
-    )
+    database_proxy.create_tables([AcqType, FileType, AcqData, FileData], safe=True)
 
     # Populate AcqType.  There is only acq type in the demo
     AcqType.create(

--- a/tests/daemon/test_entry.py
+++ b/tests/daemon/test_entry.py
@@ -51,19 +51,14 @@ def e2e_db(xfs, clidb_noinit, hostname):
 
     db = clidb_noinit
 
-    # Remove tables duplicated by the pattern_importer
-    filtered = (
-        table for table in gamut if table != ArchiveFile and table != ArchiveAcq
-    )
-
     # Create tables
     db.create_tables(
         [
-            *filtered,
+            *gamut,
             pattern_importer.AcqType,
             pattern_importer.FileType,
-            pattern_importer.ExtendedAcq,
-            pattern_importer.ExtendedFile,
+            pattern_importer.AcqData,
+            pattern_importer.FileData,
         ]
     )
 
@@ -341,9 +336,12 @@ def test_cli(e2e_db, e2e_config, mock_lfs, mock_rsync):
     # Check results
 
     # find.me has been imported
-    assert ArchiveAcq.get(name="acq2")
+    acq2 = ArchiveAcq.get(name="acq2")
+    acqdata = pattern_importer.AcqData.get(acq=acq2)
+    assert acqdata.type == pattern_importer.AcqType.get(id=1)
     findme = ArchiveFile.get(name="find.me")
-    assert findme
+    filedata = pattern_importer.FileData.get(file=findme)
+    assert filedata.type == pattern_importer.FileType.get(id=1)
 
     # ... and is scheduled for transfer to the fleet
     dftnode = StorageNode.get(name="dftnode")


### PR DESCRIPTION
We're not going to remove support to allow extensions of the alpenhorn tables.  CHIME needs it.  (Also: peewee allows it; it would be difficult to prevent from within alpenhorn.) But, I think it's both unnecessarily confusing, and also not a demonstration of best practices, to do this in an example extension.

So, this PR replaces the extension of `ArchiveAcq` and `ArchiveFile` in the pattern exporter with a couple new tables (`AcqData` and `FileData`) to hold the extra metadata that it wants to store.

As a result of changing this I've re-ordered the steps in the demo to create the alpenhorn data index first and then initialise the extension second, which I think is a more intuitive way to do it.  I've also updated the end-to-end test of the daemon in `tests/daemon/test_entry.py` for this change.