### PR TITLE
refactor(daemon): Internalise host determination

### DIFF
--- a/alpenhorn/common/metrics.py
+++ b/alpenhorn/common/metrics.py
@@ -56,9 +56,9 @@ class Metric:
         underlying metric.
 
         All metric instances will automatically bind the label "daemon" to the
-        current hostname (the value returned by `util.get_hostname()`) unless the
-        `bound` dict already binds that label to something else.  (As a result,
-        "daemon" can never appear in the `unbound` set.)
+        daemon's hostname unless the `bound` dict already binds that label to
+        something else.  (As a result, "daemon" can never appear in the
+        `unbound` set.)
 
         Newly-created metrics are implicitly set to zero, but they won't actually
         be reported until their value is explicitly set/updated.
@@ -92,9 +92,10 @@ class Metric:
         # Bind the "daemon" label if not already bound
         self._bound_labels = dict(bound)
         if "daemon" not in self._bound_labels:
-            from .util import get_hostname
+            from ..daemon import host
 
-            self._bound_labels["daemon"] = get_hostname()
+            daemon_host = host()
+            self._bound_labels["daemon"] = daemon_host if daemon_host else "(unknown)"
 
         # keys in "bound" can't also appear in "unbound"
         for key in self._bound_labels.keys():

--- a/alpenhorn/common/util.py
+++ b/alpenhorn/common/util.py
@@ -6,7 +6,6 @@ import asyncio
 import hashlib
 import logging
 import os
-import socket
 import subprocess
 from collections.abc import Callable
 from typing import Any
@@ -366,16 +365,6 @@ def md5sum_file(filename: str | os.PathLike) -> str | None:
     metric.dec()
 
     return result
-
-
-def get_hostname() -> str:
-    """Returns the hostname for the machine we're running on.
-
-    If there is a host name specified in the config, that is returned
-    otherwise the local hostname up to the first '.' is returned"""
-
-    hostname = config.get("base.hostname", default=None, as_type=str)
-    return hostname if hostname else socket.gethostname().split(".")[0]
 
 
 def pretty_bytes(num: int | None) -> str:

--- a/alpenhorn/daemon/__init__.py
+++ b/alpenhorn/daemon/__init__.py
@@ -2,6 +2,7 @@
 
 from .. import __version__
 from .entry import entry
+from .update import host
 
 # These classes are used by extensions, so let's import them into the daemon
 # base

--- a/alpenhorn/db/storage.py
+++ b/alpenhorn/db/storage.py
@@ -161,10 +161,11 @@ class StorageNode(base_model):
 
     @property
     def local(self) -> bool:
-        from ..common import util
-
         """Is this node local to where we are running?"""
-        return self.host == util.get_hostname()
+        from ..daemon import host
+
+        # If daemon.host is None, this always returns False.
+        return host and self.host == host()
 
     @property
     def archive(self) -> bool:

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -52,19 +52,6 @@ def test_md5sum_file(tmp_path):
     assert util.md5sum_file(file) == "9e107d9d372bb6826bd81d3542a419d6"
 
 
-def test_gethostname_config(hostname):
-    """Test util.get_hostname with config"""
-
-    assert util.get_hostname() == hostname
-
-
-def test_gethostname_default():
-    """Test util.get_hostname with no config"""
-    host = util.get_hostname()
-    assert "." not in host
-    assert len(host) > 0
-
-
 def test_pretty_bytes():
     """Test util.pretty_bytes."""
     with pytest.raises(TypeError):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -484,11 +484,19 @@ def hostname(set_config):
 
     Returns the hostname."""
 
+    import alpenhorn.daemon.update
+
     config._config = config.merge_dict_tree(
         config._config, {"base": {"hostname": "alpenhost"}}
     )
 
-    return "alpenhost"
+    # Set the daemon hostname, too
+    alpenhorn.daemon.update._host = "alpenhost"
+
+    yield "alpenhost"
+
+    # Reset global
+    alpenhorn.daemon.update._host = None
 
 
 @pytest.fixture

--- a/tests/daemon/test_update.py
+++ b/tests/daemon/test_update.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from alpenhorn.daemon import host as daemon_host
 from alpenhorn.daemon import update
 from alpenhorn.daemon.scheduler import FairMultiFIFOQueue, Task, pool
 from alpenhorn.db import StorageGroup, StorageNode
@@ -42,6 +43,33 @@ def mock_serial_io(dbtables):
     mock = MagicMock()
     with patch("alpenhorn.daemon.update.serial_io", mock):
         yield mock
+
+
+def test_sethost_config(hostname):
+    """Test setting daemon host with config"""
+
+    # The "hostname" fixture has already set the host in daemon.update
+    # let's temporarily undo that
+    update._host = None
+
+    # Check that resetting worked
+    assert daemon_host() is None
+
+    # Now set it again via the normal daemon method.
+    result = update._set_host()
+    assert result == hostname
+
+    assert daemon_host() == hostname
+
+
+def test_sethost_default():
+    """Test setting daemon host with no config"""
+    result = update._set_host()
+
+    assert "." not in result
+    assert len(result) > 0
+
+    assert daemon_host() == result
 
 
 def test_update_abort():


### PR DESCRIPTION
The erstwhile `get_hostname` function is one of these ancient things whose use has changed over time.  These days, the concept of the "current host" is only relevant within the daemon (because all the I/O got removed from the CLI).

I suppose, even within the daemon, because of the legacy behaviour of generating a hostname from the system hostname, problems could arise if the hostname of the machine changed while the daemon was running, resulting in discrepancy between cached and not-cached versions values returned by `get_hostname`.

This refactors this function to be an internal part of the daemon.  The daemon will update the value of the hostname once per update loop, and other parts of the daemon now can consult this main-loop-managed value by calling `daemon.host`, rather than computing the hostname independently.

In part, this refactor is trying to make future enhancements less involved:
* The update-once-a-loop change is to make #42 easier to implement, if we ever get round to that (though I guess it also handles the unlikely case of system hostname changing).
* Hiding the details of determining what value `daemon.host` takes is to make #209 easier to implement, which is probably a higher priority.