### PR TITLE
fix(group_pull_search): Find _all_ unregistered copies

### DIFF
--- a/alpenhorn/daemon/update.py
+++ b/alpenhorn/daemon/update.py
@@ -804,11 +804,10 @@ class UpdateableGroup(updateable_base):
         super().reinit(group)
 
         try:
-            self._nodes = self.io.set_nodes(nodes)
+            self.io.nodes = nodes
         except ValueError as e:
             # I/O layer didn't like the nodes we gave it
             log.warning(str(e))
-            self._nodes = None
 
     @property
     def idle(self) -> bool:
@@ -821,11 +820,11 @@ class UpdateableGroup(updateable_base):
             return False
 
         # A group with no nodes is not idle.
-        if self._nodes is None:
+        if not self.io.nodes:
             return False
 
         # If any node is not idle, the group is not idle.
-        for node in self._nodes:
+        for node in self.io.nodes:
             if not node.idle:
                 return False
 
@@ -924,9 +923,7 @@ class UpdateableGroup(updateable_base):
             return
 
         # Early checks passed: dispatch this request to the Group I/O layer
-        if copy_state == "X":
-            self.io.pull(req, did_search=True)
-        elif self.io.do_pull_search:
+        if self.io.do_pull_search:
             self.io.pull_search(req)
         else:
             self.io.pull(req, did_search=False)
@@ -937,7 +934,7 @@ class UpdateableGroup(updateable_base):
         self._do_idle_updates = False
 
         # If the available nodes weren't acceptable to the I/O layer, do nothing
-        if self._nodes is None:
+        if not self.io.nodes:
             return
 
         # Call the before update hook

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -516,36 +516,41 @@ class BaseGroupIO:
         """
         self.group = group
 
-    def set_nodes(self, nodes: list[UpdateableNode]) -> list[UpdateableNode]:
+    @property
+    def nodes(self) -> list[UpdateableNode]:
+        """The list of nodes in this group.
+
+        Ordering is important: nodes at the start of the list are more likely
+        to have I/O performed against them.
+
+        If this group has no nodes, perhaps because it rejected all nodes it was
+        offered by the daemon, this should be the empty list."""
+        raise NotImplementedError("method must be re-implemented in subclass.")
+
+    @nodes.setter
+    def nodes(self, nodes: list[UpdateableNode]) -> list[UpdateableNode]:
         """Set the list of local active nodes in this group.
 
-        This method is called to communicate to the I/O instance the list
-        of locally-active nodes.
-
-        This method is called each main loop, after regular
-        node I/O has completed but before any group I/O updates commence.
+        The daemon will attempt to assign to this property the list of
+        locally-active nodes.  This happens each time through the main loop,
+        after regular node I/O has completed but before any group I/O
+        updates commence.
 
         If group I/O cannot proceed with the supplied list of nodes,
         implementations should raise ValueError with a message which will
         be written to the log.
 
         Otherwise, it may choose to operate on any non-empty subset of
-        `nodes`.  In this case it should return the list of nodes which has
-        been selected, and record the list locally, if needed.
+        `nodes`.  In this case, the `nodes` property should later return
+        the list of nodes which have been selected.
 
         Parameters
         ----------
         nodes : list of UpdateableNodes
             local active nodes in this group.  Will never be empty.
 
-        Returns
-        -------
-        selected_nodes : list of UpdateableNodes
-            `nodes` or a non-empty subset of `nodes` on which group I/O
-            will be performed.
-
-                Raises
-                ------
+        Raises
+        ------
         ValueError
             `nodes` was not sufficient to permit group I/O to proceed.
         """

--- a/tests/daemon/test_update_group.py
+++ b/tests/daemon/test_update_group.py
@@ -220,10 +220,10 @@ def test_update_group_copy_state(
     assert not ArchiveFileCopyRequest.get(file=fileM).cancelled
     assert call.pull_search(afcrM) not in mockio.group.mock_calls
 
-    # afcrX called pull directly
+    # afcrX called pull_search
     assert not ArchiveFileCopyRequest.get(file=fileX).completed
     assert not ArchiveFileCopyRequest.get(file=fileX).cancelled
-    assert call.pull(afcrX, did_search=True) in mockio.group.mock_calls
+    assert call.pull_search(afcrX) in mockio.group.mock_calls
 
     # afcrN called pull_search
     assert not ArchiveFileCopyRequest.get(file=fileN).completed

--- a/tests/io/test_defaultgroup.py
+++ b/tests/io/test_defaultgroup.py
@@ -32,7 +32,7 @@ def test_too_many_nodes(storagegroup, storagenode, queue):
     node2 = UpdateableNode(queue, storagenode(name="node2", group=stgroup, active=True))
 
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=[node1, node2], idle=True)
-    assert group._nodes is None
+    assert not group.io.nodes
 
 
 def test_just_enough_nodes(storagegroup, storagenode, queue):
@@ -42,7 +42,7 @@ def test_just_enough_nodes(storagegroup, storagenode, queue):
     node = UpdateableNode(queue, storagenode(name="node1", group=stgroup, active=True))
 
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=[node], idle=True)
-    assert group._nodes == [node]
+    assert group.io.nodes == [node]
 
 
 def test_exists(xfs, groupnode):

--- a/tests/io/test_lustrehsmgroup.py
+++ b/tests/io/test_lustrehsmgroup.py
@@ -86,26 +86,26 @@ def test_init(storagegroup, storagenode, queue, mock_lfs):
     group = UpdateableGroup(
         queue=queue, group=stgroup, nodes=[hsm, smallfile], idle=True
     )
-    assert group._nodes is not None
+    assert group.io.nodes == [smallfile, hsm]
     assert group.io._hsm is hsm
     assert group.io._smallfile is smallfile
 
     group = UpdateableGroup(
         queue=queue, group=stgroup, nodes=[smallfile, hsm], idle=True
     )
-    assert group._nodes is not None
+    assert group.io.nodes == [smallfile, hsm]
     assert group.io._hsm is hsm
     assert group.io._smallfile is smallfile
 
     # But not these
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=[smallfile], idle=True)
-    assert group._nodes is None
+    assert group.io.nodes == []
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=[hsm], idle=True)
-    assert group._nodes is None
+    assert group.io.nodes == []
     group = UpdateableGroup(
         queue=queue, group=stgroup, nodes=[smallfile, smallfile], idle=True
     )
-    assert group._nodes is None
+    assert group.io.nodes == []
 
 
 def test_idle(queue, group):


### PR DESCRIPTION
This got away from me a bit, but the goal of this PR was to fix the group pull_search so that it finds all unregistered copies of a file when running.

This means:
* in `UpdatableGroup.update_pull`, the short circuit that skipped the search when a known corrupt file copy was present in the group is removed.
* in `alpenhorn.io._default_asyncs.group_search_async`, now all nodes in the group are explicitly checked, instead of stopping the search at the first match.
* Also, now only unregistered copies found in this way will be marked for checking (`has_file='M'`) but _all_ such files are found and checked. (The previous behaviour would find at most one extant file on disk, and force-check it, regardless of what its state in the database was).
* Because the async is now directly iterating over the node list, that created a need for a standard way for the GroupIO layer to present the list of nodes it has in the group.  As a result I've implemented an I/O-layer `nodes` property on GroupIO, and changed the old `set_nodes` method into the setter for this property.  The list provided by the `nodes` property is sorted in priority order (which may be different for different I/O classes), with earlier nodes more likely to have I/O performed on them.  Under the hood, individial I/O classes are still allowed to store the node data however they like.
* Finally, the introduction of the `nodes` property means I've been able to get rid of the private `_nodes` property in `UpdateableGroup` where it was cacheing the node list (because it was otherwise hard to retrieve that after setting it).

Though this ended up being more involved that I had hoped (I originally set out to just delete two lines to accomplish the first point), I think this smooths out some rough edges when it comes to node management in groups, as well as fixing the problem I originally found (corrupt files hiding unregistered files).