### PR TITLE
fix(task): Re-check DB connection after pulls

### DIFF
--- a/alpenhorn/daemon/scheduler/pool.py
+++ b/alpenhorn/daemon/scheduler/pool.py
@@ -65,8 +65,12 @@ class Worker(threading.Thread):
         global_abort event which will result in a clean-as-possible exit of
         all of alpenhornd.
         """
+        from ...db import database_proxy
 
         log.info("Started.")
+
+        # Connect to the database, if necessary
+        database_proxy.connect(reuse_if_open=True)
 
         # Put the worker id in `threadlocal`, so tasks can access it
         global threadlocal

--- a/alpenhorn/io/default/pull.py
+++ b/alpenhorn/io/default/pull.py
@@ -591,6 +591,10 @@ def pull_async(
     # Delete the placeholder, if we created it
     placeholder.unlink(missing_ok=True)
 
+    # How long did that take?  Let's recheck the database connection, just in case,
+    # before trying to do the update
+    task.db_check()
+
     if not req.finish(
         io.node,
         io.storage_used,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def mock_filesize():
 
 
 @pytest.fixture
-def queue():
+def queue(dbproxy):
     """A test queue."""
     yield FairMultiFIFOQueue()
 


### PR DESCRIPTION
If a pull takes too long, sometimes the subsequent DB updates will fail because the DB server has closed the connection due to inactivity.

Previously, this would result in OperationError when the update was attempted, causing the worker to bail on the job.  This meant that the the worker wouldn't report the pull as complete, meaning it would be redone (and maybe crash again, if the reattempt also took so long that the DB connection was closed).

This adds a new Task method, `Task.db_check` which can be called from within the running task to check the DB connection and re-open if it it has been closed.  The default pull task now does this after a pull finishes (successfully or not) but before trying to update the database.

I've deployed this change to fir, and it at minimum doesn't cause issues but, of course, we're not running in to the problem anymore, so I can't check that it actually does recover from this situation.

Also: Tasks now expect the database proxy to be initialised. Previously, some of the tests of the scheduler per se could be run without a configured database at all, but no longer, so the `queue` test fixture now requires the `dbproxy` fixture.