### PR TITLE
refactor(config): Access config via `common.config.get`

### DIFF
--- a/alpenhorn/common/extensions.py
+++ b/alpenhorn/common/extensions.py
@@ -127,11 +127,7 @@ def load_extensions() -> None:
 
     _id_ext = []
 
-    if "extensions" not in config.config:
-        log.debug("No extensions to load.")
-        return
-
-    for name in config.config["extensions"]:
+    for name in config.get("extensions", default=[], as_type=list):
         log.info(f"Loading extension {name}")
 
         try:

--- a/alpenhorn/common/metrics.py
+++ b/alpenhorn/common/metrics.py
@@ -356,11 +356,8 @@ def start_promclient() -> None:
     """
 
     # Get the port number.  If not found, we just return here.
-    try:
-        port = int(config.config["daemon"]["prom_client_port"])
-        if port <= 0:
-            return
-    except KeyError:
+    port = config.get_int("daemon.prom_client_port", default=None, min=1, max=65535)
+    if port is None:
         return
 
     # Okay, we're good to start the http server, if we can

--- a/alpenhorn/common/util.py
+++ b/alpenhorn/common/util.py
@@ -328,10 +328,9 @@ def get_hostname() -> str:
 
     If there is a host name specified in the config, that is returned
     otherwise the local hostname up to the first '.' is returned"""
-    if config.config is not None and "hostname" in config.config.get("base", {}):
-        return config.config["base"]["hostname"]
 
-    return socket.gethostname().split(".")[0]
+    hostname = config.get("base.hostname", default=None, as_type=str)
+    return hostname if hostname else socket.gethostname().split(".")[0]
 
 
 def pretty_bytes(num: int | None) -> str:

--- a/alpenhorn/daemon/auto_import.py
+++ b/alpenhorn/daemon/auto_import.py
@@ -447,7 +447,7 @@ def update_observer(
                 return
 
             _observers[node.io_class] = observer(
-                timeout=config.config["daemon"]["auto_import_interval"]
+                timeout=config.get_int("daemon.auto_import_interval", default=30, min=1)
             )
 
             _observers[node.io_class].start()

--- a/alpenhorn/daemon/entry.py
+++ b/alpenhorn/daemon/entry.py
@@ -85,7 +85,8 @@ def entry(ctx, conf, once, test_isolation):
     # If we can be multithreaded, start the worker pool
     if db.threadsafe():
         wpool = pool.WorkerPool(
-            num_workers=config.config["daemon"]["num_workers"], queue=queue
+            num_workers=config.get_int("daemon.num_workers", default=0, min=0),
+            queue=queue,
         )
     else:
         log.warning("Database is not threadsafe: forcing serial I/O.")

--- a/alpenhorn/db/_base.py
+++ b/alpenhorn/db/_base.py
@@ -85,10 +85,7 @@ def connect() -> None:
         _db_ext = {}
 
     # If fetch the database config, if present
-    if "database" in config.config:
-        database_config = config.config["database"]
-    else:
-        database_config = {}
+    database_config = config.get("database", default={}, as_type=dict)
 
     # Call the connect function from the database extension (or fallback)
     func = _capability("connect")

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -72,8 +72,10 @@ def _pull_timeout(size_b: int) -> float | None:
     PULL_TIMEOUT_BASE = 300  # 5 minutes base
     PULL_BYTES_PER_SECOND = 20000000  # 20MB/s
 
-    base = config.config["daemon"].get("pull_timeout_base", PULL_TIMEOUT_BASE)
-    bps = config.config["daemon"].get("pull_bytes_per_second", PULL_BYTES_PER_SECOND)
+    base = config.get_float("daemon.pull_timeout_base", default=PULL_TIMEOUT_BASE)
+    bps = config.get_float(
+        "daemon.pull_bytes_per_second", default=PULL_BYTES_PER_SECOND
+    )
 
     if bps == 0:
         return None

--- a/tests/cli/db/test_init.py
+++ b/tests/cli/db/test_init.py
@@ -103,7 +103,6 @@ def test_init_version1(clidb, cli):
 
 
 def test_init_nodb(cli, xfs):
-
     # Mess up the config file
     with open("/etc/alpenhorn/alpenhorn.conf", "w") as f:
         config = {"database": {"url": "sqlite:////MISSING/MISSING.db"}}

--- a/tests/common/test_logger.py
+++ b/tests/common/test_logger.py
@@ -5,29 +5,8 @@ import pathlib
 import socket
 from unittest.mock import MagicMock, patch
 
+import click
 import pytest
-
-import alpenhorn.common.logger
-
-
-def test_max_bytes_from_config():
-    """Test throwing things at _max_bytes_from_config"""
-
-    assert alpenhorn.common.logger._max_bytes_from_config("1") == 1
-    assert alpenhorn.common.logger._max_bytes_from_config(12) == 12
-    assert alpenhorn.common.logger._max_bytes_from_config("1k") == 1024
-    assert alpenhorn.common.logger._max_bytes_from_config("1M") == 1024 * 1024
-    assert alpenhorn.common.logger._max_bytes_from_config("1G") == 1024 * 1024 * 1024
-    assert alpenhorn.common.logger._max_bytes_from_config("3.3") == 3
-    assert alpenhorn.common.logger._max_bytes_from_config(3.3) == 3
-    assert alpenhorn.common.logger._max_bytes_from_config("3.3k") == int(3.3 * 1024)
-    assert alpenhorn.common.logger._max_bytes_from_config("3.3M") == int(
-        3.3 * 1024 * 1024
-    )
-
-    for string in ["", 0, -1, "3.3T", "words"]:
-        with pytest.raises(ValueError):
-            alpenhorn.common.logger._max_bytes_from_config(string)
 
 
 def test_log_buffer_gone(set_config, logger):
@@ -46,14 +25,14 @@ def test_config_sys_logging(set_config, logger):
     with patch("alpenhorn.common.logger.configure_sys_logging") as mock:
         logger.configure_logging()
 
-    mock.assert_called_once_with({"test": True})
+    mock.assert_called_once()
 
 
 @pytest.mark.alpenhorn_config({"logging": {"syslog": {"enable": 1}}})
 def test_syslog_bad_enable(set_config, logger):
     """Test non-bool syslog.enable."""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 
@@ -61,7 +40,7 @@ def test_syslog_bad_enable(set_config, logger):
 def test_syslog_bad_facility(set_config, logger):
     """Test invalid syslog.facility."""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 
@@ -133,7 +112,7 @@ def test_syslog_domain_socket(set_config, logger):
 def test_syslog_bad_use_tcp(set_config, logger):
     """Test non-bool syslog.use_tcp."""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 
@@ -145,14 +124,14 @@ def test_config_file_logging(set_config, logger):
     with patch("alpenhorn.common.logger.configure_file_logging") as mock:
         logger.configure_logging()
 
-    mock.assert_called_once_with({"test": True})
+    mock.assert_called_once()
 
 
 @pytest.mark.alpenhorn_config({"logging": {"file": {"watch": True}}})
 def test_file_no_name(set_config, logger):
     """Can't have logger.file without logger.file.name."""
 
-    with pytest.raises(KeyError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 
@@ -160,7 +139,7 @@ def test_file_no_name(set_config, logger):
 def test_file_bad_watch(set_config, logger):
     """Test non-bool file.watch."""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 
@@ -170,7 +149,7 @@ def test_file_bad_watch(set_config, logger):
 def test_file_bad_rotate(set_config, logger):
     """Test non-bool file.rotate."""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 
@@ -180,7 +159,7 @@ def test_file_bad_rotate(set_config, logger):
 def test_file_watch_rotate(set_config, logger):
     """Can't set both file.watch and file.rotate to True."""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 
@@ -221,7 +200,7 @@ def test_watchfile_logging(set_config, logger, xfs):
 def test_rotate_bad_count(set_config, logger, xfs):
     """Test a bad backup_count while rotating."""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 
@@ -231,7 +210,7 @@ def test_rotate_bad_count(set_config, logger, xfs):
 def test_rotate_bad_size(set_config, logger, xfs):
     """Test a bad max_bytes while rotating."""
 
-    with pytest.raises(ValueError):
+    with pytest.raises(click.ClickException):
         logger.configure_logging()
 
 

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import click
 import pytest
 
 from alpenhorn.common import metrics
@@ -338,13 +339,24 @@ def test_by_name(cleanup):
         metrics.by_name("no_such_metric")
 
 
-@pytest.mark.alpenhorn_config({"daemon": {"prom_client_port": "0"}})
 def test_start_promclient_off(set_config):
     """Test start_promclient with no port."""
 
     mock = MagicMock()
     with patch("prometheus_client.start_http_server", mock):
         metrics.start_promclient()
+
+    mock.assert_not_called()
+
+
+@pytest.mark.alpenhorn_config({"daemon": {"prom_client_port": "0"}})
+def test_start_promclient_zero(set_config):
+    """Test start_promclient with port zero."""
+
+    mock = MagicMock()
+    with patch("prometheus_client.start_http_server", mock):
+        with pytest.raises(click.ClickException):
+            metrics.start_promclient()
 
     mock.assert_not_called()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,26 +105,26 @@ def logger():
 
 @pytest.fixture
 def set_config(request, logger):
-    """Set alpenhorn.common.config.config for testing.
+    """Set alpenhorn.common.config._config for testing.
 
     Any value given in the alpenhorn_config mark is merged into the
     default config.
 
-    Yields alpenhorn.common.config.config.
+    Yields alpenhorn.common.config._config.
 
-    After the test completes, alpenhorn.common.config.config is set to None.
+    After the test completes, alpenhorn.common.config._config is set to None.
     """
-    # Initialise with the default
-    config.config = config._default_config.copy()
+    # Initialise
+    config._config = {}
 
     marker = request.node.get_closest_marker("alpenhorn_config")
     if marker is not None:
-        config.config = config.merge_dict_tree(config.config, marker.args[0])
+        config._config = config.merge_dict_tree(config._config, marker.args[0])
 
-    yield config.config
+    yield config._config
 
     # Reset globals
-    config.config = None
+    config._config = None
     extensions._db_ext = None
     extensions._id_ext = None
     extensions._io_ext = {}
@@ -424,8 +424,8 @@ def hostname(set_config):
 
     Returns the hostname."""
 
-    config.config = config.merge_dict_tree(
-        config.config, {"base": {"hostname": "alpenhost"}}
+    config._config = config.merge_dict_tree(
+        config._config, {"base": {"hostname": "alpenhost"}}
     )
 
     return "alpenhost"
@@ -454,8 +454,8 @@ def use_chimedb(set_config):
     cdb = pytest.importorskip("chimedb.core")
     cdb.test_enable()
 
-    config.config = config.merge_dict_tree(
-        config.config, {"extensions": ["chimedb.core.alpenhorn"]}
+    config._config = config.merge_dict_tree(
+        config._config, {"extensions": ["chimedb.core.alpenhorn"]}
     )
 
 
@@ -469,8 +469,8 @@ def dbproxy(set_config):
     extensions.load_extensions()
 
     # Set database.url if not already present
-    config.config = config.merge_dict_tree(
-        {"database": {"url": "sqlite:///:memory:"}}, config.config
+    config._config = config.merge_dict_tree(
+        {"database": {"url": "sqlite:///:memory:"}}, config._config
     )
 
     # DB start


### PR DESCRIPTION
Instead of directly accessing the `config.config` dict, this introduces a function, `common.config.get`, as the standard way off accessing the config.

The primary benefit here is that this centralises handling of missing config parameters (either by returning a default or by raising an exception) and also provides a convenient place for type checking/co-ercion of config values.

There are also specific functions for numerical types: `get_int`, `get_float` which can do bounds checking.  Also `get_bytes` which handles numbers specified with "k/M/G" suffixes (and used to be the bespoke `common.logger._max_bytes_from_config` function).

The config dict itself is renamed to `config._config` to indicate it shouldn't be accessed directly.

With this change to how the alpenhorn config is accessed, there is now a convenient way of specifying default values at the place a config parameter is used. So, I've deleted the `config._default_config` dict, replacing it with defaults in the `config.get` calls instead, which I think will aid with program understanding (because the default value is now in the place where it's used, rather than in some other module somewhere).

A side effect of this change is that all config errors are now reported to the user with a consistent `click.ClickException`, instead of the mess of exceptions previously seen.  Also better handling of incorrect configuration parameters types.