### PR TITLE
feat(schema_version): Implement rich comparisons

### DIFF
--- a/alpenhorn/db/data_index.py
+++ b/alpenhorn/db/data_index.py
@@ -7,6 +7,7 @@ itself.
 from __future__ import annotations
 
 import logging
+import operator
 
 import click
 import peewee as pw
@@ -44,55 +45,86 @@ class DataIndexVersion(base_model):
     version = pw.IntegerField()
 
 
+def _op_and_vers(comp: str):
+    """Decompose a string of the form <op><int>.
+
+    Raises ValueError on failure.
+    """
+
+    # We could probably do this parameterically, but there's only four of them.
+    if comp.startswith("<="):
+        return operator.le, int(comp[2:])
+    if comp.startswith(">="):
+        return operator.ge, int(comp[2:])
+    if comp.startswith("<"):
+        return operator.lt, int(comp[1:])
+    if comp.startswith(">"):
+        return operator.gt, int(comp[1:])
+    raise ValueError("unknown operator")
+
+
 def schema_version(
     *,
     check: bool = False,
     component: str | None = None,
-    component_version: int | None = None,
-) -> int:
+    component_version: str | int | None = None,
+    return_check: bool = False,
+) -> int | bool:
     """Report and optionally check Data Index schema version
 
     By default, this function returns the schema version of the
     Data Index in the database.  This function can also be used
-    to check for a particular version and raise an exception if
-    a version mismatch is encountered.
+    to check for a particular version and return the result or
+    raise an exception if a version mismatch is encountered.
 
-    All parameters must be specified by keyword.
+    All parameters are optional and must be specified by keyword.
 
     Parameters
     ----------
-    check:
+    check : bool, optional
         If True, check that the alpenhorn Data Index schema version
         is equal to `alpenhorn.db.current_version` and raise an
         exception if it isn't.  If this is True, the other parameters
         to this function are ignored.  Setting this to True is equivalent
         to setting `component` to "alpenhorn" and `component_version` to
         `alpenhorn.db.current_version`.
-    component:
+    component : str or None, optional
         The name of the schema component to report/check.  Setting this
         to `None` (the default) is equivalent to setting it to "alpenhorn".
-    component_version:
-        If not `None`, raise an exception if the schema version of the
-        component specified by `component` is not equal to this value.
-        If `component` is not present in the DataIndexVersion table, this
-        check always fails.
+    component_version : str or int or None, optional
+        If not `None`, check that the the schema version of the component
+        specified by `component` is not equal to this value.  If `component`
+        is not present in the DataIndexVersion table, the check always fails,
+        the schema version used for the check is implicitly zero.  If this
+        is an `int`, that exact schema version is required.  Otherwise, it may
+        be a string of the form: "<OP><int>" or "<OP><int>,<OP><int>" specifying
+        a schema range to check.  The "<OP>" should be one of "=", ">", ">=",
+        "<", or "<=".  In the two operator case, one operator must indicate
+        a minimum version and the other must indicate a maximum version, e.g.
+        e.g.  "<8,>=2" or ">2,<5"
+    return_check : bool, optional
+        If True, and a check is requested, return the boolean result of the
+        check, instead of the version of the indicated component.  If this
+        is True but no check has been requested, `ValueError` is raised.
+        The defalt is False.
 
     Returns
     -------
-    version : int
-        The schema version of the specified component, or of the alpenhorn
-        Data Index itself, if no other component was specified.  If this
-        function was requested to check the version (because `check` or
-        `component_version` was set), this will always equal the target
-        version (because any other version will result in an exception, instead).
+    int or bool
+        If `return_check` is True, this is the boolean result of the requested
+        check.  Otherwise, this is the schema version of the specified component,
+        or of the alpenhorn Data Index itself, if no other component was specified.
         If the `component` was not listed in the DataIndexVersion table, zero
         is returned.
 
     Raises
     ------
+    ValueError:
+        No check was requested, but `return_check` was True, or "component_version"
+        couldn't be parsed.
     click.ClickException:
-        A check was requested and the check failed, or there was an error
-        trying to read from the database.
+        A check was requested with `return_check` False, and the check failed,
+        or there was an error trying to read from the database.
     """
     # Special case for check
     if check:
@@ -100,6 +132,10 @@ def schema_version(
         component_version = current_version
     elif not component:
         component = "alpenhorn"
+
+    # Check return_check makes sense
+    if return_check and not component_version:
+        raise ValueError("return_check is True, but no check has been requested")
 
     # Fetch version for component
     try:
@@ -130,25 +166,76 @@ def schema_version(
     else:
         schema_vers = 0
 
-    # Check, if requested
-    if component_version is not None:
-        # Importantly here: if `schema` is None, this check always fails
-        # (i.e. even if the caller were to have passed component_version=0)
-        if not schema or schema_vers != component_version:
-            # There's a special message for alpenhorn itself
-            if component == "alpenhorn":
-                lead = "Data Index version mismatch"
+    # If no check, we're done
+    if component_version is None:
+        return schema_vers
+
+    # Otherwise, start checking
+    check_failed = False
+
+    # Is component_version a simple int?
+    try:
+        version1 = int(component_version)
+        op = operator.eq
+    except ValueError:
+        version1 = None
+
+    # If component_version wasn't an int, we'll need to parse it
+    if version1 is None:
+        # Split on commas
+        comparisons = component_version.split(",")
+
+        if len(comparisons) > 2:
+            raise ValueError(f"bad schema version: {component_version}")
+
+        # Decode the first (and maybe only) comparison
+        try:
+            op, version1 = _op_and_vers(comparisons[0])
+
+            # Decode the second comparison, if present
+            if len(comparisons) > 1:
+                op2, version2 = _op_and_vers(comparisons[1])
             else:
-                lead = f'Schema version mismatch for Data Index component "{component}"'
+                op2 = None
+        except ValueError as e:
+            raise ValueError(f"bad schema version: {component_version}") from e
 
-            wanted = f"wanted version {component_version}"
+        # If we have two checks, make sure they're opposite
+        if op2:
+            if op == operator.lt or op == operator.le:
+                if op2 != operator.ge and op2 != operator.gt:
+                    raise ValueError(f"bad schema version: {component_version}")
+            if op == operator.gt or op == operator.ge:
+                if op2 != operator.le and op2 != operator.lt:
+                    raise ValueError(f"bad schema version: {component_version}")
 
-            if schema:
-                found = f"found version {schema_vers}"
-            else:
-                found = "no schema found"
+            # Do the second check, first (with "not" to ensure check_failed is a bool)
+            check_failed = not op2(schema_vers, version2)
 
-            raise click.ClickException(f"{lead}:  {wanted}; {found}")
+    # Do the first check, if the second one didn't fail
+    if not check_failed:
+        check_failed = not op(schema_vers, version1)
 
-    # Check, if performed, succeeded.  Return found version
+    # If we were requested to return the result of the check, do that now
+    if return_check:
+        return not check_failed
+
+    # Otherwise, compose the clickException on error
+    if check_failed:
+        # There's a special message for alpenhorn itself
+        if component == "alpenhorn":
+            lead = "Data Index version mismatch"
+        else:
+            lead = f'Schema version mismatch for Data Index component "{component}"'
+
+        wanted = f"wanted version {component_version}"
+
+        if schema:
+            found = f"found version {schema_vers}"
+        else:
+            found = "no schema found"
+
+        raise click.ClickException(f"{lead}:  {wanted}; {found}")
+
+    # Finally, return the schema version
     return schema_vers


### PR DESCRIPTION
This retools the `schema_version` function in `alpenhorn.db` to permit specifying "rich" comparisons for component schema versions along the lines of "<3" or ">=2" or even, ">1,<4".  (All schema versions are integers).

This functionality is provided for third-party extensions which may need to decide some things about the database schema they have access to.

The only notable change from the previous behaviour is: previously if you asked to check the schema version for a missing component, the check would always fail, regardless of the value you specified in `component_version`.  Now, the schema version for such a missing component is simply treated as zero, and comparison proceeds as normal.