### PR TITLE
feat(io.lfs): Add support for user and project quota

### DIFF
--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -69,10 +69,12 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
     """LustreHSM node I/O.
 
     Required io_config keys:
-        * quota_group : string
-            the user group to query quota for
         * headroom: float
             the amount of space in kiB to keep empty on the disk.
+        * quota_id: the id (username, uid, group name, gid, or project id) to query
+            quota for.
+        * quota_type: One of "user", "group" or "project" indicating how to
+            interpret the value of quota_id.
 
     Optional io_config keys:
         * lfs : string
@@ -82,6 +84,8 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
             seconds if not given.
         * fixed_quota : integer
             the quota, in kiB, on the Lustre disk backing the HSM system
+        * quota_type: One of "user", "group" or "project" indicating how to
+            interpret the value of quota_id.  If omitted, "group" is assumed.
         * release_check_count : integer
             The number of files to check at a time when doing idle HSM status
             update (see idle_update()).  Default is 100.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -588,9 +588,11 @@ def mockgroupandnode(hostname, queue, storagenode, storagegroup, mockio):
     mockio.group.set_nodes = lambda nodes: nodes
 
     node = UpdateableNode(queue, stnode)
-    yield mockio, UpdateableGroup(
-        queue=queue, group=stgroup, nodes=[node], idle=True
-    ), node
+    yield (
+        mockio,
+        UpdateableGroup(queue=queue, group=stgroup, nodes=[node], idle=True),
+        node,
+    )
 
 
 @pytest.fixture

--- a/tests/daemon/test_auto_import.py
+++ b/tests/daemon/test_auto_import.py
@@ -67,7 +67,9 @@ def test_import_file_not_ready(dbtables, xfs, queue, simplenode, mock_lfs):
 
     # Set up node for LustreHSMIO
     simplenode.io_class = "LustreHSM"
-    simplenode.io_config = '{"quota_group": "qgroup", "headroom": 300000}'
+    simplenode.io_config = (
+        '{"quota_id": "qid", "quota_type": "group", "headroom": 300000}'
+    )
     unode = UpdateableNode(queue, simplenode)
 
     xfs.create_file("/node/acq/file")
@@ -83,7 +85,7 @@ def test_import_file_not_ready(dbtables, xfs, queue, simplenode, mock_lfs):
     )
 
     # File is being restored
-    assert mock_lfs("").hsm_state("/node/acq/file") == HSMState.RESTORING
+    assert mock_lfs("", "group").hsm_state("/node/acq/file") == HSMState.RESTORING
 
 
 def test_import_file_no_ext(dbtables, unode):

--- a/tests/daemon/test_entry.py
+++ b/tests/daemon/test_entry.py
@@ -116,7 +116,10 @@ def e2e_db(xfs, clidb_noinit, hostname):
         host=hostname,
         active=True,
         avail_gb=2000.0 / 2**30,
-        io_config='{"quota_group": "qgroup", "headroom": 10, "restore_wait": 1}',
+        io_config=(
+            '{"quota_id": "qid", "quota_type": "project", '
+            '"headroom": 10, "restore_wait": 1}'
+        ),
     )
     sf1 = StorageNode.create(
         name="sf1", group=nlgrp, root="/sf1", host=hostname, active=True
@@ -133,7 +136,10 @@ def e2e_db(xfs, clidb_noinit, hostname):
         root="/nl2",
         host=hostname,
         active=True,
-        io_config='{"quota_group": "qgroup", "headroom": 1, "release_check_count": 1}',
+        io_config=(
+            '{"quota_id": "qid", "quota_type": "project", '
+            '"headroom": 1, "release_check_count": 1}'
+        ),
         avail_gb=2000.0 / 2**30,
     )
     StorageNode.create(name="sf2", group=nlgrp, root="/sf2", host=hostname, active=True)
@@ -328,7 +334,7 @@ def test_cli(e2e_db, e2e_config, mock_lfs, mock_rsync):
     assert result.exit_code == 0
 
     # Check HSM
-    lfs = mock_lfs(quota_group="qgroup")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state("/nl2/acq1/correct.me") == lfs.HSM_RESTORED
     assert lfs.hsm_state("/nl1/acq1/restore.me") == lfs.HSM_RESTORED
     assert lfs.hsm_state("/nl1/acq1/release.me") == lfs.HSM_RELEASED

--- a/tests/daemon/test_update.py
+++ b/tests/daemon/test_update.py
@@ -181,8 +181,8 @@ def test_ioload(storagegroup, storagenode, mock_lfs):
     for ioclass, ioconfig in [
         ("Default", None),
         ("Polling", None),
-        ("LustreQuota", '{"quota_group": "qgroup"}'),
-        ("LustreHSM", '{"quota_group": "qgroup", "headroom": 100000}'),
+        ("LustreQuota", '{"quota_id": "qid", "quota_type": "project"}'),
+        ("LustreHSM", '{"quota_id": "qid", "quota_type": "group", "headroom": 100000}'),
         (None, None),
     ]:
         storagenode(

--- a/tests/io/test_lustrehsmgroup.py
+++ b/tests/io/test_lustrehsmgroup.py
@@ -22,7 +22,7 @@ def group(xfs, mock_lfs, hostname, queue, storagegroup, storagenode):
             storage_type="A",
             root="/hsm",
             host=hostname,
-            io_config='{"quota_group": "qgroup", "headroom": 10250}',
+            io_config='{"quota_id": "qid", "quota_type": "group", "headroom": 10250}',
         ),
     )
     smallfile = UpdateableNode(
@@ -75,7 +75,7 @@ def test_init(storagegroup, storagenode, queue, mock_lfs):
             name="hsm",
             group=stgroup,
             io_class="LustreHSM",
-            io_config='{"quota_group": "qgroup", "headroom": 10250}',
+            io_config='{"quota_id": "qid", "quota_type": "group", "headroom": 10250}',
         ),
     )
     smallfile = UpdateableNode(

--- a/tests/io/test_lustrehsmnode.py
+++ b/tests/io/test_lustrehsmnode.py
@@ -22,7 +22,8 @@ def node(
     simplenode.io_class = "LustreHSM"
 
     simplenode.io_config = (
-        '{"quota_group": "qgroup", "headroom": 10250, "release_check_count": 7}'
+        '{"quota_id": "qid", "quota_type": "group", '
+        '"headroom": 10250, "release_check_count": 7}'
     )
 
     # Some files
@@ -52,7 +53,7 @@ def test_init_no_headroom(have_lfs, simplenode):
     """No headroom is an error"""
 
     simplenode.io_class = "LustreHSM"
-    simplenode.io_config = '{"quota_group": "qgroup"}'
+    simplenode.io_config = '{"quota_id": "qid", "quota_type": "group"}'
 
     with pytest.raises(KeyError):
         UpdateableNode(None, simplenode)
@@ -63,7 +64,8 @@ def test_init_bad_release_count(simplenode, have_lfs):
 
     simplenode.io_class = "LustreHSM"
     simplenode.io_config = (
-        '{"quota_group": "qgroup", "headroom": 300000, "release_check_count": -1}'
+        '{"quota_id": "qgroup", "quota_type": "group", '
+        '"headroom": 300000, "release_check_count": -1}'
     )
 
     with pytest.raises(ValueError):
@@ -75,7 +77,8 @@ def test_init_bad_restore_wait(simplenode, have_lfs):
 
     simplenode.io_class = "LustreHSM"
     simplenode.io_config = (
-        '{"quota_group": "qgroup", "headroom": 300000, "restore_wait": -1}'
+        '{"quota_id": "qgroup", "quota_type": "group", '
+        '"headroom": 300000, "restore_wait": -1}'
     )
 
     with pytest.raises(ValueError):
@@ -153,7 +156,7 @@ def test_release_files(queue, mock_lfs, node):
     assert ArchiveFileCopy.get(id=7).last_update == 5
 
     # Check hsm_relase was actually called
-    lfs = mock_lfs("")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state("/node/simpleacq/file1") == lfs.HSM_RELEASED
     assert lfs.hsm_state("/node/simpleacq/file2") == lfs.HSM_RELEASED
     assert lfs.hsm_state("/node/simpleacq/file3") == lfs.HSM_RELEASED
@@ -288,7 +291,7 @@ def test_check_ready_restored(xfs, queue, node, mock_lfs):
 
     # File is still restored
     assert ArchiveFileCopy.get(id=1).ready
-    lfs = mock_lfs("")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state(copy.path) == lfs.HSM_RESTORED
 
 
@@ -332,7 +335,7 @@ def test_check_released(xfs, queue, mock_lfs, node):
     async_mock.assert_called_once()
 
     # File has been re-released
-    lfs = mock_lfs("")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state(copy.path) == lfs.HSM_RELEASED
 
 
@@ -372,7 +375,7 @@ def test_check_ready_released(xfs, queue, mock_lfs, node):
     async_mock.assert_called_once()
 
     # File has been restored
-    lfs = mock_lfs("")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state(copy.path) == lfs.HSM_RESTORED
 
 
@@ -396,7 +399,7 @@ def test_ready_path(mock_lfs, node):
     assert not node.io.ready_path("/node/simpleacq/file5")
 
     # But now released file is recalled.
-    lfs = mock_lfs("")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state("/node/simpleacq/file1") == lfs.HSM_RESTORED
     assert lfs.hsm_state("/node/simpleacq/file2") == lfs.HSM_RESTORING
     assert lfs.hsm_state("/node/simpleacq/file3") == lfs.HSM_UNARCHIVED
@@ -436,7 +439,7 @@ def test_ready_pull_restored(mock_lfs, node, queue, archivefilecopyrequest):
     assert ArchiveFileCopy.get(id=1).last_update >= before
 
     # File is restored
-    lfs = mock_lfs("")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state(copy.path) == lfs.HSM_RESTORED
 
 
@@ -469,7 +472,7 @@ def test_ready_pull_restoring(mock_lfs, node, queue, archivefilecopyrequest):
     assert not ArchiveFileCopy.get(id=1).ready
 
     # File is still being restored
-    lfs = mock_lfs("")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state(copy.path) == lfs.HSM_RESTORING
 
 
@@ -508,7 +511,7 @@ def test_ready_pull_released(mock_lfs, node, queue, archivefilecopyrequest):
     task()
 
     # File is being restored
-    lfs = mock_lfs("")
+    lfs = mock_lfs("", "group")
     assert lfs.hsm_state(copy.path) == lfs.HSM_RESTORING
 
 

--- a/tests/io/test_lustrequota.py
+++ b/tests/io/test_lustrequota.py
@@ -10,13 +10,13 @@ from alpenhorn.io.lustrequota import LustreQuotaNodeIO
 def node(simplenode, mock_lfs):
     """A LustreQuota node for testing"""
     simplenode.io_class = "LustreQuota"
-    simplenode.io_config = '{"quota_group": "qgroup"}'
+    simplenode.io_config = '{"quota_id": "qid", "quota_type": "group"}'
 
     return UpdateableNode(None, simplenode)
 
 
-def test_no_quota_group(simplenode):
-    """Test instantiating I/O without specifying quota_group."""
+def test_no_quota_id(simplenode):
+    """Test instantiating I/O without specifying quota_id."""
 
     simplenode.io_class = "LustreQuota"
 
@@ -28,13 +28,13 @@ def test_no_lfs(simplenode):
     """Test crashing if lfs(1) can't be found."""
 
     simplenode.io_class = "LustreQuota"
-    simplenode.io_config = '{"quota_group": "qgroup"}'
+    simplenode.io_config = '{"quota_id": "qid", "quota_type": "group"}'
 
     with pytest.raises(RuntimeError):
         UpdateableNode(None, simplenode)
 
 
-def test_quota_group(node):
+def test_quota_id(node):
     """Test instantiating I/O."""
 
     assert isinstance(node.io, LustreQuotaNodeIO)
@@ -45,3 +45,37 @@ def test_bytes_avail(node):
     """Test LustreQuotaNodeIO.bytes_avail"""
 
     assert node.io.bytes_avail() == 1234
+
+
+@pytest.mark.lfs_dont_mock("quota_remaining")
+def test_quota_type(mock_lfs, simplenode, mock_run_command):
+    """Test quota_type handling."""
+
+    simplenode.io_class = "LustreQuota"
+
+    # User quota
+    simplenode.io_config = '{"quota_id": "qid", "quota_type": "user"}'
+    unode = UpdateableNode(None, simplenode)
+    unode.io.bytes_avail()
+    assert "-u qid" in " ".join(mock_run_command()["cmd"])
+
+    # Group quota
+    simplenode.io_config = '{"quota_id": "qid", "quota_type": "group"}'
+    unode = UpdateableNode(None, simplenode)
+    unode.io.bytes_avail()
+    assert "-g qid" in " ".join(mock_run_command()["cmd"])
+
+    # Project quota
+    simplenode.io_config = '{"quota_id": "qid", "quota_type": "project"}'
+    unode = UpdateableNode(None, simplenode)
+    unode.io.bytes_avail()
+    assert "-p qid" in " ".join(mock_run_command()["cmd"])
+
+
+def test_bad_quota_type(mock_lfs, simplenode):
+    """Test bad quota_type handling."""
+
+    simplenode.io_class = "LustreQuota"
+    simplenode.io_config = '{"quota_id": "qid", "quota_type": "pool"}'
+    with pytest.raises(ValueError):
+        UpdateableNode(None, simplenode)


### PR DESCRIPTION
Adds a new requried I/O key `quota_type` to lustrequota and lustrehsm nodes to indicate what sort of quota should be queried (user, group, project).

Also renames I/O key `quota_group` to `quota_id`.  The legacy `quota_group` I/O key is supported as an undocumented legacy extension to ease CHIME migration.

Closes #308