### PR TITLE
fix(StorageNode): Include suspect files in size count.

### DIFF
--- a/alpenhorn/db/storage.py
+++ b/alpenhorn/db/storage.py
@@ -302,7 +302,7 @@ class StorageNode(base_model):
         size = (
             ArchiveFile.select(fn.Sum(ArchiveFile.size_b))
             .join(ArchiveFileCopy)
-            .where(ArchiveFileCopy.node == self, ArchiveFileCopy.has_file == "Y")
+            .where(ArchiveFileCopy.node == self, ArchiveFileCopy.has_file << ["Y", "M"])
         ).scalar(as_tuple=True)[0]
 
         return 0.0 if size is None else float(size) / 2**30

--- a/tests/db/test_storage.py
+++ b/tests/db/test_storage.py
@@ -224,6 +224,11 @@ def test_totalgb(simplegroup, storagenode, simplefile, archivefilecopy):
     archivefilecopy(file=simplefile, node=node, has_file="Y")
     assert node.get_total_gb() == 1.0
 
+    # Node with suspect copy
+    node = storagenode(name="suspect", group=simplegroup)
+    archivefilecopy(file=simplefile, node=node, has_file="M")
+    assert node.get_total_gb() == 1.0
+
     # Node with bad copy
     node = storagenode(name="bad", group=simplegroup)
     archivefilecopy(file=simplefile, node=node, has_file="X")


### PR DESCRIPTION
This adds files with `has_file='M'` to the total size for a node calculated by `StorageNode.get_total_gb`.

A downstream daemon pulling files can't always tell why transfers fail. As a result, in times of network trouble, it's not unusual for a pulling daemon to mark files it fails to transfer as suspect (`has_file="M"`). In these cases, because the file is okay and it was the network that was the problem, the upstream deamon will check the file and decide it's okay, setting `has_file` back to "Y".  The net effect is a downwards transient in the reported size of a node until the networking trouble gets resolved, which can have follow-on effects such as over-filling a node.

Because it triggers a check of the file, the `has_file="M"` state is temporary (assuming a node is being managed).  So this shouldn't change the reported size of anything in the long-term.