### PR TITLE
fix(update_group): Only run pre-pull search if needed

### DIFF
--- a/alpenhorn/daemon/update.py
+++ b/alpenhorn/daemon/update.py
@@ -925,9 +925,11 @@ class UpdateableGroup(updateable_base):
 
         # Early checks passed: dispatch this request to the Group I/O layer
         if copy_state == "X":
-            self.io.pull_force(req)
+            self.io.pull(req, did_search=True)
+        elif self.io.do_pull_search:
+            self.io.pull_search(req)
         else:
-            self.io.pull(req)
+            self.io.pull(req, did_search=False)
 
     def update(self) -> None:
         """Perform I/O updates on the group"""

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -15,7 +15,13 @@ from ..common import metrics
 from ..common.metrics import Metric
 from ..common.util import timeout_call
 from ..daemon.update import RemoteNode
-from ..db import ArchiveFileCopy, ArchiveFileCopyRequest, utcnow
+from ..db import (
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    StorageNode,
+    utcnow,
+)
 from . import ioutil
 
 if TYPE_CHECKING:
@@ -27,8 +33,57 @@ del TYPE_CHECKING
 log = logging.getLogger(__name__)
 
 
+def _force_check_filecopy(file_: ArchiveFile, node: StorageNode, node_io: BaseNodeIO):
+    """Force a check of an unregistered file.
+
+    Upserts an ArchiveFileCopy record to force a check of an
+    unregistered file copy on a node.
+
+    Parameters
+    ----------
+    file_ : ArchiveFile
+        The file to check
+    node : StorageNode
+        The node to run the check on
+    node_io : BaseNodeIO
+        The node I/O instance.  Used if we need to calculate
+        the file size.
+    """
+    log.info(
+        "Requesting check of " f"{file_.acq.name}/{file_.name} on node {node.name}."
+    )
+
+    # ready == False is the safe option here: copy will be readied
+    # during the subsequent check if needed.
+    try:
+        # Try to create a new copy
+        ArchiveFileCopy.create(
+            file=file_,
+            node=node,
+            has_file="M",
+            wants_file="Y",
+            ready=False,
+            size_b=node_io.filesize(file_.path, actual=True),
+        )
+    except pw.IntegrityError:
+        # Copy already exists, just update the existing
+        ArchiveFileCopy.update(
+            has_file="M",
+            wants_file="Y",
+            ready=False,
+            last_update=utcnow(),
+        ).where(
+            ArchiveFileCopy.file == file_,
+            ArchiveFileCopy.node == node,
+        ).execute()
+
+
 def pull_async(
-    task: Task, io: BaseNodeIO, tree_lock: UpDownLock, req: ArchiveFileCopyRequest
+    task: Task,
+    io: BaseNodeIO,
+    tree_lock: UpDownLock,
+    req: ArchiveFileCopyRequest,
+    did_search: bool,
 ) -> None:
     """Fulfill `req` by pulling a file onto the local node.
 
@@ -48,6 +103,9 @@ def pull_async(
         The directory tree modificiation lock.
     req : ArchiveFileCopyRequest
         The request we're fulfilling.
+    did_search : bool
+        True if a search for an existing unregistered copy was
+        already performed.
     """
 
     comp_metric = metrics.by_name("requests_completed").bind(
@@ -100,6 +158,24 @@ def pull_async(
 
     to_file = pathlib.Path(io.node.root, req.file.path)
     to_dir = to_file.parent
+
+    # Check for existing file, if not done already
+    if not did_search:
+        try:
+            if to_file.exists(follow_symlinks=False):
+                log.warning(
+                    "Skipping pull request for "
+                    f"{req.file.acq.name}/{req.file.name}: "
+                    f"file already on disk on node {req.node_from.name}."
+                )
+
+                _force_check_filecopy(req.file, io.node, io)
+                # request not resolved.  Should be sorted out after
+                # the file check happens.
+                return
+        except OSError:
+            # On error, try to do the pull
+            pass
 
     # Placeholder file
     placeholder = pathlib.Path(to_dir, f".{to_file.name}.placeholder")
@@ -368,7 +444,7 @@ def group_search_async(
 
     If the file is found, a request is made to check the
     existing file, and the pull is skipped.  If the file
-    is not found, `req` is passed to `groupio.pull_force`, which
+    is not found, `req` is passed to `groupio.pull`, which
     dispatch the ArchvieFileCopyRequest to a node in the
     group to perform the pull request.
 
@@ -407,38 +483,10 @@ def group_search_async(
             f"{req.file.acq.name}/{req.file.name}: "
             f"file already on disk in group {groupio.group.name}."
         )
-        log.info(
-            "Requesting check of "
-            f"{req.file.acq.name}/{req.file.name} on node "
-            f"{node.name}."
-        )
 
         # Update/create ArchiveFileCopy to force a check.
-
-        # ready == False is the safe option here: copy will be readied
-        # during the subsequent check if needed.
-        try:
-            # Try to create a new copy
-            ArchiveFileCopy.create(
-                file=req.file,
-                node=node.db,
-                has_file="M",
-                wants_file="Y",
-                ready=False,
-                size_b=node.io.filesize(req.file.path, actual=True),
-            )
-        except pw.IntegrityError:
-            # Copy already exists, just update the existing
-            ArchiveFileCopy.update(
-                has_file="M",
-                wants_file="Y",
-                ready=False,
-                last_update=utcnow(),
-            ).where(
-                ArchiveFileCopy.file == req.file,
-                ArchiveFileCopy.node == node.db,
-            ).execute()
+        _force_check_filecopy(req.file, node.db, node.io)
         return
 
-    # Otherwise, escallate to groupio.pull_force to actually perform the pull
-    groupio.pull_force(req)
+    # Otherwise, escallate to groupio.pull to actually perform the pull
+    groupio.pull(req, did_search=True)

--- a/alpenhorn/io/transport.py
+++ b/alpenhorn/io/transport.py
@@ -36,6 +36,9 @@ class TransportGroupIO(DefaultGroupIO):
             to the fullest node that it thinks it will fit on.
     """
 
+    # Enable the group-level pre-pull search
+    do_pull_search = True
+
     def set_nodes(self, nodes: list[UpdateableNode]) -> list[UpdateableNode]:
         """Check that nodes in group are transit nodes.
 
@@ -99,7 +102,7 @@ class TransportGroupIO(DefaultGroupIO):
 
         return None
 
-    def pull_force(self, req: ArchiveFileCopyRequest) -> None:
+    def pull(self, req: ArchiveFileCopyRequest, did_search: bool) -> None:
         """Handle a pull request.
 
         Only local pulls are only fulfilled.  Remote pulls are ignored.
@@ -112,6 +115,9 @@ class TransportGroupIO(DefaultGroupIO):
         req : ArchiveFileCopyRequest
             the request to fulfill.  We are the destination group (i.e.
             `req.group_to == self.group`).
+        did_search : boolean
+            True if a group-level pre-pull search for an existing file was
+            performed.  False otherwise.
         """
 
         # If this is a non-local transfer, skip it.
@@ -160,7 +166,7 @@ class TransportGroupIO(DefaultGroupIO):
 
             # If we got here, I guess we're going to use this disk
             # Hand the pull request off to the node
-            node.io.pull(req)
+            node.io.pull(req, did_search)
             return
 
         # If we got here, we couldn't find a disk

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -362,7 +362,7 @@ def mock_statvfs(fs):
 def mock_exists(fs):
     """Mocks pathlib.PosixPath.exists to work with pyfakefs."""
 
-    def _mocked_exists(path):
+    def _mocked_exists(path, follow_symlinks=True):
         """Mock of pathlib.PosixPath.exists to work better with pyfakefs.
 
         The problem here is if there's an unreadable file in a readable


### PR DESCRIPTION
I think I over-corrected in #190 when I created a group-level task to search for existing unregistered files before a pull happens.  It was, in theory, the correct thing to do, but in practice, it leaves us with a mountain of mostly unnecessary tasks in the queue.

In this PR, I've changed this to make the group-level pre-pull search optional.  The idea being: in cases where the destination node for a group pull is deterministic, there's no need to search the whole group, and the search can be relegated to the target node itself.

In practice, this means that we can get rid of the group-level search from all group classes that take only a single node (e.g. `Default` and `LustreQuota`) as well as from `LustreHSM` (because there the destination node is determined solely by file size).

Among the in-built I/O types, this leaves only the `Transport` group where a full, group-level search needs to happen.  Whether or not the search happened is now passed on to the node-level pull, which will do the search itself before running the pull if it hasn't happened.

In the Group I/O layer, this renames the `pull_force` method to `pull` and the `pull` method to `pull_search`, and introduces a Group I/O class attribute, `do_pull_search` to specify which classes should do the full search.

I've left the default implementation of `pull_search` in `DefaultGroupIO` even though that class sets `do_pull_search` to False, meaning that it will never be used, but it's like that to make it easier for subclasses to implement the behaviour when needed.  I've also pulled the decision making over whether to use group-level `pull` or `pull_search` out to the `UpdateableGroup`, which is probably where it should always have been.

The tests for `pull_search` have been moved from `test_defaultgroup` into `test_transport` because the DefaultGroup can no longer perform the tests.