### PR TITLE
fix(db): Exit gracefully on missing database

### DIFF
--- a/alpenhorn/db/_base.py
+++ b/alpenhorn/db/_base.py
@@ -98,7 +98,7 @@ def connect() -> None:
     # On connection error, raise click.ClickException
     try:
         db = func(config=database_config)
-    except pw.OperationalError as e:
+    except (pw.OperationalError, pw.ProgrammingError, pw.ImproperlyConfigured) as e:
         raise click.ClickException(
             f"Unable to connect to the database: {e}.\n"
             "See --help-config for more details."

--- a/tests/cli/db/test_init.py
+++ b/tests/cli/db/test_init.py
@@ -2,6 +2,7 @@
 
 import peewee as pw
 import pytest
+import yaml
 
 from alpenhorn.db import (
     ArchiveAcq,
@@ -96,6 +97,17 @@ def test_init_version1(clidb, cli):
 
     # By "old CHIME data index" we mean one without a schema version
     DataIndexVersion.delete().execute()
+
+    # Init fails
+    cli(1, ["db", "init"])
+
+
+def test_init_nodb(cli, xfs):
+
+    # Mess up the config file
+    with open("/etc/alpenhorn/alpenhorn.conf", "w") as f:
+        config = {"database": {"url": "sqlite:////MISSING/MISSING.db"}}
+        f.write(yaml.dump(config))
 
     # Init fails
     cli(1, ["db", "init"])


### PR DESCRIPTION
This replaces the previous behaviour, which was a mountain of cascading connection error tracebacks.