### PR TITLE
fix(cli): Fix setting I/O vars with no existing I/O config

### DIFF
--- a/alpenhorn/cli/options.py
+++ b/alpenhorn/cli/options.py
@@ -604,8 +604,10 @@ def set_io_config(
                 "Argument to --io-config must be a JSON object literal."
             )
     else:
-        # Decoding of default is only done if necessary
-        if isinstance(default, str):
+        if default is None:
+            default = {}
+        elif isinstance(default, str):
+            # Decoding of default is only done if necessary
             try:
                 default = json.loads(default)
             except json.JSONDecodeError:

--- a/tests/cli/node/test_modify.py
+++ b/tests/cli/node/test_modify.py
@@ -156,6 +156,27 @@ def test_modify_ioconfig(clidb, cli):
     assert json.loads(node.io_config) == {"a": 4, "b": 8, "d": 7}
 
 
+def test_modify_ioconfig_none(clidb, cli):
+    """Test --io-var with no exising io_config."""
+
+    group = StorageGroup.create(name="GROUP")
+    StorageNode.create(name="TEST", group=group, io_config=None)
+
+    cli(
+        0,
+        [
+            "node",
+            "modify",
+            "TEST",
+            "--io-var",
+            "b=8",
+        ],
+    )
+
+    node = StorageNode.get(name="TEST")
+    assert json.loads(node.io_config) == {"b": 8}
+
+
 def test_modify_iovar_bad_json(clidb, cli):
     """--io-var can't be used if the existing I/O config is invalid."""
 

--- a/tests/cli/test_options.py
+++ b/tests/cli/test_options.py
@@ -83,6 +83,13 @@ def test_sic_str_default():
     assert io_config == {"a": 25, "b": 27}
 
 
+def test_sic_none_default():
+    """Test None as default to set_io_config"""
+
+    io_config = set_io_config(None, ("a=25",), None)
+    assert io_config == {"a": 25}
+
+
 def test_sic_default_decode():
     """Test a decode error in default to set_io_config"""
 

--- a/tests/io/test_transport.py
+++ b/tests/io/test_transport.py
@@ -84,7 +84,9 @@ def transport_fleet_no_init(xfs, hostname, queue, storagegroup, storagenode):
         # mock bytes_avail to simply return avail_gb to avoid having to mess about
         # with pyfakefs
         node.io.bytes_avail = MagicMock(
-            return_value=None if node.db.avail_gb is None else node.db.avail_gb * 2**30
+            return_value=(
+                None if node.db.avail_gb is None else node.db.avail_gb * 2**30
+            )
         )
         xfs.create_dir(node.db.root)
 


### PR DESCRIPTION
This previously crashed due to an attempt to assign to None.

Also some random re-blackening, apparently.