### PR TITLE
fix(DefaultIO): Use fast bytes_avail calls in reserve_bytes

### DIFF
--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -522,7 +522,7 @@ class DefaultNodeIO(BaseNodeIO):
         """
         size *= self.reserve_factor
         with _mutex:
-            bavail = self.bytes_avail()
+            bavail = self.bytes_avail(fast=True)
             if bavail is not None and bavail - _reserved_bytes[self.node.name] < size:
                 return False  # Insufficient space
 


### PR DESCRIPTION
With this change, the free space is only updated when it's cheap to do so (i.e. not on `LustreQuota`).  This is important because this method runs in the MainThread (when it's trying to figure out whether or not it's worth attempting a pull).

We used to only have `cedar_online`, which has comparatively few transfers into it, as a `LustreQuota` node.  But now, with the new project quota on cedar, I've switched the others nodes in project space over as well and the inefficiency here is quite noticeable in `cedar_staging`.