### PR TITLE
Mypy / ruff format fixes

### DIFF
--- a/alpenhorn/cli/entry.py
+++ b/alpenhorn/cli/entry.py
@@ -16,8 +16,8 @@ def _verbosity_from_cli(verbose: int, debug: bool, quiet: int) -> int:
     Processes the --verbose, --debug and --quiet flags to determine
     the requested verbosity."""
 
-    not_both(quiet, "quiet", verbose, "verbose")
-    not_both(quiet, "quiet", debug, "debug")
+    not_both(quiet > 0, "quiet", verbose > 0, "verbose")
+    not_both(quiet > 0, "quiet", debug, "debug")
 
     # Default verbosity is 3.  --quiet decreases it.  --verbose increases it.
 

--- a/alpenhorn/cli/group/autosync.py
+++ b/alpenhorn/cli/group/autosync.py
@@ -36,8 +36,7 @@ def autosync(ctx, group_name, node_name, remove):
         # Sanity check: can't autosync within a group
         if group == node.group and not remove:
             raise click.ClickException(
-                "can't enable autosync: "
-                f'Node "{node_name}" is in group "{group_name}"'
+                f'can\'t enable autosync: Node "{node_name}" is in group "{group_name}"'
             )
 
         # What's the current state?

--- a/alpenhorn/cli/group/sync.py
+++ b/alpenhorn/cli/group/sync.py
@@ -35,7 +35,7 @@ def _run_cancel(
     ctx,
     group: StorageGroup,
     node: StorageNode,
-    acqs: list[ArchiveAcq],
+    acqs: set[ArchiveAcq],
     listed_files: set[ArchiveFile],
     show_acqs: bool,
     show_files: bool,
@@ -112,14 +112,14 @@ def _run_cancel(
     if first_time:
         if show_acqs or show_files:
             # Need to fetch the full request in this case
-            requests = ArchiveFileCopyRequest.select().where(
+            reqs = ArchiveFileCopyRequest.select().where(
                 ArchiveFileCopyRequest.id << afcrs
             )
 
         if show_acqs:
             acq_counts = {}
             acq_files = defaultdict(list)
-            for req in requests:
+            for req in reqs:
                 acq = req.file.acq
                 acq_counts[acq] = acq_counts.get(acq, 0) + 1
                 if show_files:
@@ -131,7 +131,7 @@ def _run_cancel(
                 if show_files:
                     echo("\n".join(sorted(acq_files[acq])))
         elif show_files:
-            paths = [str(req.file.path) for req in requests]
+            paths = [str(req.file.path) for req in reqs]
             echo("\n".join(sorted(paths)))
 
     # Do update
@@ -151,7 +151,7 @@ def _run_sync(
     ctx,
     group: StorageGroup,
     node: StorageNode,
-    acqs: list[ArchiveAcq],
+    acqs: set[ArchiveAcq],
     listed_files: set[ArchiveFile],
     show_acqs: bool,
     show_files: bool,
@@ -401,7 +401,7 @@ def run_query(
         try:
             group = StorageGroup.get(name=group_name)
         except pw.DoesNotExist:
-            raise click.ClickException("No such group: " + node_name)
+            raise click.ClickException("No such group: " + group_name)
 
     # Resolve acqs
     acqs = resolve_acq(acq)

--- a/alpenhorn/cli/node/clean.py
+++ b/alpenhorn/cli/node/clean.py
@@ -235,36 +235,36 @@ def _run_query(
         if size and results["S"]["count"]:
             files = "files" if results["S"]["count"] != 1 else "file"
             echo(
-                f'{results["S"]["count"]} {files} '
-                f'({pretty_bytes(results["S"]["size"])}) '
+                f"{results['S']['count']} {files} "
+                f"({pretty_bytes(results['S']['size'])}) "
                 "already contributing to size constraint."
             )
 
         if breakdown:
             if results["Y"]["count"]:
                 files = "files" if results["Y"]["count"] != 1 else "file"
-                size = (
+                size_str = (
                     "unknown size"
                     if results["Y"]["size"] is None
                     else pretty_bytes(results["Y"]["size"])
                 )
-                echo(f'  {results["Y"]["count"]} present {files} ({size})')
+                echo(f"  {results['Y']['count']} present {files} ({size_str})")
             if results["M"]["count"]:
                 files = "files" if results["M"]["count"] != 1 else "file"
-                size = (
+                size_str = (
                     "unknown size"
                     if results["M"]["size"] is None
                     else pretty_bytes(results["M"]["size"])
                 )
-                echo(f'  {results["M"]["count"]} marked {files} ({size})')
+                echo(f"  {results['M']['count']} marked {files} ({size_str})")
             if results["N"]["count"]:
                 files = "files" if results["N"]["count"] != 1 else "file"
-                size = (
+                size_str = (
                     "unknown size"
                     if results["N"]["size"] is None
                     else pretty_bytes(results["N"]["size"])
                 )
-                echo(f'  {results["N"]["count"]} released {files} ({size})')
+                echo(f"  {results['N']['count']} released {files} ({size_str})")
 
         # Now update, if needed
         if update:

--- a/alpenhorn/cli/options.py
+++ b/alpenhorn/cli/options.py
@@ -34,8 +34,7 @@ def cli_option(option: str, **extra_kwargs):
         args = ("--address",)
         kwargs = {
             "metavar": "ADDR",
-            "help": "Domain name or IP address to use for remote access to the "
-            "node.",
+            "help": "Domain name or IP address to use for remote access to the node.",
         }
     elif option == "all_":
         # Has no help; must be provided when used
@@ -463,13 +462,13 @@ def files_in_nodes(
 
             # In this mode, there's no reason to continue once the set is empty
             if not node_files:
-                return []
+                break
 
     return node_files
 
 
 def files_in_groups(
-    groups: list[StorageGroup],
+    groups: set[StorageGroup],
     state_expr: pw.Expression | None = None,
     in_any: bool = False,
 ) -> set[int] | None:
@@ -481,7 +480,7 @@ def files_in_groups(
     Parameters
     ----------
     groups:
-        list of StorageGroups.
+        set of StorageGroups.
     state_expr:
         if given and not None, a peewee.Expression defining the
         state of files we're looking for.  If None, a
@@ -531,7 +530,7 @@ def files_in_groups(
 
             # In this mode, there's no reason to continue once the set is empty
             if not group_files:
-                return []
+                break
 
     return group_files
 
@@ -639,7 +638,7 @@ def set_io_config(
         # something it can't encode, but I don't think this hurts.
         try:
             json.dumps(dict([split_data]))
-        except json.JSONEncodeError:
+        except json.JSONDecodeError:
             raise click.ClickException(f'Cannot parse argument: "--io-var={var}"')
 
         # Now set
@@ -749,7 +748,7 @@ def check_if_from_stdin(path: str, check: bool, force: bool) -> bool:
     return False
 
 
-def files_from_file(path: str | None, node: str | None = None) -> None:
+def files_from_file(path: str | None, node: str | None = None) -> set[ArchiveFile]:
     """Read a file list from a file given with --file-list
 
     Returns a set of ArchiveFiles.

--- a/alpenhorn/common/config.py
+++ b/alpenhorn/common/config.py
@@ -193,7 +193,7 @@ def test_isolation(enable: bool = True) -> None:
     _test_isolation = enable
 
 
-def load_config(cli_conf: os.PathLike, cli: bool) -> None:
+def load_config(cli_conf: str | os.PathLike | None, cli: bool) -> None:
     """Find and load the configuration from a file."""
 
     global config, _test_isolation
@@ -216,7 +216,7 @@ def load_config(cli_conf: os.PathLike, cli: bool) -> None:
         config_files.append(enviro_conf)
 
     if cli_conf:
-        config_files.append(cli_conf)
+        config_files.append(str(cli_conf))
 
     no_config = True
 

--- a/alpenhorn/common/extensions.py
+++ b/alpenhorn/common/extensions.py
@@ -247,7 +247,7 @@ def import_detection() -> list[ImportDetect]:
     return _id_ext
 
 
-def io_module(name: str) -> ModuleType:
+def io_module(name: str) -> ModuleType | None:
     """Returns the module supporting I/O class named `name`.
 
     Parameters

--- a/alpenhorn/common/util.py
+++ b/alpenhorn/common/util.py
@@ -16,6 +16,7 @@ from .metrics import Metric
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from os import PathLike
 del TYPE_CHECKING
 
 log = logging.getLogger(__name__)
@@ -154,7 +155,7 @@ def start_alpenhorn(
 
 def run_command(
     cmd: list[str], timeout: float | None = None, **kwargs
-) -> tuple(int | None, str, str):
+) -> tuple[int | None, str, str]:
     """Run a command.
 
     Parameters
@@ -244,7 +245,7 @@ def timeout_call(func: Callable, timeout: float, /, *args: Any, **kwargs: Any) -
     return asyncio.run(_async_wrapper(func, timeout, args, kwargs))
 
 
-async def _md5sum_file(filename: str) -> str | None:
+async def _md5sum_file(filename: str | PathLike) -> str | None:
     """asyncio implementation of md5sum_file().
 
     Aborts and returns None if computation is too slow.
@@ -292,7 +293,7 @@ async def _md5sum_file(filename: str) -> str | None:
     return md5.hexdigest()
 
 
-def md5sum_file(filename: str) -> str | None:
+def md5sum_file(filename: str | PathLike) -> str | None:
     """Find the md5sum of a given file.
 
     This implementation runs in an asyncio wrapper and will time out

--- a/alpenhorn/daemon/auto_import.py
+++ b/alpenhorn/daemon/auto_import.py
@@ -28,6 +28,7 @@ from ..scheduler import Task
 
 if TYPE_CHECKING:
     import os
+    from collections.abc import Generator
 
     from ..scheduler import FairMultiFIFOQueue
     from .update import UpdateableNode
@@ -151,7 +152,7 @@ def _import_file(
     path: pathlib.PurePath,
     register: bool,
     req: ArchiveFileImportRequest | None,
-) -> None:
+) -> Generator[int]:
     """Import `path` on `node` into the DB.  This is run by a worker.
 
     Parameters
@@ -289,8 +290,7 @@ def _import_file(
         if copy.wants_file == "Y":
             copy.has_file = "M"
             log.warning(
-                f'Imported missing file "{path}" on node {node.name}.'
-                "  Marking suspect."
+                f'Imported missing file "{path}" on node {node.name}.  Marking suspect.'
             )
         else:
             copy.has_file = "Y"

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -320,8 +320,7 @@ def delete_async(
         # If at least two _other_ copies exist, we can delete the file.
         if ncopies < copies_required:
             log.warning(
-                f"Too few archive copies ({ncopies}) "
-                f"to delete {shortname} on {name}."
+                f"Too few archive copies ({ncopies}) to delete {shortname} on {name}."
             )
             continue  # Skip this one
 

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -15,7 +15,7 @@ from typing import IO, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import os
-    from collections.abc import Iterator
+    from collections.abc import Iterable
 
     from ..daemon.update import UpdateableNode
     from ..db import (
@@ -305,7 +305,7 @@ class BaseNodeIO:
         """
         raise NotImplementedError("method must be re-implemented in subclass.")
 
-    def file_walk(self, path: pathlib.Path) -> Iterator[pathlib.PurePath]:
+    def file_walk(self, path: pathlib.Path) -> Iterable[pathlib.PurePath]:
         """Iterate through directory `path`.
 
         Should successively yield a pathlib.PurePath for each file under `path`,
@@ -361,7 +361,7 @@ class BaseNodeIO:
         """
         raise NotImplementedError("method must be re-implemented in subclass.")
 
-    def md5(self, path: str | pathlib.Path, *segments) -> str:
+    def md5(self, path: str | pathlib.Path, *segments) -> str | None:
         """Compute the MD5 hash of the file at the specified path.
 
         Parameters
@@ -374,8 +374,9 @@ class BaseNodeIO:
 
         Returns
         -------
-        md5sum : str
-            the base64-encoded MD5 hash value
+        md5sum : str or None
+            the base64-encoded MD5 hash value, or None if the hash couldn't be
+            computed.
         """
         raise NotImplementedError("method must be re-implemented in subclass.")
 

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -29,7 +29,7 @@ from .base import BaseGroupIO, BaseNodeIO, BaseNodeRemote
 from .updownlock import UpDownLock
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterable
 
     from ..db import ArchiveFileCopy, ArchiveFileCopyRequest, StorageNode
     from ..service.queue import FairMultiFIFOQueue
@@ -79,9 +79,9 @@ class DefaultNodeIO(BaseNodeIO):
     observer = Observer
 
     def __init__(
-        self, node: StorageNode, queue: FairMultiFIFOQueue, config: dict
+        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue
     ) -> None:
-        super().__init__(node, queue, config)
+        super().__init__(node, config, queue)
 
         # The directory tree modification lock
         self.tree_lock = UpDownLock()
@@ -276,7 +276,7 @@ class DefaultNodeIO(BaseNodeIO):
         # Apparent size
         return path.stat().st_size
 
-    def file_walk(self, path) -> Iterator[pathlib.PurePath]:
+    def file_walk(self, path) -> Iterable[pathlib.PurePath]:
         """An iterator over all regular files under `node.root/path`
 
         pathlib.PurePaths returned by the iterator are absolute

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -31,6 +31,7 @@ from .lustrequota import LustreQuotaNodeIO
 
 if TYPE_CHECKING:
     import os
+    from collections.abc import Generator
 
     from ..db import ArchiveFile, ArchiveFileCopyRequest
     from ..scheduler import FairMultiFIFOQueue
@@ -390,7 +391,9 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
             the file copy to auto-verify
         """
 
-        def _async(task: Task, node_io: LustreHSMNodeIO, copy: ArchiveFileCopy) -> None:
+        def _async(
+            task: Task, node_io: LustreHSMNodeIO, copy: ArchiveFileCopy
+        ) -> Generator[int]:
             """Verify a file (with restore and release, if necessary).
 
             Parameters
@@ -654,9 +657,9 @@ class LustreHSMGroupIO(DefaultGroupIO):
     # SETUP
 
     def __init__(
-        self, queue: FairMultiFIFOQueue, group: UpdateableGroup, config: dict
+        self, group: UpdateableGroup, config: dict, queue: FairMultiFIFOQueue
     ) -> None:
-        super().__init__(queue, group, config)
+        super().__init__(group, config, queue)
 
         self._threshold = self.config.get("threshold", 1000000000)  # bytes
 

--- a/alpenhorn/io/updownlock.py
+++ b/alpenhorn/io/updownlock.py
@@ -262,6 +262,5 @@ class UpDownLock:
         else:
             state = "locked down"
         return (
-            f"<UpDownLock object state={state} count={abs(count)} "
-            f"at {hex(id(self))}>"
+            f"<UpDownLock object state={state} count={abs(count)} at {hex(id(self))}>"
         )

--- a/alpenhorn/scheduler/pool.py
+++ b/alpenhorn/scheduler/pool.py
@@ -385,7 +385,7 @@ _signalpool = None
 
 
 # The signal handlers themselves
-def _handle_usr1(signum: signal.Signals, frame: FrameType) -> None:
+def _handle_usr1(signum: int, frame: FrameType | None) -> None:
     """SIGUSR1 signal handler.
 
     Sends an increment request to the worker pool.
@@ -394,7 +394,7 @@ def _handle_usr1(signum: signal.Signals, frame: FrameType) -> None:
     _signalpool.add_worker(blocking=False)
 
 
-def _handle_usr2(signum: signal.Signals, frame: FrameType) -> None:
+def _handle_usr2(signum: int, frame: FrameType | None) -> None:
     """SIGUSR2 signal handler.
 
     Sends an decrement request to the worker pool.

--- a/alpenhorn/scheduler/queue.py
+++ b/alpenhorn/scheduler/queue.py
@@ -105,23 +105,27 @@ class FairMultiFIFOQueue:
             "queue_locked", "The queue fifo is locked", unbound=["fifo"]
         )
 
-    def _inc_metrics(self, fifo: str, status: str) -> None:
+    def _inc_metrics(self, fifo: Hashable, status: str) -> None:
         """Increment the queue_count metric.
 
         Adds one to the metric with fifo=fifo and status=status.  Also adds
         one to the marginalised ..._any and ..._all metrics.
         """
 
+        fifo = str(fifo)
+
         self._qcount.inc(fifo=fifo, status=status)
         self._qcount_any.inc(fifo=fifo)
         self._qcount_all.inc(status=status)
 
-    def _dec_metrics(self, fifo: str, status: str) -> None:
+    def _dec_metrics(self, fifo: Hashable, status: str) -> None:
         """Decrement the queue_count metric.
 
         Subtracts one from the metric with fifo=fifo and status=status.  Also
         subtracts one from the marginalised ..._any and ..._all metrics.
         """
+
+        fifo = str(fifo)
 
         self._qcount.dec(fifo=fifo, status=status)
         self._qcount_any.dec(fifo=fifo)


### PR DESCRIPTION
## Errors found by `mypy`

`ruff`, explicitly, doesn't do type checking with type hinting, so I've experimented a bit with running `mypy` on the code to see what it would say.  The primary result is now I have Opinions on `mypy`, which this PR is too narrow to contain.  But has also found some problems that I've fixed here, which is great.  Still, I'm not convinced it's something we want running in our CI...

Most of these fixes are fixes to the type hints themselves, which is what I was expecting `mypy` to help me with, but there are a few actual (albeit minor) bugs which have also been fixed.

## ruff format

I also experimented in this branch with `ruff format` as a replacement for `black`.  It produces results that are very similar (by design: the `ruff` devs are overtly trying to mimic black), but it's not identical. The thing I liked most about `ruff format` is its ability to concatenate strings when the result would fit on a single line.

The code here has been run through `black` and then `ruff format` and then back through `black`, meaning there are a few formatting changes in the code that were changed by `ruff` from what `black` had done, but then were considered acceptable by the second `black` run, and not reverted. (Several other changes made by `ruff format` _were_ reverted.)

I think the formatting done by `ruff format` is good enough that, were we using `ruff` everywhere I'd suggest using it for formatting as well as linting, and ditch `black`, just to minimise the number of tools we have in play.  But, since we're not using `ruff` everywhere, I don't think it's worth switching.  We definitely shouldn't get ourselves into a situation where were using `black` in some projects and `ruff format` in others.