### PR TITLE
fix(schema_version): Handle peewee.ProgrammingError

### DIFF
--- a/alpenhorn/db/data_index.py
+++ b/alpenhorn/db/data_index.py
@@ -103,7 +103,7 @@ def schema_version(
     # Fetch version for component
     try:
         schema = DataIndexVersion.get_or_none(component=component)
-    except pw.OperationalError:
+    except (pw.OperationalError, pw.ProgrammingError):
         # This may be because the table doesn't exist.  Look for it.
         if DataIndexVersion._meta.table_name in database_proxy.get_tables():
             # Table exists, but be some sort of other error


### PR DESCRIPTION
A quick chaser for #300... It looks like `mysql.connector` raises `ProgrammingError` when the table doesn't exist, unlike SQlite, which uses `OperationalError`, so let's handle both.

(Yet another argument for a MySQL pass on the test suite.)