### PR TITLE
feat(db): Implement schema versioning

### DIFF
--- a/alpenhorn/cli/cli.py
+++ b/alpenhorn/cli/cli.py
@@ -7,11 +7,26 @@ from typing import TYPE_CHECKING
 import click
 
 from ..common.logger import echo
-from ..db import connect as dbconnect  # noqa: F401
+from ..db import connect, schema_version
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 del TYPE_CHECKING
+
+
+def dbconnect(check: bool = True) -> None:
+    """Connect to the database, with schema checking.
+
+    Parameters
+    ----------
+    check:
+        If True (the default), raises ClickException if the
+        database doesn't conform to the current schema version.
+    """
+
+    connect()
+    if check:
+        schema_version(check=True)
 
 
 def check_then_update(

--- a/alpenhorn/cli/db/__init__.py
+++ b/alpenhorn/cli/db/__init__.py
@@ -10,7 +10,8 @@ from .init import init
 def cli():
     """Manage the Data Index."""
 
-    dbconnect()
+    # Don't exit on schema mismatch
+    dbconnect(check=False)
 
 
 cli.add_command(init, "init")

--- a/alpenhorn/cli/db/init.py
+++ b/alpenhorn/cli/db/init.py
@@ -3,20 +3,17 @@
 import click
 
 from ...db import (
-    ArchiveAcq,
-    ArchiveFile,
-    ArchiveFileCopy,
-    ArchiveFileCopyRequest,
-    ArchiveFileImportRequest,
-    StorageGroup,
-    StorageNode,
-    StorageTransferAction,
+    DataIndexVersion,
+    current_version,
     database_proxy,
+    gamut,
+    schema_version,
 )
 
 
 @click.command()
-def init():
+@click.pass_context
+def init(ctx):
     """Initialise the Data Index.
 
     This command will create all the database table required
@@ -27,16 +24,33 @@ def init():
     functionality.
     """
 
-    # Create any alpenhorn core tables
-    core_tables = [
-        ArchiveAcq,
-        ArchiveFile,
-        ArchiveFileCopy,
-        ArchiveFileCopyRequest,
-        ArchiveFileImportRequest,
-        StorageGroup,
-        StorageNode,
-        StorageTransferAction,
-    ]
+    # Check database schema version
+    vers = schema_version()
 
-    database_proxy.create_tables(core_tables, safe=True)
+    # Are we already good?
+    if vers == current_version:
+        click.echo("Data Index already initialised.")
+        ctx.exit(0)
+
+    # Version mismatch.  This needs to be solved with schema migration.
+    if vers > 0:
+        raise click.ClickException(f"Data Index version {vers} already present.")
+
+    # No schema version, check the database for existing tables
+    dbtables = database_proxy.get_tables()
+
+    # "Data Index version 1" refers to CHIME's (former) data index.  No
+    # one should encounter that anymore.
+    for table in gamut:
+        if table._meta.table_name in dbtables:
+            raise click.ClickException(
+                "Partially initialsed Data Index (or Data Index version 1) found.  "
+                "Manual repair required."
+            )
+
+    # No data index tables exist.  We should be good to create the database.
+    database_proxy.create_tables(gamut)
+
+    # Set schema version
+    DataIndexVersion.create(component="alpenhorn", version=current_version)
+    click.echo(f"Data Index version {current_version} initialised.")

--- a/alpenhorn/daemon/entry.py
+++ b/alpenhorn/daemon/entry.py
@@ -72,6 +72,9 @@ def entry(ctx, conf, once, test_isolation):
     # Connect to the database
     db.connect()
 
+    # Check the data index schema.  This doesn't return on mismatch
+    db.schema_version(check=True)
+
     # Start the prometheus client, if appropriate.
     if not once:
         metrics.start_promclient()

--- a/alpenhorn/db/__init__.py
+++ b/alpenhorn/db/__init__.py
@@ -37,6 +37,7 @@ thread, typically via the peewee table models provided by this module.
 
 # Table models
 from .acquisition import ArchiveAcq, ArchiveFile
+from .data_index import DataIndexVersion, current_version, schema_version
 from .archive import ArchiveFileCopy, ArchiveFileCopyRequest, ArchiveFileImportRequest
 from .storage import StorageGroup, StorageNode, StorageTransferAction
 
@@ -49,3 +50,16 @@ from ._base import EnumField, base_model
 # Naive-UTC stuff courtesy peewee.  These were originally in datetime
 # but were deprecated in 3.12 as too confusing.
 from peewee import utcnow, utcfromtimestamp
+
+# This contains all tables in the Data Index
+gamut = (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    ArchiveFileImportRequest,
+    DataIndexVersion,
+    StorageGroup,
+    StorageNode,
+    StorageTransferAction,
+)

--- a/alpenhorn/db/data_index.py
+++ b/alpenhorn/db/data_index.py
@@ -1,0 +1,141 @@
+"""Data Index metadata
+
+This module provides access to metadata about the Data Index
+itself.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import click
+import peewee as pw
+
+from ._base import base_model, database_proxy
+
+log = logging.getLogger(__name__)
+
+# This is the alpenhorn Data Index schema version implemented by this
+# version of the alpenhorn code-base.  In general, only a single schema
+# version (the one specified here) is supported by a particular version
+# of alpenhorn.
+current_version = 2
+
+
+class DataIndexVersion(base_model):
+    """Schema version table for the Data Index.
+
+    Attributes
+    ----------
+    component : str
+        The component of the Data Index being versioned.
+        The primary alpenhorn tables have the component
+        name "alpenhorn".  Extensions may also use this
+        table to track their database schema versions by
+        setting this to the name of the extension.
+    version : int
+        The schema version of the Data Index for the component.
+        Schema versions should start at one and increment by
+        one each time the schema for the specified `component`
+        is changed.
+    """
+
+    component = pw.CharField(max_length=256, unique=True)
+    version = pw.IntegerField()
+
+
+def schema_version(
+    *,
+    check: bool = False,
+    component: str | None = None,
+    component_version: int | None = None,
+) -> int:
+    """Report and optionally check Data Index schema version
+
+    By default, this function returns the schema version of the
+    Data Index in the database.  This function can also be used
+    to check for a particular version and raise an exception if
+    a version mismatch is encountered.
+
+    All parameters must be specified by keyword.
+
+    Parameters
+    ----------
+    check:
+        If True, check that the alpenhorn Data Index schema version
+        is equal to `alpenhorn.db.current_version` and raise an
+        exception if it isn't.  If this is True, the other parameters
+        to this function are ignored.  Setting this to True is equivalent
+        to setting `component` to "alpenhorn" and `component_version` to
+        `alpenhorn.db.current_version`.
+    component:
+        The name of the schema component to report/check.  Setting this
+        to `None` (the default) is equivalent to setting it to "alpenhorn".
+    component_version:
+        If not `None`, raise an exception if the schema version of the
+        component specified by `component` is not equal to this value.
+        If `component` is not present in the DataIndexVersion table, this
+        check always fails.
+
+    Returns
+    -------
+    version : int
+        The schema version of the specified component, or of the alpenhorn
+        Data Index itself, if no other component was specified.  If this
+        function was requested to check the version (because `check` or
+        `component_version` was set), this will always equal the target
+        version (because any other version will result in an exception, instead).
+        If the `component` was not listed in the DataIndexVersion table, zero
+        is returned.
+
+    Raises
+    ------
+    click.ClickException:
+        A check was requested and the check failed.
+    """
+    # Special case for check
+    if check:
+        component = "alpenhorn"
+        component_version = current_version
+    elif not component:
+        component = "alpenhorn"
+
+    # Fetch version for component
+    try:
+        schema = DataIndexVersion.get_or_none(component=component)
+    except pw.OperationalError:
+        # This may be because the table doesn't exist.  Look for it.
+        if DataIndexVersion._meta.table_name in database_proxy.get_tables():
+            # Table exists, but be some sort of other error
+            raise
+
+        # Otherwise, no table
+        schema = None
+
+    if schema:
+        schema_vers = schema.version
+    else:
+        schema_vers = 0
+
+    # Check, if requested
+    if component_version is not None:
+        # Importantly here: if `schema` is None, this check always fails
+        # (i.e. even if the caller were to have passed component_version=0)
+        if not schema or schema_vers != component_version:
+            # There's a special message for alpenhorn itself
+            if component == "alpenhorn":
+                lead = "Data Index version mismatch"
+            else:
+                lead = f'Schema version mismatch for Data Index component "{component}"'
+
+            wanted = f"wanted version {component_version}"
+
+            if schema:
+                found = f"found version {schema_vers}"
+            else:
+                found = "no schema found"
+
+            raise click.ClickException(f"{lead}:  {wanted}; {found}")
+
+    # Check, if performed, succeeded.  Return found version
+    return schema_vers

--- a/demo/demo-script.md
+++ b/demo/demo-script.md
@@ -252,10 +252,11 @@ CLI:
   alpenhorn db init
 ```
 Remember that all these alpenhorn commands need to be run inside the `alpen1` container that we
-started in the last section.  The `db init` command outputs nothing when successful:
+started in the last section.  On successful completion, the `db init` command will report the version
+of the database schema used to create the Data Index:
 ```(console)
 root@alpen1:/# alpenhorn db init
-root@alpen1:/#
+Data Index version 2 initialised.
 ```
 
 ### Create the first StorageNode

--- a/tests/cli/acq/test_list.py
+++ b/tests/cli/acq/test_list.py
@@ -18,6 +18,12 @@ def test_no_list(clidb, cli):
     assert "Name" not in result.output
 
 
+def test_schema_mismatch(clidb, cli, cli_wrong_schema):
+    """Test schema mismatch."""
+
+    cli(1, ["acq", "list"])
+
+
 def test_list(clidb, cli, assert_row_present):
     """Test with no constraints."""
 

--- a/tests/cli/file/test_list.py
+++ b/tests/cli/file/test_list.py
@@ -11,6 +11,12 @@ from alpenhorn.db import (
 )
 
 
+def test_schema_mismatch(clidb, cli, cli_wrong_schema):
+    """Test schema mismatch."""
+
+    cli(1, ["file", "list"])
+
+
 def test_only_from_to(clidb, cli):
     """Can't only use --from or --to"""
 

--- a/tests/cli/group/test_list.py
+++ b/tests/cli/group/test_list.py
@@ -3,6 +3,12 @@
 from alpenhorn.db import StorageGroup
 
 
+def test_schema_mismatch(clidb, cli, cli_wrong_schema):
+    """Test schema mismatch."""
+
+    cli(1, ["group", "list"])
+
+
 def test_list(clidb, cli):
     """Test listing groups."""
 

--- a/tests/cli/node/test_list.py
+++ b/tests/cli/node/test_list.py
@@ -32,6 +32,12 @@ def some_nodes(clidb):
     )
 
 
+def test_schema_mismatch(clidb, cli, cli_wrong_schema):
+    """Test schema mismatch."""
+
+    cli(1, ["node", "list"])
+
+
 def test_no_list(clidb, cli):
     """Test listing no nodes."""
 

--- a/tests/db/test_data_index.py
+++ b/tests/db/test_data_index.py
@@ -1,0 +1,113 @@
+"""test alpenhorn.db.data_index."""
+
+import click
+import peewee as pw
+import pytest
+
+from alpenhorn.db.data_index import DataIndexVersion, current_version, schema_version
+
+
+def test_data_index_version(dbproxy):
+    """Test that the DataIndexVersion table can be created."""
+    dbproxy.create_tables([DataIndexVersion])
+    assert set(dbproxy.get_tables()) == {"dataindexversion"}
+
+
+def test_data_index_version_model(dbproxy):
+    """Test DataIndexVersion table model."""
+
+    dbproxy.create_tables([DataIndexVersion])
+
+    DataIndexVersion.create(component="test", version=3)
+
+    # component is unique
+    with pytest.raises(pw.IntegrityError):
+        DataIndexVersion.create(component="test", version=4)
+
+    # component cannot be NULL
+    with pytest.raises(pw.IntegrityError):
+        DataIndexVersion.create(component=None, version=5)
+
+    # version cannot be NULL
+    with pytest.raises(pw.IntegrityError):
+        DataIndexVersion.create(component="test2", version=None)
+
+    # Check DB
+    assert DataIndexVersion.select().where(
+        DataIndexVersion.component == "test"
+    ).dicts().get() == {
+        "id": 1,
+        "component": "test",
+        "version": 3,
+    }
+
+
+def test_schema_version(dbtables):
+    """schema_version() should return the version."""
+
+    assert schema_version() == current_version
+
+
+def test_schema_version_check_ok(dbtables):
+    """Test successful check in schema_version."""
+
+    # Parameters other than check are ignored
+    assert (
+        schema_version(
+            check=True, component="MISSING", component_version=current_version + 1
+        )
+        == current_version
+    )
+
+
+def test_schema_version_check_bad(dbtables):
+    """Test unsuccessful check in schema_version."""
+
+    # Change version
+    DataIndexVersion.update(version=current_version + 1).where(
+        DataIndexVersion.component == "alpenhorn"
+    ).execute()
+
+    with pytest.raises(click.ClickException):
+        schema_version(check=True)
+
+
+def test_schema_version_check_explicit(dbtables):
+    """Test explicit check with schema_version."""
+
+    # Change version
+    DataIndexVersion.update(version=current_version + 1).where(
+        DataIndexVersion.component == "alpenhorn"
+    ).execute()
+
+    assert (
+        schema_version(component="alpenhorn", component_version=current_version + 1)
+        == current_version + 1
+    )
+
+    with pytest.raises(click.ClickException):
+        schema_version(component="alpenhorn", component_version=current_version + 2)
+
+
+def test_schema_version_missing(dbproxy, dbtables):
+    """Test schema_version with missing data."""
+
+    # Delete all rows
+    DataIndexVersion.delete().execute()
+
+    assert schema_version() == 0
+
+    with pytest.raises(click.ClickException):
+        schema_version(check=True)
+
+    # This should also fail (can't match to zero)
+    with pytest.raises(click.ClickException):
+        schema_version(component="alpenhorn", component_version=0)
+
+
+def test_schema_version_no_table(dbproxy):
+    """Test schema_version with no DataIndexVersion table."""
+
+    # This is one of the few functions that should still work
+    # if the table is not present
+    assert schema_version() == 0


### PR DESCRIPTION
Adds schema versioning to the database.  There's no support for schema migration (that may have to come later, if we ever change the database schema), but I think it's useful to at least set up schema version tracking before we release alpenhorn more generally.  This way, if we _do_ decide to change the database schema later at the very least users will be able to tell whether the alpenhorn they're using is compatible with the database they have.

Adds a new table, `DataIndexVersion`, with columns as outlined in #62 to track schema versioning (which can be used by extensions, if they so desire).  Also adds a new global `alpenhorn.db.current_version` containing the currently-supported schema version, which I've set to 2, leaving 1 to represent all old ("CHIME-style") data index versions.

Both the daemon and the CLI will now check the schema version reported by the database on start-up and refuse to run if it's different than the version they expect.  The sole exception here is the `alpenhorn db` command group, which skips the check, to allow using this group when the database hasn't been initialised yet.  However, the `db init` command now will check whether the databse already exists (even in part) and refuse to operate if it does.  The sole exception being: if the database-reported schema version is equal to the version `db init` was going to create, then it successfully does nothing.

To avoid constantly having to update it all over the place, I've also created a `alpenhorn.db.gamut` tuple which lists all tables in the data index, meaning there's only one place the whole list needs to be maintained now.

Closes #62
Closes #271

NB: this breaks the demo script as written because, with this change, initialising the pattern importer before creating the data index will cause `db init` to detect a broken data index and refuse to complete. This is my secret motivation behind #299.

Also: before this is deployed, we will need to add `DataIndexVersion` to the CHIME data index so the new checks don't stop the daemon and CLI from running.