### PR TITLE
refactor: Drop the use of `typing.TYPE_CHECKING`

### DIFF
--- a/alpenhorn/cli/cli.py
+++ b/alpenhorn/cli/cli.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Callable
 
 import click
 
 from ..common.logger import echo
 from ..db import connect, schema_version
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-del TYPE_CHECKING
 
 
 def dbconnect(check: bool = True) -> None:

--- a/alpenhorn/common/extensions.py
+++ b/alpenhorn/common/extensions.py
@@ -71,27 +71,21 @@ from __future__ import annotations
 
 import importlib
 import logging
-from typing import TYPE_CHECKING
+import pathlib
+from collections.abc import Callable
+from types import ModuleType
 
+from ..daemon import UpdateableNode
+from ..db import ArchiveAcq, ArchiveFile, ArchiveFileCopy
 from . import config
 
-if TYPE_CHECKING:
-    import pathlib
-    from collections.abc import Callable
-    from types import ModuleType
-
-    from .alpenhorn import ArchiveAcq, ArchiveFile
-    from .archive import ArchiveFileCopy
-    from .update import UpdateableNode
-
-    ImportCallback = Callable[
-        [ArchiveFileCopy, ArchiveFile | None, ArchiveAcq | None, UpdateableNode], None
-    ]
-    ImportDetect = Callable[
-        [pathlib.Path, UpdateableNode],
-        tuple[pathlib.Path | str | None, ImportCallback | None],
-    ]
-del TYPE_CHECKING
+ImportCallback = Callable[
+    [ArchiveFileCopy, ArchiveFile | None, ArchiveAcq | None, UpdateableNode], None
+]
+ImportDetect = Callable[
+    [pathlib.Path, UpdateableNode],
+    tuple[pathlib.Path | str | None, ImportCallback | None],
+]
 
 log = logging.getLogger(__name__)
 

--- a/alpenhorn/common/util.py
+++ b/alpenhorn/common/util.py
@@ -5,19 +5,16 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+import os
 import socket
 import subprocess
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from typing import Any
 
 import click
 
-from . import config, extensions, logger
+from . import config
 from .metrics import Metric
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from os import PathLike
-del TYPE_CHECKING
 
 log = logging.getLogger(__name__)
 
@@ -139,6 +136,8 @@ def start_alpenhorn(
     verbosity : int, optional
         For the cli, the initial verbosity level.  Ignored for daemons.
     """
+    from . import extensions, logger
+
     # Initialise logging
     logger.init_logging(cli=cli, verbosity=verbosity)
 
@@ -245,7 +244,7 @@ def timeout_call(func: Callable, timeout: float, /, *args: Any, **kwargs: Any) -
     return asyncio.run(_async_wrapper(func, timeout, args, kwargs))
 
 
-async def _md5sum_file(filename: str | PathLike) -> str | None:
+async def _md5sum_file(filename: str | os.PathLike) -> str | None:
     """asyncio implementation of md5sum_file().
 
     Aborts and returns None if computation is too slow.
@@ -293,7 +292,7 @@ async def _md5sum_file(filename: str | PathLike) -> str | None:
     return md5.hexdigest()
 
 
-def md5sum_file(filename: str | PathLike) -> str | None:
+def md5sum_file(filename: str | os.PathLike) -> str | None:
     """Find the md5sum of a given file.
 
     This implementation runs in an asyncio wrapper and will time out

--- a/alpenhorn/daemon/__init__.py
+++ b/alpenhorn/daemon/__init__.py
@@ -2,3 +2,7 @@
 
 from .. import __version__
 from .entry import entry
+
+# These classes are used by extensions, so let's import them into the daemon
+# base
+from .update import UpdateableNode, UpdateableGroup, RemoteNode

--- a/alpenhorn/daemon/auto_import.py
+++ b/alpenhorn/daemon/auto_import.py
@@ -8,8 +8,9 @@ for a module.
 from __future__ import annotations
 
 import logging
+import os
 import pathlib
-from typing import TYPE_CHECKING
+from collections.abc import Generator
 
 import peewee as pw
 from watchdog.events import FileSystemEventHandler
@@ -23,17 +24,8 @@ from ..db import (
     ArchiveFileImportRequest,
     utcnow,
 )
-from ..io import ioutil
-from ..scheduler import Task
-
-if TYPE_CHECKING:
-    import os
-    from collections.abc import Generator
-
-    from ..scheduler import FairMultiFIFOQueue
-    from .update import UpdateableNode
-del TYPE_CHECKING
-
+from ..scheduler import FairMultiFIFOQueue, Task
+from .update import UpdateableNode
 
 log = logging.getLogger(__name__)
 
@@ -169,6 +161,8 @@ def _import_file(
     req : ArchiveFileImportRequest or None
         If not None, req will be marked as complete if the import isn't skipped.
     """
+
+    from ..io import ioutil
 
     # Skip non-files
     fullpath = pathlib.Path(node.db.root).joinpath(path)

--- a/alpenhorn/daemon/entry.py
+++ b/alpenhorn/daemon/entry.py
@@ -9,7 +9,6 @@ from .. import db
 from ..common import config, metrics
 from ..common.util import help_config_option, start_alpenhorn, version_option
 from ..scheduler import FairMultiFIFOQueue, pool
-from . import auto_import, update
 
 log = logging.getLogger(__name__)
 
@@ -62,6 +61,8 @@ def entry(ctx, conf, once, test_isolation):
     it to run only a single update pass and then exit after updates have completed
     by using the "--exit-after-update" flag.
     """
+
+    from . import auto_import, update
 
     # Turn on test isolation, if requested
     config.test_isolation(enable=test_isolation)

--- a/alpenhorn/db/_base.py
+++ b/alpenhorn/db/_base.py
@@ -9,8 +9,6 @@ import click
 import peewee as pw
 from playhouse import db_url
 
-from ..common import config, extensions
-
 # All peewee-generated logs are logged to this namespace.
 log = logging.getLogger(__name__)
 
@@ -75,6 +73,8 @@ def connect() -> None:
     This must be called once, after extensions are loaded, before
     threads are created.
     """
+    from ..common import config, extensions
+
     # attempt to load a database extension
     global _db_ext
     _db_ext = extensions.database_extension()

--- a/alpenhorn/db/archive.py
+++ b/alpenhorn/db/archive.py
@@ -153,7 +153,7 @@ class ArchiveFileCopyRequest(base_model):
             True if processing the request should continue.  False if
             the request has been cancelled, or should be skipped.
         """
-        from ..daemon.update import RemoteNode
+        from ..daemon import RemoteNode
 
         # The only label left unbound here is "result"
         comp_metric = metrics.by_name("requests_completed").bind(

--- a/alpenhorn/db/storage.py
+++ b/alpenhorn/db/storage.py
@@ -5,17 +5,12 @@ from __future__ import annotations
 
 import logging
 import pathlib
-from typing import TYPE_CHECKING
 
 import peewee as pw
 from peewee import fn
 
-from ..common import util
 from ._base import EnumField, base_model
-
-if TYPE_CHECKING:
-    from .acquisition import ArchiveFile
-del TYPE_CHECKING
+from .acquisition import ArchiveFile
 
 log = logging.getLogger(__name__)
 
@@ -174,6 +169,8 @@ class StorageNode(base_model):
 
     @property
     def local(self) -> bool:
+        from ..common import util
+
         """Is this node local to where we are running?"""
         return self.host == util.get_hostname()
 

--- a/alpenhorn/io/_default_asyncs.py
+++ b/alpenhorn/io/_default_asyncs.py
@@ -7,13 +7,12 @@ import logging
 import pathlib
 import shutil
 import time
-from typing import TYPE_CHECKING
 
 import peewee as pw
 
 from ..common.metrics import Metric
 from ..common.util import timeout_call
-from ..daemon.update import RemoteNode
+from ..daemon import RemoteNode
 from ..db import (
     ArchiveFile,
     ArchiveFileCopy,
@@ -21,13 +20,10 @@ from ..db import (
     StorageNode,
     utcnow,
 )
+from ..scheduler import Task
 from . import ioutil
-
-if TYPE_CHECKING:
-    from ..scheduler import Task
-    from .base import BaseGroupIO, BaseNodeIO
-    from .updownlock import UpDownLock
-del TYPE_CHECKING
+from .base import BaseGroupIO, BaseNodeIO
+from .updownlock import UpDownLock
 
 log = logging.getLogger(__name__)
 

--- a/alpenhorn/io/base.py
+++ b/alpenhorn/io/base.py
@@ -10,23 +10,20 @@ by subclassing from DefaultIO instead of from here directly.
 from __future__ import annotations
 
 import logging
+import os
 import pathlib
-from typing import IO, TYPE_CHECKING
+from collections.abc import Hashable, Iterable
+from typing import IO
 
-if TYPE_CHECKING:
-    import os
-    from collections.abc import Hashable, Iterable
-
-    from ..daemon.update import UpdateableNode
-    from ..db import (
-        ArchiveFile,
-        ArchiveFileCopy,
-        ArchiveFileCopyRequest,
-        StorageGroup,
-        StorageNode,
-    )
-    from ..scheduler import FairMultiFIFOQueue
-del TYPE_CHECKING
+from ..daemon import UpdateableNode
+from ..db import (
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    StorageGroup,
+    StorageNode,
+)
+from ..scheduler import FairMultiFIFOQueue
 
 log = logging.getLogger(__name__)
 

--- a/alpenhorn/io/default.py
+++ b/alpenhorn/io/default.py
@@ -14,27 +14,25 @@ import logging
 import os
 import pathlib
 import threading
-from typing import IO, TYPE_CHECKING
+from collections.abc import Hashable, Iterable
+from typing import IO
 
 from watchdog.observers import Observer
 
 from ..common import util
-from ..db import ArchiveAcq, ArchiveFile
-from ..scheduler import Task
+from ..daemon import UpdateableNode
+from ..db import (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    ArchiveFileCopyRequest,
+    StorageNode,
+)
+from ..scheduler import FairMultiFIFOQueue, Task
 from . import ioutil
-
-# The asyncs are over here:
 from ._default_asyncs import check_async, delete_async, group_search_async, pull_async
 from .base import BaseGroupIO, BaseNodeIO, BaseNodeRemote
 from .updownlock import UpDownLock
-
-if TYPE_CHECKING:
-    from collections.abc import Hashable, Iterable
-
-    from ..db import ArchiveFileCopy, ArchiveFileCopyRequest, StorageNode
-    from ..service.queue import FairMultiFIFOQueue
-    from ..service.update import UpdateableNode
-del TYPE_CHECKING
 
 log = logging.getLogger(__name__)
 

--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import errno
 import logging
+import os
 import pathlib
 import re
 import shutil
 import time
 from tempfile import TemporaryDirectory
-from typing import TYPE_CHECKING
 
 import peewee as pw
 
@@ -17,6 +17,7 @@ from .. import db
 from ..common import config, metrics, util
 from ..common.metrics import Metric
 from ..db import (
+    ArchiveFile,
     ArchiveFileCopy,
     ArchiveFileCopyRequest,
     StorageNode,
@@ -25,15 +26,8 @@ from ..db import (
     utcnow,
 )
 from ..scheduler import threadlocal
-
-if TYPE_CHECKING:
-    import os
-
-    from ..acquisition import ArchiveFile
-    from .base import BaseNodeIO
-    from .updownlock import UpDownLock
-del TYPE_CHECKING
-
+from .base import BaseNodeIO
+from .updownlock import UpDownLock
 
 log = logging.getLogger(__name__)
 

--- a/alpenhorn/io/lfs.py
+++ b/alpenhorn/io/lfs.py
@@ -32,16 +32,11 @@ run these commands:
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 from enum import Enum
-from typing import TYPE_CHECKING
 
 from alpenhorn.common import util
-
-if TYPE_CHECKING:
-    import os
-del TYPE_CHECKING
-
 
 log = logging.getLogger(__name__)
 

--- a/alpenhorn/io/lustrehsm.py
+++ b/alpenhorn/io/lustrehsm.py
@@ -15,28 +15,22 @@ This module provides:
 from __future__ import annotations
 
 import logging
+import os
 import pathlib
 import time
-from typing import IO, TYPE_CHECKING
+from collections.abc import Generator, Hashable
+from typing import IO
 
 import peewee as pw
 
 from ..common.util import pretty_bytes, pretty_deltat
+from ..daemon import UpdateableGroup, UpdateableNode
 from ..daemon.querywalker import QueryWalker
-from ..db import ArchiveFileCopy, utcnow
-from ..scheduler import Task
+from ..db import ArchiveFile, ArchiveFileCopy, ArchiveFileCopyRequest, utcnow
+from ..scheduler import FairMultiFIFOQueue, Task
 from .base import BaseNodeRemote
 from .default import DefaultGroupIO
 from .lustrequota import LustreQuotaNodeIO
-
-if TYPE_CHECKING:
-    import os
-    from collections.abc import Generator, Hashable
-
-    from ..db import ArchiveFile, ArchiveFileCopyRequest
-    from ..scheduler import FairMultiFIFOQueue
-    from ..service.update import UpdateableGroup, UpdateableNode
-del TYPE_CHECKING
 
 log = logging.getLogger(__name__)
 

--- a/alpenhorn/io/lustrequota.py
+++ b/alpenhorn/io/lustrequota.py
@@ -14,17 +14,12 @@ or else set to a fixed value via the `io_config`.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from collections.abc import Hashable
 
+from ..db import StorageNode
+from ..scheduler import FairMultiFIFOQueue
 from .default import DefaultNodeIO
 from .lfs import LFS
-
-if TYPE_CHECKING:
-    from collections.abc import Hashable
-
-    from ..queue import FairMultiFIFOQueue
-    from ..storage import StorageNode
-del TYPE_CHECKING
 
 log = logging.getLogger(__name__)
 

--- a/alpenhorn/io/transport.py
+++ b/alpenhorn/io/transport.py
@@ -3,16 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import pathlib
 
+from ..daemon import UpdateableNode
+from ..db import ArchiveFileCopyRequest
 from .default import DefaultGroupIO
-
-if TYPE_CHECKING:
-    import pathlib
-
-    from ..archive import ArchiveFileCopyRequest
-    from ..update import UpdateableNode
-del TYPE_CHECKING
 
 log = logging.getLogger(__name__)
 

--- a/examples/pattern_importer.py
+++ b/examples/pattern_importer.py
@@ -25,22 +25,23 @@ from __future__ import annotations
 
 import json
 import os
+import pathlib
 import re
 from functools import partial
-from typing import TYPE_CHECKING
 
 import peewee as pw
 
 from alpenhorn.common import config as alpenconf
-from alpenhorn.db import ArchiveAcq, ArchiveFile, base_model, connect, database_proxy
-
-if TYPE_CHECKING:
-    import pathlib
-
-    from alpenhorn.common.extensions import ImportCallback
-    from alpenhorn.daemon.update import UpdateableNode
-    from alpenhorn.db.archive import ArchiveFileCopy
-del TYPE_CHECKING
+from alpenhorn.common.extensions import ImportCallback
+from alpenhorn.daemon import UpdateableNode
+from alpenhorn.db import (
+    ArchiveAcq,
+    ArchiveFile,
+    ArchiveFileCopy,
+    base_model,
+    connect,
+    database_proxy,
+)
 
 
 class TypeBase(base_model):
@@ -284,7 +285,8 @@ def demo_init() -> None:
     """Extension init for alpenhorn demo
 
     This function initialises the alpenhorn data index to support this extension
-    when used in the the alpenhorn demo (see alpenhorn/dmeo/demo-script.md).
+    when used in the the alpenhorn demo (see
+    https://alpenhorn.readthedocs.io/en/latest/demo.html)
 
     It creates the AcqType, FileType, AcqData, and FileData tables and
     then populates the AcqType and FileType tables to allow the demo


### PR DESCRIPTION
Given we're not using a static type checker in our CI, the imports protected by `TYPE_CHECKING` have gotten too out-of-date to be useful. So, let's try getting rid of `TYPE_CHECKING`, and deal with circular import some other way.

This also words around sphinx autodoc problems associated with the use of `TYPE_CHECKING`.

Other than monkeying about with imports, the only other change I've made here is to re-import `UpdatedableNode/Group` and `RemoteNode` up a level in `alpenhorn.daemon` to make importing these easier.  The pattern_importer extension demonstrates that third-parties are going to want to have access to these.

This and #332 overlap to a degree.  Probably one or the other should be reviewed and merged first before the other is reviewed, though the order I don't think matters.