### PR TITLE
feat(common.util): Allow negative sizes in `pretty_bytes`

### DIFF
--- a/alpenhorn/common/util.py
+++ b/alpenhorn/common/util.py
@@ -361,28 +361,30 @@ def pretty_bytes(num: int | None) -> str:
         return "-"
 
     # Reject weird stuff
+    sign = ""
     try:
         num = int(num)
         if num < 0:
-            raise ValueError("negative size")
+            sign = "-"
+            num = -num
     except TypeError:
         raise TypeError("non-numeric size")
 
     if num < 2**10:
-        return f"{num} B"
+        return f"{sign}{num} B"
 
     for x, p in enumerate("kMGTPE"):
         if num < 2 ** ((2 + x) * 10):
             num /= 2 ** ((1 + x) * 10)
             if num >= 100:
-                return f"{num:.1f} {p}iB"
+                return f"{sign}{num:.1f} {p}iB"
             if num >= 10:
-                return f"{num:.2f} {p}iB"
-            return f"{num:.3f} {p}iB"
+                return f"{sign}{num:.2f} {p}iB"
+            return f"{sign}{num:.3f} {p}iB"
 
     # overflow or something: in this case lets just go
     # with what we were given and get on with our day.
-    return f"{num} B"
+    return f"{sign}{num} B"
 
 
 def pretty_deltat(seconds: float) -> str:

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -67,9 +67,6 @@ def test_gethostname_default():
 
 def test_pretty_bytes():
     """Test util.pretty_bytes."""
-    with pytest.raises(ValueError):
-        util.pretty_bytes(-1)
-
     with pytest.raises(TypeError):
         util.pretty_bytes({})
 
@@ -108,6 +105,12 @@ def test_pretty_bytes():
     assert util.pretty_bytes(12) == "12 B"
     assert util.pretty_bytes(1) == "1 B"
     assert util.pretty_bytes(0) == "0 B"
+
+    # Also negative sizes are permitted
+    assert util.pretty_bytes(-123456789012) == "-115.0 GiB"
+    assert util.pretty_bytes(-12345678) == "-11.77 MiB"
+    assert util.pretty_bytes(-1234) == "-1.205 kiB"
+    assert util.pretty_bytes(-1) == "-1 B"
 
 
 def test_pretty_deltat():


### PR DESCRIPTION
I still think passing a negative number to this function probably indicates a bug, but it's probably not the kind of bug we need to necessarily crash over (since this is just going to be used in a log message, after all).