### PR TITLE
Dequeue tasks when stopping/reseting I/O for a node.

### DIFF
--- a/alpenhorn/daemon/auto_import.py
+++ b/alpenhorn/daemon/auto_import.py
@@ -422,7 +422,10 @@ def update_observer(
         # If this node isn't being auto-imported or we're force-stopping
         # it, delete a watcher if one was previously scheduled
         if node.name in _watchers:
-            _observers[node.io_class].unschedule(_watchers[node.name])
+            try:
+                _observers[node.io_class].unschedule(_watchers[node.name])
+            except KeyError:
+                pass  # wasn't being watched
             del _watchers[node.name]
     else:
         # If there's already a watcher for this node, do nothing

--- a/alpenhorn/daemon/update.py
+++ b/alpenhorn/daemon/update.py
@@ -178,8 +178,13 @@ class updateable_base:
             # Parse I/O config if present
             config = self._parse_io_config(storage.io_config)
 
+            # Generate a new fifo key and label it
+            fifo = (self.is_group, storage.name, time.monotonic())
+            label = f"Group {storage.name}" if self.is_group else f"Node {storage.name}"
+            self._queue.label_fifo(fifo, label=label)
+
             # Initialise I/O object
-            self.io = self.io_class(storage, config, self._queue)
+            self.io = self.io_class(storage, config, self._queue, fifo)
 
             return True
 

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -15,7 +15,7 @@ from typing import IO, TYPE_CHECKING
 
 if TYPE_CHECKING:
     import os
-    from collections.abc import Iterable
+    from collections.abc import Hashable, Iterable
 
     from ..daemon.update import UpdateableNode
     from ..db import (
@@ -123,11 +123,13 @@ class BaseNodeIO:
     ----------
     node : StorageNode
         the node
-    queue : FairMultiFIFOQueue
-        the task queue
     config : dict
         the parsed `node.io_config`. If `node.io_config` is None,
         this is an empty `dict`.
+    queue : FairMultiFIFOQueue
+        the task queue
+    fifo : Hashable
+        the queue fifo key to use when submitting tasks.
     """
 
     # SETUP
@@ -144,12 +146,12 @@ class BaseNodeIO:
     observer = None
 
     def __init__(
-        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue
+        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue, fifo: Hashable
     ) -> None:
         self.node = node
         self._queue = queue
         self.config = config
-        self.fifo = "n:" + node.name
+        self.fifo = fifo
 
     def set_storage(self, node: StorageNode) -> None:
         """Update the cached StorageNode instance.
@@ -459,22 +461,28 @@ class BaseGroupIO:
     ----------
     group : StorageGroup
         The group
-    queue : FairMultiFIFOQueue
-        the task queue
     config : dict
         The parsed `group.io_config`. If `group.io_config` is None,
         this is an empty `dict`.
+    queue : FairMultiFIFOQueue
+        the task queue
+    fifo : Hashable
+        the queue fifo key to use when submitting tasks.
     """
 
     # SETUP
 
     def __init__(
-        self, group: StorageGroup, config: dict, queue: FairMultiFIFOQueue
+        self,
+        group: StorageGroup,
+        config: dict,
+        queue: FairMultiFIFOQueue,
+        fifo: Hashable,
     ) -> None:
         self.group = group
         self._queue = queue
         self.config = config
-        self.fifo = "g:" + group.name
+        self.fifo = fifo
 
     def set_storage(self, group: StorageGroup) -> None:
         """Update the cached StorageGroup instance.

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -29,7 +29,7 @@ from .base import BaseGroupIO, BaseNodeIO, BaseNodeRemote
 from .updownlock import UpDownLock
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Hashable, Iterable
 
     from ..db import ArchiveFileCopy, ArchiveFileCopyRequest, StorageNode
     from ..service.queue import FairMultiFIFOQueue
@@ -79,9 +79,9 @@ class DefaultNodeIO(BaseNodeIO):
     observer = Observer
 
     def __init__(
-        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue
+        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue, fifo: Hashable
     ) -> None:
-        super().__init__(node, config, queue)
+        super().__init__(node, config, queue, fifo)
 
         # The directory tree modification lock
         self.tree_lock = UpDownLock()

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -31,7 +31,7 @@ from .lustrequota import LustreQuotaNodeIO
 
 if TYPE_CHECKING:
     import os
-    from collections.abc import Generator
+    from collections.abc import Generator, Hashable
 
     from ..db import ArchiveFile, ArchiveFileCopyRequest
     from ..scheduler import FairMultiFIFOQueue
@@ -97,9 +97,13 @@ class LustreHSMNodeIO(LustreQuotaNodeIO):
     remote_class = LustreHSMNodeRemote
 
     def __init__(
-        self, node: UpdateableNode, config: dict, queue: FairMultiFIFOQueue
+        self,
+        node: UpdateableNode,
+        config: dict,
+        queue: FairMultiFIFOQueue,
+        fifo: Hashable,
     ) -> None:
-        super().__init__(node, config, queue)
+        super().__init__(node, config, queue, fifo)
 
         self._headroom = config["headroom"] * 2**10  # convert from kiB
 
@@ -661,9 +665,13 @@ class LustreHSMGroupIO(DefaultGroupIO):
     # SETUP
 
     def __init__(
-        self, group: UpdateableGroup, config: dict, queue: FairMultiFIFOQueue
+        self,
+        group: UpdateableGroup,
+        config: dict,
+        queue: FairMultiFIFOQueue,
+        fifo: Hashable,
     ) -> None:
-        super().__init__(group, config, queue)
+        super().__init__(group, config, queue, fifo)
 
         self._threshold = self.config.get("threshold", 1000000000)  # bytes
 

--- a/alpenhorn/io/lustrequota.py
+++ b/alpenhorn/io/lustrequota.py
@@ -20,6 +20,8 @@ from .default import DefaultNodeIO
 from .lfs import LFS
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
+
     from ..queue import FairMultiFIFOQueue
     from ..storage import StorageNode
 del TYPE_CHECKING
@@ -54,9 +56,9 @@ class LustreQuotaNodeIO(DefaultNodeIO):
     """
 
     def __init__(
-        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue
+        self, node: StorageNode, config: dict, queue: FairMultiFIFOQueue, fifo: Hashable
     ) -> None:
-        super().__init__(node, config, queue)
+        super().__init__(node, config, queue, fifo)
 
         quota_id = config.get("quota_id", None)
         quota_type = config.get("quota_type", None)

--- a/tests/daemon/test_update.py
+++ b/tests/daemon/test_update.py
@@ -170,7 +170,7 @@ def test_serial_io(fastqueue, set_config):
     assert task_count == 3
 
 
-def test_ioload(storagegroup, storagenode, mock_lfs):
+def test_ioload(storagegroup, storagenode, queue, mock_lfs):
     """Test instantiation of the I/O classes"""
 
     for ioclass in ["Default", "Transport", "LustreHSM", None]:
@@ -193,11 +193,11 @@ def test_ioload(storagegroup, storagenode, mock_lfs):
         )
 
     for node in StorageNode.select().execute():
-        unode = update.UpdateableNode(None, node)
+        unode = update.UpdateableNode(queue, node)
         assert isinstance(unode.io, BaseNodeIO)
 
     for group in StorageGroup.select().execute():
-        ugroup = update.UpdateableGroup(queue=None, group=group, nodes=[], idle=True)
+        ugroup = update.UpdateableGroup(queue=queue, group=group, nodes=[], idle=True)
         assert isinstance(ugroup.io, BaseGroupIO)
 
 

--- a/tests/daemon/test_update_node.py
+++ b/tests/daemon/test_update_node.py
@@ -85,6 +85,31 @@ def test_reinit(storagenode, simplegroup, queue):
     assert stnode is node.db
 
 
+def test_reinit_clear_fifo(storagenode, simplegroup, queue):
+    """Test that reinit clears pending tasks from the queue."""
+
+    # Create a node
+    stnode = storagenode(name="node", group=simplegroup)
+    node = UpdateableNode(queue, stnode)
+
+    # Queue something with the node's FIFO key
+    queue.put(None, node._fifo)
+
+    # Check queue
+    assert queue.qsize == 1
+
+    # Change io_config to force re-init
+    stnode = StorageNode.get(id=node.db.id)
+    stnode.io_config = "{}"
+    stnode.save()
+
+    # Check that reinit occurs
+    assert node.reinit(stnode)
+
+    # Now the queue is empty
+    assert queue.qsize == 0
+
+
 def test_bad_ioconfig(simplenode, queue):
     """io_config not resolving to a dict is an error."""
     simplenode.io_config = "true"

--- a/tests/daemon/test_update_node.py
+++ b/tests/daemon/test_update_node.py
@@ -12,11 +12,11 @@ from alpenhorn.db.archive import ArchiveFileCopy, ArchiveFileImportRequest
 from alpenhorn.db.storage import StorageNode
 
 
-def test_bad_ioclass(simplenode):
+def test_bad_ioclass(simplenode, queue):
     """A missing I/O class is a problem."""
 
     simplenode.io_class = "Missing"
-    unode = UpdateableNode(None, simplenode)
+    unode = UpdateableNode(queue, simplenode)
     assert unode.io_class is None
     assert unode.io is None
 
@@ -85,16 +85,16 @@ def test_reinit(storagenode, simplegroup, queue):
     assert stnode is node.db
 
 
-def test_bad_ioconfig(simplenode):
+def test_bad_ioconfig(simplenode, queue):
     """io_config not resolving to a dict is an error."""
     simplenode.io_config = "true"
 
     with pytest.raises(ValueError):
-        UpdateableNode(None, simplenode)
+        UpdateableNode(queue, simplenode)
 
     # But this is fine
     simplenode.io_config = "{}"
-    UpdateableNode(None, simplenode)
+    UpdateableNode(queue, simplenode)
 
 
 def test_idle(unode, queue):

--- a/tests/io/test_defaultgroup.py
+++ b/tests/io/test_defaultgroup.py
@@ -30,8 +30,8 @@ def test_too_many_nodes(storagegroup, storagenode, queue):
     """Test DefaultGroupIO rejecting more than one node."""
 
     stgroup = storagegroup(name="group")
-    node1 = UpdateableNode(None, storagenode(name="node1", group=stgroup, active=True))
-    node2 = UpdateableNode(None, storagenode(name="node2", group=stgroup, active=True))
+    node1 = UpdateableNode(queue, storagenode(name="node1", group=stgroup, active=True))
+    node2 = UpdateableNode(queue, storagenode(name="node2", group=stgroup, active=True))
 
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=[node1, node2], idle=True)
     assert group._nodes is None
@@ -41,7 +41,7 @@ def test_just_enough_nodes(storagegroup, storagenode, queue):
     """Test DefaultGroupIO accepting one node."""
 
     stgroup = storagegroup(name="group")
-    node = UpdateableNode(None, storagenode(name="node1", group=stgroup, active=True))
+    node = UpdateableNode(queue, storagenode(name="node1", group=stgroup, active=True))
 
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=[node], idle=True)
     assert group._nodes == [node]

--- a/tests/io/test_ioutil_crd.py
+++ b/tests/io/test_ioutil_crd.py
@@ -23,6 +23,7 @@ def mock_post_add():
 
 @pytest.fixture
 def db_setup(
+    queue,
     mock_filesize,
     mock_post_add,
     storagegroup,
@@ -40,7 +41,7 @@ def db_setup(
     )
 
     return (
-        UpdateableNode(None, node_to).io,
+        UpdateableNode(queue, node_to).io,
         archivefilecopy(file=simplefile, node=node_from, has_file="Y"),
         archivefilecopyrequest(file=simplefile, node_from=node_from, group_to=group_to),
         time.time() - 2,  # start_time

--- a/tests/io/test_lustrehsmgroup.py
+++ b/tests/io/test_lustrehsmgroup.py
@@ -70,7 +70,7 @@ def test_init(storagegroup, storagenode, queue, mock_lfs):
     stgroup = storagegroup(name="group", io_class="LustreHSM")
 
     hsm = UpdateableNode(
-        None,
+        queue,
         storagenode(
             name="hsm",
             group=stgroup,
@@ -79,7 +79,7 @@ def test_init(storagegroup, storagenode, queue, mock_lfs):
         ),
     )
     smallfile = UpdateableNode(
-        None, storagenode(name="smallfile", group=stgroup, io_class="Default")
+        queue, storagenode(name="smallfile", group=stgroup, io_class="Default")
     )
 
     # These should work

--- a/tests/io/test_lustrehsmnode.py
+++ b/tests/io/test_lustrehsmnode.py
@@ -49,17 +49,17 @@ def node(
     return UpdateableNode(queue, simplenode)
 
 
-def test_init_no_headroom(have_lfs, simplenode):
+def test_init_no_headroom(have_lfs, queue, simplenode):
     """No headroom is an error"""
 
     simplenode.io_class = "LustreHSM"
     simplenode.io_config = '{"quota_id": "qid", "quota_type": "group"}'
 
     with pytest.raises(KeyError):
-        UpdateableNode(None, simplenode)
+        UpdateableNode(queue, simplenode)
 
 
-def test_init_bad_release_count(simplenode, have_lfs):
+def test_init_bad_release_count(simplenode, queue, have_lfs):
     """Check for bad release_check_count."""
 
     simplenode.io_class = "LustreHSM"
@@ -69,10 +69,10 @@ def test_init_bad_release_count(simplenode, have_lfs):
     )
 
     with pytest.raises(ValueError):
-        UpdateableNode(None, simplenode)
+        UpdateableNode(queue, simplenode)
 
 
-def test_init_bad_restore_wait(simplenode, have_lfs):
+def test_init_bad_restore_wait(simplenode, queue, have_lfs):
     """Check for bad restore_wait."""
 
     simplenode.io_class = "LustreHSM"
@@ -82,7 +82,7 @@ def test_init_bad_restore_wait(simplenode, have_lfs):
     )
 
     with pytest.raises(ValueError):
-        UpdateableNode(None, simplenode)
+        UpdateableNode(queue, simplenode)
 
 
 def test_release_files_okay(queue, node):

--- a/tests/io/test_lustrequota.py
+++ b/tests/io/test_lustrequota.py
@@ -7,31 +7,31 @@ from alpenhorn.io.lustrequota import LustreQuotaNodeIO
 
 
 @pytest.fixture
-def node(simplenode, mock_lfs):
+def node(simplenode, queue, mock_lfs):
     """A LustreQuota node for testing"""
     simplenode.io_class = "LustreQuota"
     simplenode.io_config = '{"quota_id": "qid", "quota_type": "group"}'
 
-    return UpdateableNode(None, simplenode)
+    return UpdateableNode(queue, simplenode)
 
 
-def test_no_quota_id(simplenode):
+def test_no_quota_id(simplenode, queue):
     """Test instantiating I/O without specifying quota_id."""
 
     simplenode.io_class = "LustreQuota"
 
     with pytest.raises(KeyError):
-        UpdateableNode(None, simplenode)
+        UpdateableNode(queue, simplenode)
 
 
-def test_no_lfs(simplenode):
+def test_no_lfs(simplenode, queue):
     """Test crashing if lfs(1) can't be found."""
 
     simplenode.io_class = "LustreQuota"
     simplenode.io_config = '{"quota_id": "qid", "quota_type": "group"}'
 
     with pytest.raises(RuntimeError):
-        UpdateableNode(None, simplenode)
+        UpdateableNode(queue, simplenode)
 
 
 def test_quota_id(node):
@@ -48,34 +48,34 @@ def test_bytes_avail(node):
 
 
 @pytest.mark.lfs_dont_mock("quota_remaining")
-def test_quota_type(mock_lfs, simplenode, mock_run_command):
+def test_quota_type(mock_lfs, queue, simplenode, mock_run_command):
     """Test quota_type handling."""
 
     simplenode.io_class = "LustreQuota"
 
     # User quota
     simplenode.io_config = '{"quota_id": "qid", "quota_type": "user"}'
-    unode = UpdateableNode(None, simplenode)
+    unode = UpdateableNode(queue, simplenode)
     unode.io.bytes_avail()
     assert "-u qid" in " ".join(mock_run_command()["cmd"])
 
     # Group quota
     simplenode.io_config = '{"quota_id": "qid", "quota_type": "group"}'
-    unode = UpdateableNode(None, simplenode)
+    unode = UpdateableNode(queue, simplenode)
     unode.io.bytes_avail()
     assert "-g qid" in " ".join(mock_run_command()["cmd"])
 
     # Project quota
     simplenode.io_config = '{"quota_id": "qid", "quota_type": "project"}'
-    unode = UpdateableNode(None, simplenode)
+    unode = UpdateableNode(queue, simplenode)
     unode.io.bytes_avail()
     assert "-p qid" in " ".join(mock_run_command()["cmd"])
 
 
-def test_bad_quota_type(mock_lfs, simplenode):
+def test_bad_quota_type(mock_lfs, queue, simplenode):
     """Test bad quota_type handling."""
 
     simplenode.io_class = "LustreQuota"
     simplenode.io_config = '{"quota_id": "qid", "quota_type": "pool"}'
     with pytest.raises(ValueError):
-        UpdateableNode(None, simplenode)
+        UpdateableNode(queue, simplenode)

--- a/tests/io/test_transport.py
+++ b/tests/io/test_transport.py
@@ -123,7 +123,7 @@ def test_group_init(transport_fleet_no_init, queue):
 
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=nodes, idle=True)
     assert group._nodes == nodes
-    assert group.io.fifo == "g:group"
+    assert group.io.fifo is not None
 
 
 def test_group_init_bad(transport_fleet_no_init, queue):

--- a/tests/scheduler/test_task.py
+++ b/tests/scheduler/test_task.py
@@ -241,43 +241,15 @@ def test_requeue_closed(queue):
     assert queue.qsize == 0
 
 
-def test_requeue_closed(queue):
-    """Test requeueing on a closed FIFO"""
-
-    def _task(task):
-        task.requeue()
-
-    # Queue the task
-    Task(_task, queue, "fifo", requeue=True)
-    assert queue.qsize == 1
-
-    # Get the task
-    task, key = queue.get()
-
-    # Clear and close the fifo
-    assert queue.clear_fifo("fifo", keep_clear=True) == (0, 0)
-
-    # Queue is empty
-    assert queue.qsize == 0
-
-    # Run the task, to requeue it
-    task()
-    queue.task_done(key)
-
-    # Queue is empty because requeue didn't happen
-    assert queue.qsize == 0
-
-
 def test_deferred_closed(queue):
     """Test deferring a task on a closed fifo."""
-    task_finished = False
 
     def _task(task, queue):
         # Close the fifo here
         queue.clear_fifo("fifo", keep_clear=True)
 
         # Defer
-        yield 1e-5
+        yield 1
 
     Task(_task, queue, "fifo", args=(queue,))
     assert queue.qsize == 1

--- a/tests/scheduler/test_task.py
+++ b/tests/scheduler/test_task.py
@@ -212,3 +212,82 @@ def test_exclusive_task(queue):
 
     # Everything's taken care of
     assert queue.qsize == 0
+
+
+def test_requeue_closed(queue):
+    """Test requeueing on a closed FIFO"""
+
+    def _task(task):
+        task.requeue()
+
+    # Queue the task
+    Task(_task, queue, "fifo", requeue=True)
+    assert queue.qsize == 1
+
+    # Get the task
+    task, key = queue.get()
+
+    # Clear and close the fifo
+    assert queue.clear_fifo("fifo", keep_clear=True) == (0, 0)
+
+    # Queue is empty
+    assert queue.qsize == 0
+
+    # Run the task, to requeue it
+    task()
+    queue.task_done(key)
+
+    # Queue is empty because requeue didn't happen
+    assert queue.qsize == 0
+
+
+def test_requeue_closed(queue):
+    """Test requeueing on a closed FIFO"""
+
+    def _task(task):
+        task.requeue()
+
+    # Queue the task
+    Task(_task, queue, "fifo", requeue=True)
+    assert queue.qsize == 1
+
+    # Get the task
+    task, key = queue.get()
+
+    # Clear and close the fifo
+    assert queue.clear_fifo("fifo", keep_clear=True) == (0, 0)
+
+    # Queue is empty
+    assert queue.qsize == 0
+
+    # Run the task, to requeue it
+    task()
+    queue.task_done(key)
+
+    # Queue is empty because requeue didn't happen
+    assert queue.qsize == 0
+
+
+def test_deferred_closed(queue):
+    """Test deferring a task on a closed fifo."""
+    task_finished = False
+
+    def _task(task, queue):
+        # Close the fifo here
+        queue.clear_fifo("fifo", keep_clear=True)
+
+        # Defer
+        yield 1e-5
+
+    Task(_task, queue, "fifo", args=(queue,))
+    assert queue.qsize == 1
+    assert queue.deferred_size == 0
+
+    # Run the task until it defers
+    task, key = queue.get()
+    task()
+    queue.task_done(key)
+
+    # task is neither queued nor deferred
+    assert queue.qsize == 0
+    assert queue.deferred_size == 0


### PR DESCRIPTION
This is a four-piece (=commit) update to the daemon to deal with tasks which are left in the queue after the node/group they're targetting goes away.

## Piece 1: Allow setting fifo label value

That is, setting the value of the "fifo" label in the metrics generated by the queue.  This is preparation for the next piece.  The goal here is to avoid requiring the FIFO used in the queue (which can be anything hashable) to be something human-readable.

## Piece 2: Use a unique FIFO for each IO instance

With the freedom that piece one gives us, piece 2 changes the way FIFO keys used by I/O instances to submit tasks are generated.  Now a unique FIFO will be used by each instance of an I/O class.

FIFO keys started out as just StorageNode.name.  That worked until StorageGroups also started submitting tasks, and they were distinguished by group/node.  The change here increases that specialisation by guaranteeing that an I/O instance will always have a unique FIFO.

Calculation of the FIFO key has been pulled out of `alpenhorn.io.base` (where it really shouldn't have been) and instead is now generated by the UpdatableNode/Group when the I/O is instantiated, and passed to it.

The new `label_fifo()` call in the queue is used to give the key a useful name in the metrics.  The label is the same for all I/O isntances of a given Storage object, meaning they're (deliberately) merged together, obfuscating the fact that different instances of the Storage object's I/O framework actually have separate FIFOs.

*NB*: no real changes to the test suite here other than using actual `queue`s in places where I had been lazy and had substituted `None` in when the queue wasn't actually being used.

## Piece 3: Implement FIFO clearing
Adds a method, `clear_fifo`, to the queue which will dequeue all pending and deferred tasks in the specified FIFO.  After doing this, the FIFO may be optionally closed, preventing further putting new items into it.  Calling `put` on a closed FIFO will raise `KeyError`.

In-progress tasks are not affected, though if the FIFO they're running out of is closed, and these tasks requeue or defer themselves, they won't successfully be able to do that.

The `Task` has been updated to be able to handle this `KeyError` (by doing nothing other than printing a message that the item was discarded).  However, invoking `clear_fifo`, isn't done until Piece 4, so this situation will not happen.

*Also*: moved the `task_done` method without change to better organise the `queue` module.

## Piece 4: Dequeue tasks when stopping/reseting I/O for a node

When a node stops being updated (e.g. when deactivated), now pending tasks for the node are discarded from the queue (by calling `clear_fifo`).  This will happen both when the node/group is no longer available (because it was deactivated or the filesystem went away), but also as part of a re-init, since that's going to restart the I/O framework for the storage node/group.

This is effectively the same as killing the daemon and restarting it, (but only for this node), but it turns out that's a fairly safe thing to do, because we've done a good bit of work to make the daemon robust against that situation over the years. So, despite my original opinion on the option,  this closes #309 using the first of the proposed solutions.

I think this is the right way to deal with this because it also fixes another problem which I've been mulling over: how to deal with pending I/O when a node goes away.  And this seems like the right solution to that problem too: i.e. just throw it all away, and assume some future daemon will figure it out.