### PR TITLE
refactor: Use _ for all dummy variables

### DIFF
--- a/alpenhorn/io/ioutil.py
+++ b/alpenhorn/io/ioutil.py
@@ -248,7 +248,7 @@ def rsync(
             "--rsh=ssh -q",
         ]
 
-    ret, stdout, stderr = util.run_command(
+    ret, _, stderr = util.run_command(
         [
             "rsync",
             *remote_args,

--- a/tests/common/test_metrics.py
+++ b/tests/common/test_metrics.py
@@ -22,7 +22,7 @@ def cleanup():
 
     # Delete all metrics from the prometheus client registry and our dict
     while metrics._metrics:
-        key, value = metrics._metrics.popitem()
+        _, value = metrics._metrics.popitem()
         REGISTRY.unregister(value[0])
 
 

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -7,13 +7,13 @@ from alpenhorn.common import util
 
 def test_run_retval0():
     """Test getting success from run_command."""
-    retval, stdout, stderr = util.run_command(["true"])
+    retval, _, _ = util.run_command(["true"])
     assert retval == 0
 
 
 def test_run_retval1():
     """Test getting failure from run_command."""
-    retval, stdout, stderr = util.run_command(["false"])
+    retval, _, _ = util.run_command(["false"])
     assert retval != 0
 
 
@@ -37,7 +37,7 @@ def test_run_stderr():
 
 def test_run_timeout():
     """Test run_command timing out."""
-    retval, stdout, stderr = util.run_command(["sleep", "10"], timeout=0.1)
+    retval, _, _ = util.run_command(["sleep", "10"], timeout=0.1)
     assert retval is None
 
 

--- a/tests/daemon/test_update.py
+++ b/tests/daemon/test_update.py
@@ -73,7 +73,7 @@ def test_update_node_not_idle(
     hostname, xfs, mockgroupandnode, queue, emptypool, loop_once, mock_serial_io
 ):
     """Test update_loop with a not idle node."""
-    mockio, _, node = mockgroupandnode
+    mockio, _, _ = mockgroupandnode
 
     # Set up the I/O mock
     mockio.node.before_update.return_value = True
@@ -210,7 +210,7 @@ def test_update_group_not_idle_node(
     As a result, the group idle check doesn't happen (group idle
     is forced to be False in this instance)."""
 
-    mockio, _, node = mockgroupandnode
+    mockio, _, _ = mockgroupandnode
 
     # Set up the I/O mock
     mockio.node.before_update.return_value = True
@@ -242,7 +242,7 @@ def test_update_group_not_idle_group(
     but we force the group to appear non-idle after
     the update."""
 
-    mockio, group, node = mockgroupandnode
+    mockio, _, _ = mockgroupandnode
 
     # This function adds something to the queue so that after the
     # node update, it's not idle

--- a/tests/daemon/test_update_group.py
+++ b/tests/daemon/test_update_group.py
@@ -87,8 +87,8 @@ def pull(
 def test_update_group_inactive(mockgroupandnode, hostname, queue, pull, simplenode):
     """Test running update.update_group with source node inactive."""
 
-    mockio, group, node = mockgroupandnode
-    file, copy, afcr = pull
+    mockio, group, _ = mockgroupandnode
+    file, _, _ = pull
 
     # Source not active
     simplenode.active = False
@@ -106,8 +106,8 @@ def test_update_group_inactive(mockgroupandnode, hostname, queue, pull, simpleno
 def test_update_group_nosrc(mockgroupandnode, hostname, queue, pull):
     """Test running update.update_group with source file missing."""
 
-    mockio, group, node = mockgroupandnode
-    file, copy, afcr = pull
+    mockio, group, _ = mockgroupandnode
+    _, copy, afcr = pull
 
     # Source not present
     copy.has_file = "N"
@@ -125,8 +125,8 @@ def test_update_group_nosrc(mockgroupandnode, hostname, queue, pull):
 def test_update_group_notready(mockgroupandnode, hostname, queue, pull):
     """Test running update.update_group with source file not ready."""
 
-    mockio, group, node = mockgroupandnode
-    file, copy, afcr = pull
+    mockio, group, _ = mockgroupandnode
+    file, _, afcr = pull
 
     # Force source not ready
     with patch(
@@ -152,8 +152,8 @@ def test_update_group_multicopy(
 ):
     """update.update_group shouldn't queue simultaneous pulls for the same file."""
 
-    mockio, group, node = mockgroupandnode
-    file, copy, afcr = pull
+    mockio, group, _ = mockgroupandnode
+    file, _, afcr = pull
 
     # Make a duplicate AFCR
     archivefilecopyrequest(node_from=afcr.node_from, group_to=afcr.group_to, file=file)
@@ -202,10 +202,10 @@ def test_update_group_copy_state(
     # Make some pull requests
     commonargs = (simpleacq, simplenode, "Y", group.db, node.db)
     factories = (archivefile, archivefilecopy, archivefilecopyrequest)
-    fileY, srcY, dstY, afcrY = make_afcr("fileY", *commonargs, "Y", *factories)
-    fileM, srcM, dstM, afcrM = make_afcr("fileM", *commonargs, "M", *factories)
-    fileX, srcX, dstX, afcrX = make_afcr("fileX", *commonargs, "X", *factories)
-    fileN, srcN, dstN, afcrN = make_afcr("fileN", *commonargs, "N", *factories)
+    fileY, _, _, afcrY = make_afcr("fileY", *commonargs, "Y", *factories)
+    fileM, _, _, afcrM = make_afcr("fileM", *commonargs, "M", *factories)
+    fileX, _, _, afcrX = make_afcr("fileX", *commonargs, "X", *factories)
+    fileN, _, _, afcrN = make_afcr("fileN", *commonargs, "N", *factories)
 
     # run update
     group.update()
@@ -233,7 +233,7 @@ def test_update_group_copy_state(
 
 def test_group_idle_group(queue, mockgroupandnode):
     """Test DefaultGroupIO.idle via group queue."""
-    mockio, group, node = mockgroupandnode
+    _, group, _ = mockgroupandnode
 
     # Currently idle
     assert group.idle is True
@@ -245,7 +245,7 @@ def test_group_idle_group(queue, mockgroupandnode):
     assert group.idle is False
 
     # Dequeue it
-    task, key = queue.get()
+    _, key = queue.get()
 
     # Still not idle, because task is in-progress
     assert group.idle is False
@@ -259,7 +259,7 @@ def test_group_idle_group(queue, mockgroupandnode):
 
 def test_group_idle_node(queue, mockgroupandnode):
     """Test DefaultGroupIO.idle via node queue."""
-    mockio, group, node = mockgroupandnode
+    _, group, node = mockgroupandnode
 
     # Currently idle
     assert group.idle is True
@@ -271,7 +271,7 @@ def test_group_idle_node(queue, mockgroupandnode):
     assert group.idle is False
 
     # Dequeue it
-    task, key = queue.get()
+    _, key = queue.get()
 
     # Still not idle, because task is in-progress
     assert group.idle is False

--- a/tests/daemon/test_update_node.py
+++ b/tests/daemon/test_update_node.py
@@ -135,7 +135,7 @@ def test_idle(unode, queue):
     assert unode.idle is False
 
     # Dequeue it
-    task, key = queue.get()
+    _, key = queue.get()
 
     # Still not idle, because task is in-progress
     assert unode.idle is False

--- a/tests/io/test_defaultnode_pull.py
+++ b/tests/io/test_defaultnode_pull.py
@@ -188,7 +188,7 @@ def test_pull_sync_fit(xfs, queue, test_req):
 def test_pull_async_noroute(queue, pull_async_true):
     """Test no route for remote pull."""
 
-    node, req = pull_async_true
+    _, req = pull_async_true
 
     # Make the request non-local
     req.node_from.host = "other-host"
@@ -211,7 +211,7 @@ def test_pull_async_noroute(queue, pull_async_true):
 def test_pull_async_bbcp_fail(queue, have_bbcp, pull_async_true, skip_db_checks):
     """Test an unsuccessful bbcp remote pull."""
 
-    node, req = pull_async_true
+    _, req = pull_async_true
 
     # Make the request non-local
     req.node_from.host = "other-host"
@@ -271,7 +271,7 @@ def test_pull_async_remote_rsync_fail(
 ):
     """Test an unsuccessful rsync remote pull."""
 
-    node, req = pull_async_true
+    _, req = pull_async_true
 
     # Make the request non-local
     req.node_from.host = "other-host"
@@ -328,7 +328,7 @@ def test_pull_async_remote_rsync_succeed(
 def test_pull_async_remote_nomethod(queue, pull_async_true):
     """Test remote pull with no command available."""
 
-    node, req = pull_async_true
+    _, req = pull_async_true
 
     # Make the request non-local
     req.node_from.host = "other-host"
@@ -373,7 +373,7 @@ def test_pull_async_link(queue, pull_async_true, skip_db_checks):
 def test_pull_async_link_arccontam(queue, pull_async_true, skip_db_checks):
     """Test not creating hardlinks between archive nodes."""
 
-    node, req = pull_async_true
+    node, _ = pull_async_true
 
     # Make one node non-archival
     node.db.storage_type = "F"

--- a/tests/io/test_ioutil_crd.py
+++ b/tests/io/test_ioutil_crd.py
@@ -252,7 +252,7 @@ def test_md5ok_str(db_setup):
 def test_dstcopy(db_setup_with_copy):
     """Test successful transfer with existing destination copy record."""
 
-    io, copy, req, start_time, post_add, dstcopy = db_setup_with_copy
+    io, _, req, start_time, post_add, dstcopy = db_setup_with_copy
 
     assert (
         copy_request_done(

--- a/tests/io/test_lustrehsmgroup.py
+++ b/tests/io/test_lustrehsmgroup.py
@@ -123,7 +123,7 @@ def test_idle(queue, group):
         assert group.idle is False
 
         # Dequeue it
-        task, key = queue.get()
+        queue.get()
         queue.task_done(node.io.fifo)
 
         # Now idle again

--- a/tests/io/test_transport.py
+++ b/tests/io/test_transport.py
@@ -167,7 +167,7 @@ def test_idle(queue, transport_fleet):
     assert group.idle is False
 
     # Dequeue it
-    task, key = queue.get()
+    queue.get()
     queue.task_done(nodes[2].io.fifo)
 
     # Now idle again
@@ -280,7 +280,7 @@ def test_pull_nonode(req, archivefilecopy, transport_fleet):
 def test_pull_search(transport_fleet, simplecopyrequest, queue):
     """Test task submission in TransportGroupIO.pull_search()."""
 
-    group, nodes = transport_fleet
+    group, _ = transport_fleet
 
     # The patch is done in io.default, where the pull_search method
     # is actually defined.
@@ -306,7 +306,7 @@ def test_pull_search(transport_fleet, simplecopyrequest, queue):
 def test_group_search_dispatch(transport_fleet, dbtables, simplecopyrequest, queue):
     """Test group_search_async dispatch to pull"""
 
-    group, nodes = transport_fleet
+    group, _ = transport_fleet
 
     mock = MagicMock()
     group.io.pull = mock

--- a/tests/scheduler/test_queue.py
+++ b/tests/scheduler/test_queue.py
@@ -15,7 +15,7 @@ def clean_queue(queue):
     # Check that the queue is clean by pulling everything out
     count = 0
     while queue.qsize > 0:
-        item, key = queue.get()
+        _, key = queue.get()
         queue.task_done(key)
         count += 1
 
@@ -122,7 +122,7 @@ def test_concurrency(clean_queue):
     # Consumer thread
     def consumer(clean_queue):
         for i in range(100):
-            item, key = clean_queue.get()
+            _, key = clean_queue.get()
             clean_queue.task_done(key)
 
     # Create a bunch of consumers
@@ -240,7 +240,7 @@ def test_clear_nokeep(clean_queue):
     assert clean_queue.qsize == 1
 
     # Clean up
-    item, key = clean_queue.get()
+    _, key = clean_queue.get()
     clean_queue.task_done(key)
 
 
@@ -282,11 +282,11 @@ def test_clear_pending(clean_queue):
     assert clean_queue.fifo_size("fifo") == 0
 
     # Remove the rest
-    item, key = clean_queue.get()
+    _, key = clean_queue.get()
     clean_queue.task_done(key)
-    item, key = clean_queue.get()
+    _, key = clean_queue.get()
     clean_queue.task_done(key)
-    item, key = clean_queue.get()
+    _, key = clean_queue.get()
     clean_queue.task_done(key)
 
 

--- a/tests/scheduler/test_task.py
+++ b/tests/scheduler/test_task.py
@@ -188,7 +188,7 @@ def test_exclusive_task(queue):
     assert queue.qsize == 3
 
     # Pop the first task
-    task, key = queue.get(timeout=0.1)
+    _, key = queue.get(timeout=0.1)
 
     # Can't pop the second task yet
     assert queue.get(timeout=0.1) is None
@@ -197,7 +197,7 @@ def test_exclusive_task(queue):
     queue.task_done(key)
 
     # Now we can get the second task
-    task, key = queue.get(timeout=0.1)
+    _, key = queue.get(timeout=0.1)
 
     # Fail to get the third task because
     # we're now executing an exclusive task
@@ -207,7 +207,7 @@ def test_exclusive_task(queue):
     queue.task_done(key)
 
     # Now we can get the third task
-    item, key = queue.get(timeout=0.1)
+    _, key = queue.get(timeout=0.1)
     queue.task_done(key)
 
     # Everything's taken care of


### PR DESCRIPTION
Fixes complaints by the new version of `ruff`.