### PR TITLE
fix(daemon): Set `alpenhorn_worker_count` metric directly

### DIFF
--- a/alpenhorn/daemon/update.py
+++ b/alpenhorn/daemon/update.py
@@ -972,6 +972,11 @@ def update_loop(
         description="Group is available (active and initialized)",
         unbound={"name"},
     )
+    worker_count_metric = Metric(
+        "worker_count",
+        description="Number of worker threads",
+        bound={"pool_type": type(pool).__name__},
+    )
 
     while not global_abort.is_set():
         loop_start = time.time()
@@ -1114,8 +1119,10 @@ def update_loop(
         loop_time = time.time() - loop_start
         log.info(f"Main loop execution was {util.pretty_deltat(loop_time)}.")
 
+        # Update metrics
         loop_time_metric.set(loop_time)
         loop_count_metric.inc()
+        worker_count_metric.set(len(pool))
 
         # Pool and queue info
         log.info(


### PR DESCRIPTION
Instead of incrementing and decrementing this metric in the worker pool, as workers are added and removed, let's just set it to the actual value every time we do a main-loop update so it can't get out-of-sync. Closes #356.

I suspect the original problem in the linked issue arose from the metric not being properly decremented when a worker terminated abnormally and got restarted.  This way, though, there's no need to do any of that explicit bookkeeping on the worker count.