### PR TITLE
fix: Don't double-cache the database extension

### DIFF
--- a/alpenhorn/db/__init__.py
+++ b/alpenhorn/db/__init__.py
@@ -42,7 +42,7 @@ from .archive import ArchiveFileCopy, ArchiveFileCopyRequest, ArchiveFileImportR
 from .storage import StorageGroup, StorageNode, StorageTransferAction
 
 # Basic functionality
-from ._base import connect, close, database_proxy, threadsafe
+from ._base import connect, close, database_proxy, set_extension, threadsafe
 
 # Prototypes
 from ._base import EnumField, base_model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def set_config(request, logger):
 
     # Reset globals
     config._config = None
-    extload._db_ext = None
+    db._base._db_ext = None
     extload._id_ext = None
     extload._io_ext = {}
 


### PR DESCRIPTION
The database extension used to be cached in both `common.db._base` and in `common.extload`, in slightly different forms.  This worked in practice, but was probably more confusing than necessary.

So, now the database extension only gets stored in `common.db._base`.