### PR TITLE
refactor(db): Replace StorageNode.storage_type with StorageNode.archive

### DIFF
--- a/alpenhorn/cli/node/create.py
+++ b/alpenhorn/cli/node/create.py
@@ -12,7 +12,6 @@ from ..options import (
     exactly_one,
     resolve_group,
     set_io_config,
-    set_storage_type,
 )
 
 
@@ -47,11 +46,6 @@ from ..options import (
     is_flag=True,
 )
 @cli_option(
-    "field",
-    help="Make node a field node (i.e. neither an archive node nor a transport "
-    "node).  This is the default.  Incompatible with --archive or --transport.",
-)
-@cli_option(
     "group",
     help="Add node to Storage Group GROUP, which must already exist.  "
     "Incompatible with --create-group",
@@ -66,7 +60,6 @@ from ..options import (
 @cli_option("min_avail", default=0, show_default=True)
 @cli_option("notes")
 @cli_option("root")
-@cli_option("transport")
 @cli_option("username")
 def create(
     node_name,
@@ -77,7 +70,6 @@ def create(
     auto_verify,
     io_class,
     create_group,
-    field,
     group,
     host,
     init,
@@ -87,7 +79,6 @@ def create(
     min_avail,
     notes,
     root,
-    transport,
     username,
 ):
     """Create a new Storage Node.
@@ -97,12 +88,6 @@ def create(
     All node must be part of a Storage Group.  Specify an existing Storage
     Group with --group, or else create a single-node group called NAME for
     this node with --create-group.
-
-    When the node is created, it must be assigned a role.  Use --archive to
-    specify an archive node, or --transport for transport nodes.  Using neither
-    of these flags makes the node a field node, which is the default.  The
-    --field flag can be used to explicitly indicate this, but that is not
-    required.
 
     A note on the distinction between HOST and ADDR: the host specifies which
     alpenhorn server instance is responsible for managing the node.  the address
@@ -119,7 +104,6 @@ def create(
         raise click.UsageError("--min-avail must be non-negative")
 
     io_config = set_io_config(io_config, io_var, {})
-    storage_type = set_storage_type(archive, field, transport)
 
     with database_proxy.atomic():
         # Check name
@@ -149,7 +133,7 @@ def create(
             active=activate,
             auto_import=auto_import,
             auto_verify=auto_verify,
-            storage_type=storage_type,
+            archive=archive,
             max_total_gb=max_total,
             min_avail_gb=min_avail,
             notes=notes,

--- a/alpenhorn/cli/node/list.py
+++ b/alpenhorn/cli/node/list.py
@@ -20,8 +20,6 @@ from ..options import cli_option, resolve_group
 def list_(active, group, host):
     """List Storage Nodes."""
 
-    roles = {"A": "archive", "F": "-", "T": "transport"}
-
     data = []
     nodes = StorageNode.select().join(StorageGroup)
 
@@ -39,7 +37,7 @@ def list_(active, group, host):
             (
                 node.name,
                 node.group.name,
-                roles.get(node.storage_type, "???"),
+                "Yes" if node.archive else "No",
                 node.io_class,
                 node.host,
                 "Yes" if node.active else "No",
@@ -52,7 +50,7 @@ def list_(active, group, host):
         headers = [
             "Name",
             "Group",
-            "Role",
+            "Archive",
             "I/O Class",
             "Host",
             "Active",

--- a/alpenhorn/cli/node/show.py
+++ b/alpenhorn/cli/node/show.py
@@ -48,13 +48,6 @@ def show(name, actions, all_, imports, stats, transfers):
 
     node = resolve_node(name)
 
-    if node.storage_type == "A":
-        type_name = "Archive"
-    elif node.storage_type == "T":
-        type_name = "Transport"
-    else:
-        type_name = "-"
-
     if node.max_total_gb and node.max_total_gb > 0:
         max_total = pretty_bytes(node.max_total_gb * 2**30)
     else:
@@ -74,7 +67,7 @@ def show(name, actions, all_, imports, stats, transfers):
     echo("   Storage Node: " + node.name)
     echo("  Storage Group: " + node.group.name)
     echo("         Active: " + ("Yes" if node.active else "No"))
-    echo("           Type: " + type_name)
+    echo("        Archive: " + ("Yes" if node.archive else "No"))
     echo("          Notes: " + (node.notes if node.notes else ""))
     echo("      I/O Class: " + (node.io_class if node.io_class else "Default"))
     echo()

--- a/alpenhorn/cli/options.py
+++ b/alpenhorn/cli/options.py
@@ -41,11 +41,10 @@ def cli_option(option: str, **extra_kwargs):
         args = ("all_", "--all", "-a")
         kwargs = {"is_flag": True}
     elif option == "archive":
-        args = ("--archive",)
+        args = ("--archive/--no-archive",)
         kwargs = {
             "is_flag": True,
-            "help": "Make node an archive node.  Incompatible with --field "
-            "or --transport.",
+            "help": "Make node an archive node / or (the default) not an archive node.",
         }
     elif option == "archive_ok":
         args = ("--archive-ok",)
@@ -68,13 +67,6 @@ def cli_option(option: str, **extra_kwargs):
             "-x",
         )
         kwargs = {"is_flag": True, "help": "Cancel the operation"}
-    elif option == "field":
-        args = ("--field",)
-        kwargs = {
-            "is_flag": True,
-            "help": "Make node a field node (i.e. neither an archive node "
-            "nor a transport node).  Incompatible with --archive or --transport.",
-        }
     elif option == "file_list":
         args = ("-F", "--file-list")
         kwargs = {
@@ -186,13 +178,6 @@ def cli_option(option: str, **extra_kwargs):
         kwargs = {
             "metavar": "DEST_GROUP",
             "help": "Destination Group for the transfer.",
-        }
-    elif option == "transport":
-        args = ("--transport",)
-        kwargs = {
-            "is_flag": True,
-            "help": "Make node a transport node.  Incompatible with --archive "
-            "or --field.",
         }
     elif option == "username":
         args = ("--username",)
@@ -533,37 +518,6 @@ def files_in_groups(
                 break
 
     return group_files
-
-
-def set_storage_type(
-    archive: bool, field: bool, transport: bool, none_ok: bool = False
-) -> str | None:
-    """Set node storage_type.
-
-    Processes the --archive, --field, --transport options.
-
-    Returns one of 'A', 'F', 'T', depending on which of the options is set.
-
-    If none of the options are set, None is returned if `none_ok` is True, otherwise
-    the default 'F' is returned.
-
-    Raises a click.UsageError if more than one flag is set.
-    """
-
-    # Usage checks
-    not_both(archive, "archive", field, "field")
-    not_both(archive, "archive", transport, "transport")
-    not_both(field, "field", transport, "transport")
-
-    if archive:
-        return "A"
-    if transport:
-        return "T"
-    if not field and none_ok:
-        return None
-
-    # Default
-    return "F"
 
 
 def set_io_config(

--- a/alpenhorn/db/acquisition.py
+++ b/alpenhorn/db/acquisition.py
@@ -74,7 +74,7 @@ class ArchiveFile(base_model):
             self.copies.join(StorageNode)
             .select()
             .where(
-                StorageNode.storage_type == "A",
+                StorageNode.archive == 1,
                 ArchiveFileCopy.has_file == "Y",
             )
             .count()

--- a/alpenhorn/db/storage.py
+++ b/alpenhorn/db/storage.py
@@ -11,7 +11,7 @@ import random
 import peewee as pw
 from peewee import fn
 
-from ._base import EnumField, base_model
+from ._base import base_model
 from .acquisition import ArchiveFile
 
 log = logging.getLogger(__name__)
@@ -122,11 +122,8 @@ class StorageNode(base_model):
         If greater than zero, automatically re-verify file copies on this
         node during times of no other activity.  The value is the maximum
         number of files that will be re-verified per update loop.
-    storage_type : enum
-        What is the type of storage?
-        - 'A': archival storage
-        - 'T': transiting storage
-        - 'F': all other storage (i.e acquisition machines)
+    archive : boolenum
+        Is this an archive node?
     max_total_gb : float
         The maximum amout of storage we should use.
     min_avail_gb : float
@@ -153,7 +150,7 @@ class StorageNode(base_model):
     active = pw.BooleanField(default=False)
     auto_import = pw.BooleanField(default=False)
     auto_verify = pw.IntegerField(default=0)
-    storage_type = EnumField(["A", "T", "F"], default="A")
+    archive = pw.BooleanField(default=False)
     max_total_gb = pw.FloatField(null=True)
     min_avail_gb = pw.FloatField(default=0)
     avail_gb = pw.FloatField(null=True)
@@ -168,11 +165,6 @@ class StorageNode(base_model):
 
         # If daemon.host is None, this always returns False.
         return host and self.host == host()
-
-    @property
-    def archive(self) -> bool:
-        """Is this node an archival node?"""
-        return self.storage_type == "A"
 
     @property
     def under_min(self) -> bool:

--- a/alpenhorn/io/transport.py
+++ b/alpenhorn/io/transport.py
@@ -22,9 +22,8 @@ class TransportGroupIO(DefaultGroupIO):
     storage.
 
     Features of a Transport StorageGroup:
-        - it may have any number of nodes.  All node must have
-            node.db.storage_type == 'T', but no restrictions are put on the
-            io_class of nodes
+        - it may have any number of non-archival nodes.  No restrictions are put
+            on the io_class of nodes
         - all pulls to the StorageGroup must be local: non-local pull
             requests will be ignored
         - when handling pull requests, transport nodes are prioritised by
@@ -61,8 +60,7 @@ class TransportGroupIO(DefaultGroupIO):
     def nodes(self, nodes: list[UpdateableNode]) -> None:
         """nodes setter
 
-        This checks that nodes in group are transport nodes
-        (storage_type == "T").
+        This checks that nodes in group are not archive nodes.
 
         Parameters
         ----------
@@ -72,13 +70,13 @@ class TransportGroupIO(DefaultGroupIO):
         Raises
         ------
         ValueError
-            none of the supplied `nodes` were Transport nodes.
+            all of the supplied `nodes` were rejected for being archive nodes.
         """
         self._nodes = []
         for node in nodes:
-            if node.db.storage_type != "T":
+            if node.db.archive:
                 log.warning(
-                    f'Ignoring non-transport node "{node.name}" '
+                    f'Ignoring archive node "{node.name}" '
                     f'in Transport Group "{self.group.name}"'
                 )
             else:

--- a/doc/demo.rst
+++ b/doc/demo.rst
@@ -965,7 +965,7 @@ node by checking its metadata after the ``modify`` command:
       Storage Node: demo_storage1
      Storage Group: demo_storage1
             Active: Yes
-              Type: -
+           Archive: Yes
              Notes:
          I/O Class: Default
 
@@ -1146,7 +1146,7 @@ alpenhorn CLI:
       Storage Node: demo_storage2
      Storage Group: demo_storage2
             Active: No
-              Type: -
+           Archive: Yes
              Notes:
          I/O Class: Default
 
@@ -1725,7 +1725,7 @@ whether it can delete that file.
 Archive nodes
 ~~~~~~~~~~~~~
 
-An archive node is any storage node with the "archive" storage type.
+An archive node is any storage node with the "archive" flag set.
 Let's change ``demo_storage2`` into an archive node. We do that by
 modifying it's metadata:
 
@@ -1735,7 +1735,7 @@ modifying it's metadata:
    alpenhorn node modify --archive demo_storage2
 
 After running this command, you can look at the node metadata to see
-that it now has the "archive" storage type:
+that it now has the "archive" flag set:
 
 .. code:: console
    :class: demoshell
@@ -1746,7 +1746,7 @@ that it now has the "archive" storage type:
       Storage Node: demo_storage2
      Storage Group: demo_storage2
             Active: Yes
-              Type: Archive
+           Archive: Yes
              Notes:
          I/O Class: Default
 
@@ -2114,7 +2114,7 @@ Auto-clean actions can be seen in the metadata for the node or group:
       Storage Node: demo_storage1
      Storage Group: demo_storage1
             Active: Yes
-              Type: -
+           Archive: No
              Notes:
          I/O Class: Default
 
@@ -2298,13 +2298,8 @@ available on ``alpenhost3``:
 .. code:: console
    :class: demoshell
 
-   alpenhorn node create transport1 --transport --group transport_group --host=alpenhost3 \
+   alpenhorn node create transport1 --group transport_group --host=alpenhost3 \
                                     --root=/mnt/transport --init --activate
-
-Note the use of the ``--transport`` flag to set the node's storage type
-to "transport". The "Transport" Group I/O class allows StorageNodes of
-any class to be added to the group, but requires all such nodes to have
-the "transport" storage type.
 
 The filesystem has already been made available in the ``alpenhost3``
 container, so wait for the daemon on ``alpenhost3`` to initialise the node:

--- a/tests/cli/file/test_clean.py
+++ b/tests/cli/file/test_clean.py
@@ -13,7 +13,7 @@ def test_no_cancel_node(clidb, cli):
     """Must have at least one of --cancel or --node"""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -26,7 +26,7 @@ def test_cancel_now(clidb, cli):
     """Can't use --now and --cancel together"""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -39,7 +39,7 @@ def test_missing_file(clidb, cli):
     """Test a bad path."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -52,7 +52,7 @@ def test_missing_node(clidb, cli):
     """Test a bad node name."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -65,8 +65,8 @@ def test_clean(clidb, cli):
     """Test M-cleaning."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
-    node2 = StorageNode.create(name="Node2", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
+    node2 = StorageNode.create(name="Node2", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -83,7 +83,7 @@ def test_no_change(clidb, cli):
     """Test no change."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -98,7 +98,7 @@ def test_now(clidb, cli):
     """Test --now."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -113,7 +113,7 @@ def test_archive(clidb, cli):
     """Test archive node."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="A")
+    node = StorageNode.create(name="Node", group=group, archive=True)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -129,7 +129,7 @@ def test_archive_ok(clidb, cli):
     """Test archive node forcing."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="A")
+    node = StorageNode.create(name="Node", group=group, archive=True)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -144,7 +144,7 @@ def test_cancel(clidb, cli):
     """Test archive node forcing."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -159,8 +159,8 @@ def test_cancel_no_node(clidb, cli):
     """Test archive node forcing."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="Node", group=group, storage_type="F")
-    node2 = StorageNode.create(name="Node2", group=group, storage_type="F")
+    node = StorageNode.create(name="Node", group=group, archive=False)
+    node2 = StorageNode.create(name="Node2", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -177,8 +177,8 @@ def test_absent(clidb, cli):
     """Test file absent from node."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="Node", group=group, storage_type="F")
-    node2 = StorageNode.create(name="Node2", group=group, storage_type="F")
+    StorageNode.create(name="Node", group=group, archive=False)
+    node2 = StorageNode.create(name="Node2", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)
@@ -193,8 +193,8 @@ def test_cancel_absent(clidb, cli):
     """Test cancel with file absent from node."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="Node", group=group, storage_type="F")
-    node2 = StorageNode.create(name="Node2", group=group, storage_type="F")
+    StorageNode.create(name="Node", group=group, archive=False)
+    node2 = StorageNode.create(name="Node2", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
     file_ = ArchiveFile.create(name="File", acq=acq)

--- a/tests/cli/node/test_clean.py
+++ b/tests/cli/node/test_clean.py
@@ -22,7 +22,7 @@ def test_cancel_now(clidb, cli):
     """Test --cancel --now fails."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="NODE", group=group, storage_type="F")
+    StorageNode.create(name="NODE", group=group, archive=False)
 
     cli(2, ["node", "clean", "NODE", "--cancel", "--now"])
 
@@ -31,7 +31,7 @@ def test_cancel_size(clidb, cli):
     """Test --cancel --size fails."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="NODE", group=group, storage_type="F")
+    StorageNode.create(name="NODE", group=group, archive=False)
 
     cli(2, ["node", "clean", "NODE", "--cancel", "--size=3"])
 
@@ -40,7 +40,7 @@ def test_check_force(clidb, cli):
     """Test --check --force fails."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="NODE", group=group, storage_type="F")
+    StorageNode.create(name="NODE", group=group, archive=False)
 
     cli(2, ["node", "clean", "NODE", "--check", "--force"])
 
@@ -49,7 +49,7 @@ def test_bad_days(clidb, cli):
     """Test non-positive --days."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="NODE", group=group, storage_type="F")
+    StorageNode.create(name="NODE", group=group, archive=False)
 
     cli(2, ["node", "clean", "NODE", "--days=0"])
     cli(2, ["node", "clean", "NODE", "--days=-1"])
@@ -59,7 +59,7 @@ def test_bad_size(clidb, cli):
     """Test non-positive --size."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="NODE", group=group, storage_type="F")
+    StorageNode.create(name="NODE", group=group, archive=False)
 
     cli(2, ["node", "clean", "NODE", "--size=0"])
     cli(2, ["node", "clean", "NODE", "--size=-1"])
@@ -69,7 +69,7 @@ def test_run(clidb, cli):
     """Test a simple clean."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq")
     fileYY = ArchiveFile.create(name="FileYY", acq=acq, size_b=2345)
     ArchiveFileCopy.create(node=node, file=fileYY, has_file="Y", wants_file="Y")
@@ -93,7 +93,7 @@ def test_now(clidb, cli):
     """Test clean --now."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq")
     fileY = ArchiveFile.create(name="FileY", acq=acq, size_b=4567)
     ArchiveFileCopy.create(node=node, file=fileY, has_file="Y", wants_file="Y")
@@ -110,7 +110,7 @@ def test_cancel(clidb, cli):
     """Test clean --cancel."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq")
     fileM = ArchiveFile.create(name="FileM", acq=acq, size_b=6789)
     ArchiveFileCopy.create(node=node, file=fileM, has_file="Y", wants_file="M")
@@ -128,7 +128,7 @@ def test_check(clidb, cli):
     """Test clean --check."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq")
     file = ArchiveFile.create(name="File", acq=acq, size_b=2345)
     ArchiveFileCopy.create(node=node, file=file, has_file="Y", wants_file="Y")
@@ -143,7 +143,7 @@ def test_force(clidb, cli):
     """Test clean --force."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq")
     file = ArchiveFile.create(name="File", acq=acq, size_b=3456)
     ArchiveFileCopy.create(node=node, file=file, has_file="Y", wants_file="Y")
@@ -158,7 +158,7 @@ def test_archive(clidb, cli):
     """Test clean on an archive node."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="A")
+    node = StorageNode.create(name="NODE", group=group, archive=True)
     acq = ArchiveAcq.create(name="Acq")
     file = ArchiveFile.create(name="File", acq=acq, size_b=4567)
     ArchiveFileCopy.create(node=node, file=file, has_file="Y", wants_file="Y")
@@ -173,7 +173,7 @@ def test_archive_ok(clidb, cli):
     """Test clean on an archive node with --archive-ok."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="A")
+    node = StorageNode.create(name="NODE", group=group, archive=True)
     acq = ArchiveAcq.create(name="Acq")
     file = ArchiveFile.create(name="File", acq=acq, size_b=5678)
     ArchiveFileCopy.create(node=node, file=file, has_file="Y", wants_file="Y")
@@ -188,7 +188,7 @@ def test_bad_target(clidb, cli):
     """Test clean with a non-exsitent target."""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq")
     file = ArchiveFile.create(name="File", acq=acq, size_b=6789)
     ArchiveFileCopy.create(node=node, file=file, has_file="Y", wants_file="Y")
@@ -203,7 +203,7 @@ def test_target(clidb, cli):
     """Test clean with some targets."""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     target1 = StorageGroup.create(name="Target1")
     tnode1 = StorageNode.create(name="TNode1", group=target1)
     target2 = StorageGroup.create(name="Target2")
@@ -252,7 +252,7 @@ def test_empty_target(clidb, cli):
     """Test clean with no files in the target."""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     target1 = StorageGroup.create(name="Target1")
     tnode1 = StorageNode.create(name="TNode1", group=target1)
     target2 = StorageGroup.create(name="Target2")
@@ -289,7 +289,7 @@ def test_bad_acq(clidb, cli):
     """Test clean with a non-exsitent acq."""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq")
     file = ArchiveFile.create(name="File", acq=acq, size_b=4567)
     ArchiveFileCopy.create(node=node, file=file, has_file="Y", wants_file="Y")
@@ -304,7 +304,7 @@ def test_acq(clidb, cli):
     """Test clean with some acq."""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
 
     # File1 is in Acq1
     acq1 = ArchiveAcq.create(name="Acq1")
@@ -333,7 +333,7 @@ def test_empty_acq(clidb, cli):
     """Test clean with no files in target acq."""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
 
     # File1 is in Acq1
     acq1 = ArchiveAcq.create(name="Acq1")
@@ -361,7 +361,7 @@ def test_days(clidb, cli):
     now = utcnow()
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
 
@@ -395,7 +395,7 @@ def test_size(clidb, cli):
     """Test clean with --size"""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
 
@@ -421,7 +421,7 @@ def test_size_part(clidb, cli):
     """Test clean with --size partially satisfied"""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
 
@@ -447,7 +447,7 @@ def test_size_done(clidb, cli):
     """Test clean with --size already satisfied"""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
 
@@ -473,7 +473,7 @@ def test_include_bad(clidb, cli):
     """Test clean with --include-bad"""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
 
     acq = ArchiveAcq.create(name="Acq")
 
@@ -496,7 +496,7 @@ def test_file_list(clidb, cli, xfs):
     """Test clean with --file-list"""
 
     group = StorageGroup.create(name="Group1")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F", root="/NODE")
+    node = StorageNode.create(name="NODE", group=group, archive=False, root="/NODE")
 
     acq = ArchiveAcq.create(name="Acq")
 

--- a/tests/cli/node/test_create.py
+++ b/tests/cli/node/test_create.py
@@ -74,7 +74,7 @@ def test_create_default(clidb, cli):
     assert not node.auto_import
     assert node.auto_verify == 0
     assert node.min_avail_gb == 0
-    assert node.storage_type == "F"
+    assert not node.archive
 
 
 def test_with_group(clidb, cli):
@@ -163,45 +163,16 @@ def test_archive(clidb, cli):
     cli(0, ["node", "create", "TEST", "--archive", "--create-group"])
 
     node = StorageNode.get(name="TEST")
-    assert node.storage_type == "A"
+    assert node.archive
 
 
-def test_field(clidb, cli):
-    """Test creating a field node with explicit --field"""
+def test_no_archive(clidb, cli):
+    """Test creating a field node with explicit --no-archive"""
 
-    cli(0, ["node", "create", "TEST", "--field", "--create-group"])
-
-    node = StorageNode.get(name="TEST")
-    assert node.storage_type == "F"
-
-
-def test_transport(clidb, cli):
-    """Test creating a transport node"""
-
-    cli(0, ["node", "create", "TEST", "--transport", "--create-group"])
+    cli(0, ["node", "create", "TEST", "--no-archive", "--create-group"])
 
     node = StorageNode.get(name="TEST")
-    assert node.storage_type == "T"
-
-
-def test_multirole(clidb, cli):
-    """Test various combinations of multiple role flags."""
-
-    cli(2, ["node", "create", "TEST", "--archive", "--field", "--create-group"])
-    cli(2, ["node", "create", "TEST", "--archive", "--transport", "--create-group"])
-    cli(2, ["node", "create", "TEST", "--field", "--transport", "--create-group"])
-    cli(
-        2,
-        [
-            "node",
-            "create",
-            "TEST",
-            "--archve",
-            "--field",
-            "--transport",
-            "--create-group",
-        ],
-    )
+    assert not node.archive
 
 
 def test_set_all(clidb, cli):

--- a/tests/cli/node/test_list.py
+++ b/tests/cli/node/test_list.py
@@ -10,11 +10,11 @@ def some_nodes(clidb):
     """Define some nodes to list"""
 
     group = StorageGroup.create(name="Group1")
-    StorageNode.create(name="Node1", group=group, storage_type="F")
+    StorageNode.create(name="Node1", group=group, archive=False)
     StorageNode.create(
         name="Node2",
         group=group,
-        storage_type="A",
+        archive=True,
         io_class="Class2",
         notes="Note2",
         active=True,
@@ -25,7 +25,7 @@ def some_nodes(clidb):
     StorageNode.create(
         name="Node3",
         group=group,
-        storage_type="T",
+        archive=False,
         active=False,
         host="Host2",
         root="/Node3",
@@ -51,12 +51,12 @@ def test_list(some_nodes, cli, assert_row_present):
     """Test listing nodes."""
 
     result = cli(0, ["node", "list"])
-    assert_row_present(result.output, "Node1", "Group1", "-", "", "", "No", "", "")
+    assert_row_present(result.output, "Node1", "Group1", "No", "", "", "No", "", "")
     assert_row_present(
         result.output,
         "Node2",
         "Group1",
-        "archive",
+        "Yes",
         "Class2",
         "Host2",
         "Yes",
@@ -64,7 +64,7 @@ def test_list(some_nodes, cli, assert_row_present):
         "Note2",
     )
     assert_row_present(
-        result.output, "Node3", "Group2", "transport", "", "Host2", "No", "/Node3", ""
+        result.output, "Node3", "Group2", "No", "", "Host2", "No", "/Node3", ""
     )
 
 
@@ -77,7 +77,7 @@ def test_active(some_nodes, cli, assert_row_present):
         result.output,
         "Node2",
         "Group1",
-        "archive",
+        "Yes",
         "Class2",
         "Host2",
         "Yes",
@@ -91,10 +91,10 @@ def test_inactive(some_nodes, cli, assert_row_present):
     """Test limit --inactive."""
 
     result = cli(0, ["node", "list", "--inactive"])
-    assert_row_present(result.output, "Node1", "Group1", "-", "", "", "No", "", "")
+    assert_row_present(result.output, "Node1", "Group1", "No", "", "", "No", "", "")
     assert "Node2" not in result.output
     assert_row_present(
-        result.output, "Node3", "Group2", "transport", "", "Host2", "No", "/Node3", ""
+        result.output, "Node3", "Group2", "No", "", "Host2", "No", "/Node3", ""
     )
 
 
@@ -107,7 +107,7 @@ def test_host(some_nodes, cli, assert_row_present):
         result.output,
         "Node2",
         "Group1",
-        "archive",
+        "Yes",
         "Class2",
         "Host2",
         "Yes",
@@ -115,7 +115,7 @@ def test_host(some_nodes, cli, assert_row_present):
         "Note2",
     )
     assert_row_present(
-        result.output, "Node3", "Group2", "transport", "", "Host2", "No", "/Node3", ""
+        result.output, "Node3", "Group2", "No", "", "Host2", "No", "/Node3", ""
     )
 
 
@@ -123,12 +123,12 @@ def test_group(some_nodes, cli, assert_row_present):
     """Test limit --group."""
 
     result = cli(0, ["node", "list", "--group=Group1"])
-    assert_row_present(result.output, "Node1", "Group1", "-", "", "", "No", "", "")
+    assert_row_present(result.output, "Node1", "Group1", "No", "", "No", "", "")
     assert_row_present(
         result.output,
         "Node2",
         "Group1",
-        "archive",
+        "Yes",
         "Class2",
         "Host2",
         "Yes",

--- a/tests/cli/node/test_verify.py
+++ b/tests/cli/node/test_verify.py
@@ -19,7 +19,7 @@ def file_gamut(clidb):
         (has_file, wants_file, ArchiveFileCopy)
     """
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq")
     files = []
     for has in ["Y", "M", "X", "N"]:
@@ -41,7 +41,7 @@ def test_check_force(clidb, cli):
     """Test --check --force fails."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="NODE", group=group, storage_type="F")
+    StorageNode.create(name="NODE", group=group, archive=False)
 
     cli(2, ["node", "verify", "NODE", "--check", "--force"])
 
@@ -50,7 +50,7 @@ def test_cancel_multistatus(clidb, cli):
     """Test --cancel with multiple statuses chosen."""
 
     group = StorageGroup.create(name="Group")
-    StorageNode.create(name="NODE", group=group, storage_type="F")
+    StorageNode.create(name="NODE", group=group, archive=False)
 
     cli(2, ["node", "verify", "NODE", "--cancel", "--corrupt", "--healthy"])
     cli(2, ["node", "verify", "NODE", "--cancel", "--corrupt", "--missing"])
@@ -343,7 +343,7 @@ def test_verify_acq(clidb, cli):
     """Test verify with some --acq constraints."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F")
+    node = StorageNode.create(name="NODE", group=group, archive=False)
     acq = ArchiveAcq.create(name="Acq1")
     file1 = ArchiveFile.create(name="File", acq=acq)
     ArchiveFileCopy.create(node=node, file=file1, has_file="X", wants_file="Y")
@@ -366,7 +366,7 @@ def test_file_list(clidb, cli, xfs):
     """Test verify with --file-list."""
 
     group = StorageGroup.create(name="Group")
-    node = StorageNode.create(name="NODE", group=group, storage_type="F", root="/NODE")
+    node = StorageNode.create(name="NODE", group=group, archive=False, root="/NODE")
     acq = ArchiveAcq.create(name="Acq")
     file1 = ArchiveFile.create(name="File1", acq=acq)
     ArchiveFileCopy.create(node=node, file=file1, has_file="X", wants_file="Y")

--- a/tests/daemon/test_entry.py
+++ b/tests/daemon/test_entry.py
@@ -78,6 +78,7 @@ def e2e_db(xfs, clidb_noinit, hostname):
         root="/dft",
         host=hostname,
         active=True,
+        archive=True,
         auto_import=True,
     )
     xfs.create_file("/dft/ALPENHORN_NODE", contents="dftnode")
@@ -89,7 +90,6 @@ def e2e_db(xfs, clidb_noinit, hostname):
     fleet = StorageGroup.create(name="fleet", io_class="Transport")
     tp1 = StorageNode.create(
         name="tp1",
-        storage_type="T",
         group=fleet,
         root="/tp/one",
         host=hostname,
@@ -97,7 +97,6 @@ def e2e_db(xfs, clidb_noinit, hostname):
     )
     tp2 = StorageNode.create(
         name="tp2",
-        storage_type="T",
         group=fleet,
         root="/tp/two",
         host=hostname,
@@ -118,6 +117,7 @@ def e2e_db(xfs, clidb_noinit, hostname):
         root="/nl1",
         host=hostname,
         active=True,
+        archive=True,
         avail_gb=2000.0 / 2**30,
         io_config=(
             '{"quota_id": "qid", "quota_type": "project", '
@@ -125,7 +125,7 @@ def e2e_db(xfs, clidb_noinit, hostname):
         ),
     )
     sf1 = StorageNode.create(
-        name="sf1", group=nlgrp, root="/sf1", host=hostname, active=True
+        name="sf1", group=nlgrp, root="/sf1", host=hostname, active=True, archive=True
     )
     xfs.create_file("/sf1/ALPENHORN_NODE", contents="sf1")
 

--- a/tests/daemon/test_update_group.py
+++ b/tests/daemon/test_update_group.py
@@ -189,9 +189,6 @@ def test_update_group_copy_state(
     mockio.group.exists.return_value = None
 
     # Dest is a transport group
-    node.db.storage_type = "T"
-    node.db.save()
-
     group.db.io_class = "Transport"
     group.db.save()
 

--- a/tests/daemon/test_update_node.py
+++ b/tests/daemon/test_update_node.py
@@ -538,7 +538,7 @@ def test_update_delete_under_min(unode, simpleacq, archivefile, archivefilecopy)
     # Force under min and not archive
     unode.db.avail_gb = 5
     unode.db.min_avail_gb = 10
-    unode.db.storage_type = "F"
+    unode.db.archive = False
     assert unode.db.under_min
     assert not unode.db.archive
 

--- a/tests/db/test_acquisition.py
+++ b/tests/db/test_acquisition.py
@@ -95,49 +95,49 @@ def test_archive_count(simplegroup, storagenode, simplefile, archivefilecopy):
     # Create a bunch of copies in various states on various node types
     archivefilecopy(
         file=simplefile,
-        node=storagenode(name="n1", group=simplegroup, storage_type="A"),
+        node=storagenode(name="n1", group=simplegroup, archive=True),
         has_file="N",
     )
     assert simplefile.archive_count == 0
     archivefilecopy(
         file=simplefile,
-        node=storagenode(name="n2", group=simplegroup, storage_type="F"),
+        node=storagenode(name="n2", group=simplegroup, archive=False),
         has_file="Y",
     )
     assert simplefile.archive_count == 0
     archivefilecopy(
         file=simplefile,
-        node=storagenode(name="n3", group=simplegroup, storage_type="T"),
+        node=storagenode(name="n3", group=simplegroup, archive=False),
         has_file="Y",
     )
     assert simplefile.archive_count == 0
     archivefilecopy(
         file=simplefile,
-        node=storagenode(name="n4", group=simplegroup, storage_type="F"),
+        node=storagenode(name="n4", group=simplegroup, archive=False),
         has_file="Y",
     )
     assert simplefile.archive_count == 0
     archivefilecopy(
         file=simplefile,
-        node=storagenode(name="n5", group=simplegroup, storage_type="A"),
+        node=storagenode(name="n5", group=simplegroup, archive=True),
         has_file="Y",
     )
     assert simplefile.archive_count == 1
     archivefilecopy(
         file=simplefile,
-        node=storagenode(name="n6", group=simplegroup, storage_type="A"),
+        node=storagenode(name="n6", group=simplegroup, archive=True),
         has_file="X",
     )
     assert simplefile.archive_count == 1
     archivefilecopy(
         file=simplefile,
-        node=storagenode(name="n7", group=simplegroup, storage_type="A"),
+        node=storagenode(name="n7", group=simplegroup, archive=True),
         has_file="M",
     )
     assert simplefile.archive_count == 1
     archivefilecopy(
         file=simplefile,
-        node=storagenode(name="n8", group=simplegroup, storage_type="A"),
+        node=storagenode(name="n8", group=simplegroup, archive=True),
         has_file="Y",
     )
     assert simplefile.archive_count == 2

--- a/tests/db/test_storage_node.py
+++ b/tests/db/test_storage_node.py
@@ -27,6 +27,7 @@ def test_storage_model(storagegroup, storagenode):
         group=group,
         active=True,
         address="addr.addr",
+        archive=True,
         auto_import=True,
         auto_verify=1,
         avail_gb=2.2,
@@ -38,7 +39,6 @@ def test_storage_model(storagegroup, storagenode):
         min_avail_gb=5.5,
         notes="Notes",
         root="/root",
-        storage_type="T",
         username="user",
     )
 
@@ -53,6 +53,7 @@ def test_storage_model(storagegroup, storagenode):
         "group": group.id,
         "active": False,
         "address": None,
+        "archive": False,
         "auto_import": False,
         "auto_verify": 0,
         "avail_gb": None,
@@ -64,7 +65,6 @@ def test_storage_model(storagegroup, storagenode):
         "min_avail_gb": 0,
         "notes": None,
         "root": None,
-        "storage_type": "A",
         "username": None,
     }
 
@@ -74,6 +74,7 @@ def test_storage_model(storagegroup, storagenode):
         "group": group.id,
         "active": True,
         "address": "addr.addr",
+        "archive": True,
         "auto_import": True,
         "auto_verify": 1,
         "avail_gb": 2.2,
@@ -85,7 +86,6 @@ def test_storage_model(storagegroup, storagenode):
         "min_avail_gb": 5.5,
         "notes": "Notes",
         "root": "/root",
-        "storage_type": "T",
         "username": "user",
     }
 
@@ -98,18 +98,6 @@ def test_local(simplenode, hostname):
 
     simplenode.host = "other-host"
     assert not simplenode.local
-
-
-def test_archive_property(simplegroup, storagenode):
-    """Test the StorageNode.archive boolean."""
-    node = storagenode(name="a", group=simplegroup, storage_type="A")
-    assert node.archive is True
-
-    node = storagenode(name="f", group=simplegroup, storage_type="F")
-    assert node.archive is False
-
-    node = storagenode(name="t", group=simplegroup, storage_type="T")
-    assert node.archive is False
 
 
 def test_undermin(simplegroup, storagenode):

--- a/tests/io/default/test_delete.py
+++ b/tests/io/default/test_delete.py
@@ -39,7 +39,7 @@ def test_ncopies(
     simpleacq,
     archivefile,
     archivefilecopy,
-    storage_type="F",
+    archive=False,
 ):
     """Test not deleting from non-archival node
     when there are not enough other copies of the file."""
@@ -47,11 +47,11 @@ def test_ncopies(
     # Need to make the containing directory
     xfs.create_dir("/node/simpleacq")
 
-    unode.db.storage_type = storage_type
+    unode.db.archive = archive
     unode.db.save()
 
-    arc1 = storagenode(name="arc1", group=simplegroup, root="/arc1", storage_type="A")
-    arc2 = storagenode(name="arc2", group=simplegroup, root="/arc2", storage_type="A")
+    arc1 = storagenode(name="arc1", group=simplegroup, root="/arc1", archive=True)
+    arc2 = storagenode(name="arc2", group=simplegroup, root="/arc2", archive=True)
 
     # Can't be deleted from node: only one archive copy
     file1 = archivefile(name="file1", acq=simpleacq)
@@ -113,7 +113,7 @@ def test_ncopies_archive(
         simpleacq,
         archivefile,
         archivefilecopy,
-        storage_type="A",
+        archive=True,
     )
 
 

--- a/tests/io/default/test_pull.py
+++ b/tests/io/default/test_pull.py
@@ -89,7 +89,9 @@ def test_req(
     group_to = storagegroup(name="group_to")
     node_to = UpdateableNode(
         queue,
-        storagenode(name="node_to", group=group_to, host=hostname, root="/node_to"),
+        storagenode(
+            name="node_to", group=group_to, host=hostname, root="/node_to", archive=True
+        ),
     )
     node_from = storagenode(
         name="node_from",
@@ -99,6 +101,7 @@ def test_req(
         username="user",
         address="addr",
         active=True,
+        archive=True,
     )
 
     copy = archivefilecopy(file=simplefile, node=node_from, has_file="Y")
@@ -378,7 +381,7 @@ def test_pull_async_link_arccontam(queue, pull_async_true, skip_db_checks):
     node, _ = pull_async_true
 
     # Make one node non-archival
-    node.db.storage_type = "F"
+    node.db.archive = False
 
     # Call the async
     task, key = queue.get()
@@ -403,7 +406,7 @@ def test_pull_async_local_rsync_succeed(
     node, req = pull_async_true
 
     # Make one node non-archival to avoid hardlinking
-    node.db.storage_type = "F"
+    node.db.archive = False
 
     # Call the async
     task, key = queue.get()
@@ -435,7 +438,7 @@ def test_pull_async_local_rsync_fail(
     node, req = pull_async_true
 
     # Make one node non-archival to avoid hardlinking
-    node.db.storage_type = "F"
+    node.db.archive = False
 
     # Call the async
     task, key = queue.get()
@@ -470,7 +473,7 @@ def test_pull_fail_unlink(xfs, queue, have_rsync, pull_async_true, skip_db_check
     assert path.exists()
 
     # Force hardlinking to fail
-    node.db.storage_type = "T"
+    node.db.archive = False
 
     # Call the async
     task, key = queue.get()
@@ -581,7 +584,7 @@ def test_pull_async_path_local_copy(xfs, dbtables, test_req, queue, skip_db_chec
     unode, req = test_req
 
     # Make one node non-archival to avoid hardlinking
-    unode.db.storage_type = "F"
+    unode.db.archive = False
 
     # Destination path
     dest = pathlib.Path("/dest/path")
@@ -602,7 +605,7 @@ def test_pull_async_path_rsync(
     unode, req = test_req
 
     # Make one node non-archival to avoid hardlinking
-    unode.db.storage_type = "F"
+    unode.db.archive = False
 
     # Destination path
     dest = pathlib.Path("/dest/path")

--- a/tests/io/test_lustrehsmgroup.py
+++ b/tests/io/test_lustrehsmgroup.py
@@ -19,7 +19,7 @@ def group(xfs, mock_lfs, hostname, queue, storagegroup, storagenode):
             name="hsm",
             io_class="LustreHSM",
             group=stgroup,
-            storage_type="A",
+            archive=True,
             root="/hsm",
             host=hostname,
             io_config='{"quota_id": "qid", "quota_type": "group", "headroom": 10250}',
@@ -30,7 +30,7 @@ def group(xfs, mock_lfs, hostname, queue, storagegroup, storagenode):
         storagenode(
             name="smallfile",
             group=stgroup,
-            storage_type="A",
+            archive=True,
             root="/smallfile",
             host=hostname,
         ),

--- a/tests/io/test_transport.py
+++ b/tests/io/test_transport.py
@@ -38,10 +38,10 @@ def transport_fleet_no_init(xfs, hostname, queue, storagegroup, storagenode):
             storagenode(
                 name="node1",
                 group=stgroup,
-                storage_type="T",
                 avail_gb=10,
                 root="/node1",
                 host=hostname,
+                archive=False,
             ),
         ),
         UpdateableNode(
@@ -49,10 +49,10 @@ def transport_fleet_no_init(xfs, hostname, queue, storagegroup, storagenode):
             storagenode(
                 name="node2",
                 group=stgroup,
-                storage_type="T",
                 avail_gb=20,
                 root="/node2",
                 host=hostname,
+                archive=False,
             ),
         ),
         UpdateableNode(
@@ -60,10 +60,10 @@ def transport_fleet_no_init(xfs, hostname, queue, storagegroup, storagenode):
             storagenode(
                 name="node3",
                 group=stgroup,
-                storage_type="T",
                 avail_gb=40,
                 root="/node3",
                 host=hostname,
+                archive=False,
             ),
         ),
         UpdateableNode(
@@ -71,10 +71,10 @@ def transport_fleet_no_init(xfs, hostname, queue, storagegroup, storagenode):
             storagenode(
                 name="node4",
                 group=stgroup,
-                storage_type="T",
                 avail_gb=None,
                 root="/node4",
                 host=hostname,
+                archive=False,
             ),
         ),
     ]
@@ -135,7 +135,7 @@ def test_group_init_bad(transport_fleet_no_init, queue):
 
     # Change all the nodes to not be transport nodes.
     for node in nodes:
-        node.db.storage_type = "F"
+        node.db.archive = True
 
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=nodes, idle=True)
     assert group.io.nodes == []
@@ -146,8 +146,8 @@ def test_group_init_mixed(transport_fleet_no_init, queue):
     stgroup, nodes = transport_fleet_no_init
 
     # Change _some_ of the nodes to non-transport
-    nodes[0].db.storage_type = "A"
-    nodes[3].db.storage_type = "F"
+    nodes[0].db.archive = True
+    nodes[3].db.archive = True
 
     group = UpdateableGroup(queue=queue, group=stgroup, nodes=nodes, idle=True)
     assert group.io.nodes == nodes[1:3]


### PR DESCRIPTION
This replaces the three-valued enum `StorageNode.storage_type` with a simple boolean called `StorageNode.archive`.

In the alpenhorn-1 days, `storage_type` had three values:
  * "A" for archive nodes
  * "T" for transport nodes
  * "F" for everything else ("field" nodes)

This was needed because the transport disk logic was special-cased in alpenhorn-1 and triggered on `storage_type == 'T'`.  In Alpenhorn-2, after the I/O rewrite, transport logic is now handled by the "Transport" I/O class, meaning the "T" value for `storage_type` lost its usefulness.

So now all `storage_type` is doing is indicating whether a node is an archive node or not, and it's going to be less confusing if we just change this into a boolean value in the database.  (In part, it removes the confusion over what a "field node" is.  See #49 ). And alpenhorn-1 is no longer blocking us from doing this.

(Note: the Transport group I/O _did_ reject nodes if they didn't have storage_type "T", but I did this mostly to give `storage_type="T"` a purpose, an not because I ever found it to be helpful.)

Closes #338 

Specific changes
----------------

* Replaced the `StorageNode.storage_type` EnumField with a `StorageNode.archive` BooleanField.
* Deleted the `StorageNode.archive` property which was simply returning `storage_type == "A"`.  Because this property, was already working like the new "archive" field does, there's little actual code that needs to be updated here.
* Deleted the --transport flag and renamed the --field flag to --no-archive in "node create" and "node modify"
* Deleted the now-unused helper function `cli.options.set_storage_type`
* In "node show", replaced the "Type" entry with a "Archive" flag entry.
* The `TransportGroupIO.nodes` setter now rejects nodes with the archive bit set.
* Updated the demo script.