### PR TITLE
feat(daemon): Add daemon.archive_copy_count to config

### DIFF
--- a/alpenhorn/common/config.py
+++ b/alpenhorn/common/config.py
@@ -112,7 +112,17 @@ Example config:
         # Minimum time length (in seconds) between updates
         update_interval: 60
 
-        # Timescale on which to poll the filesystem for new data to import
+        # Minimum number of copies of a file which must exist on archive nodes
+        # before any other copy of the file can be deleted.
+        #
+        # WARNING: Setting this to a value smaller than two violates the
+        # alpenhorn daemon's data integrity rules.  To acknowledge this and
+        # run with a value less that two, you will need to add to the daemon
+        # invocation the "--disable-archive-integrity" flag.
+        archive_copy_count: 2
+
+        # Period (in seconds) at which to poll the filesystem for new files to
+        # import.
         auto_import_interval: 30
 
         # Minimum number of days to wait from the last update of a file copy
@@ -149,7 +159,7 @@ Example config:
         # error will be triggered if the number of _consecutive_ main loops
         # where such a third-party update is detected equals or exceeds this
         # value.  Setting this to a zero disables the check.
-       update_skew_threshold: 4
+        update_skew_threshold: 4
 """
 
 from __future__ import annotations

--- a/alpenhorn/daemon/entry.py
+++ b/alpenhorn/daemon/entry.py
@@ -34,6 +34,15 @@ sys.excepthook = log_exception
     metavar="FILE",
 )
 @click.option(
+    "no_integrity",
+    "--disable-archive-integrity",
+    is_flag=True,
+    help="Allow use of an alpenhorn config which violates alpenhorn's normal "
+    'data protection rules.  Specifically, if the "daemon.archive_copy_count" '
+    "is set to a value less than two, this flag is required to let the daemon "
+    "run in a mode where it cannot guarantee file preservation.",
+)
+@click.option(
     "once",
     "--exit-after-update",
     "-o",
@@ -52,7 +61,7 @@ sys.excepthook = log_exception
 @version_option
 @help_config_option
 @click.pass_context
-def entry(ctx, conf, once, test_isolation):
+def entry(ctx, conf, no_integrity, once, test_isolation):
     """Alpenhornd: data management daemon.
 
     The alpenhorn daemon can be used to manage Storage Nodes.  See the alpenhorn
@@ -70,6 +79,18 @@ def entry(ctx, conf, once, test_isolation):
 
     # Initialise alpenhorn
     start_alpenhorn(conf, cli=False)
+
+    # Warn about or bail if archive_copy_count is too small at start-up
+    if config.get_int("daemon.archive_copy_count", default=2, min=0) < 2:
+        log.error(
+            'Config parameter "daemon.archive_copy_count" too small '
+            "to guarantee archive integrity"
+        )
+        if not no_integrity:
+            raise click.ClickException(
+                "FATAL.  Data protection rules not satisfied and "
+                "--disable-archive-integrity not used."
+            )
 
     # Start the prometheus client, if appropriate.
     if not once:

--- a/alpenhorn/daemon/update.py
+++ b/alpenhorn/daemon/update.py
@@ -558,29 +558,14 @@ class UpdateableNode(updateable_base):
             )
             .order_by(ArchiveFileCopy.id)
         ):
-            # Only delete files marked for discretionary cleaning (wants_file == 'M')
-            # when we need to get back over min_avail_gb.  Because avail_needed
-            # decreases as we add files to the file deletion list, we'll never delete
+            # Check the database to see if this file can be deleted
+            #
+            # The value of "discretionary" here means we'll only delete files
+            # marked for discretionary cleaning (wants_file == 'M') when we need
+            # to get back over min_avail_gb.  Because avail_needed decreases as
+            # we add files to the file deletion list, we'll never try to delete
             # more of these than the amount of space we need to clear up.
-            if copy.wants_file == "M" and avail_needed <= 0:
-                continue
-
-            # Don't delete file copies which are the source for pending
-            # copy requests
-            if (
-                ArchiveFileCopyRequest.select()
-                .where(
-                    ArchiveFileCopyRequest.file == copy.file,
-                    ArchiveFileCopyRequest.node_from == self.db,
-                    ArchiveFileCopyRequest.completed == 0,
-                    ArchiveFileCopyRequest.cancelled == 0,
-                )
-                .count()
-            ):
-                log.info(
-                    f"Skipping delete of {copy.file.path} on node {self.name}: "
-                    "transfer pending"
-                )
+            if not copy.check_delete(discretionary=(avail_needed > 0)):
                 continue
 
             # If we are trying to get back above min_avail_gb, keep a running total

--- a/alpenhorn/db/archive.py
+++ b/alpenhorn/db/archive.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 
 import peewee as pw
 
-from ..common import util
+from ..common import config, util
 from ._base import EnumField, base_model, database_proxy
 from .acquisition import ArchiveFile
 from .storage import StorageGroup, StorageNode, StorageTransferAction
@@ -109,6 +109,72 @@ class ArchiveFileCopy(base_model):
 
         key = self.has_file + self.wants_file
         return states.get(key, "Corrupt")
+
+    def check_delete(self, discretionary: bool = True) -> bool:
+        """Check whether this copy can be deleted.
+
+        Checks the data index to determine whether this copy can
+        be deleted from its node.
+
+        Parameters
+        ----------
+        discretionary : bool
+            If False, don't allow deletion of files marked for discretionary
+            cleaning (``wants_file='M'``).  Defaults to True.
+
+        Returns
+        bool
+            True if this copy can be deleted.  False otherwise.
+        """
+
+        # Has deletion been requested?
+        if self.wants_file == "Y" or (self.wants_file == "M" and not discretionary):
+            return False
+
+        # Can't delete files that aren't present
+        if self.has_file == "N":
+            return False
+
+        # How many archive copies do we need before we're allowed to delete this
+        # file copy?
+        archive_copies_needed = config.get_int(
+            "daemon.archive_copy_count", default=2, min=0
+        )
+
+        archive_count = self.file.archive_count
+        # If this copy is on an archive node itself, it does't count towards the
+        # archive count
+        if self.node.archive and self.has_file == "Y":
+            archive_count -= 1
+
+        # Don't delete files which aren't fully archived
+        if archive_count < archive_copies_needed:
+            log.info(
+                "Too few archive copies "
+                f"({archive_count} < {archive_copies_needed}) to delete "
+                f"{self.file.path} on node {self.node.name}"
+            )
+            return False
+
+        # Don't delete file copies which are the source for pending
+        # copy requests
+        if (
+            ArchiveFileCopyRequest.select()
+            .where(
+                ArchiveFileCopyRequest.file == self.file,
+                ArchiveFileCopyRequest.node_from == self.node,
+                ArchiveFileCopyRequest.completed == 0,
+                ArchiveFileCopyRequest.cancelled == 0,
+            )
+            .first()
+        ):
+            log.info(
+                f"Skipping delete of {self.file.path} on node {self.node.name}: "
+                "transfer pending"
+            )
+            return False
+
+        return True
 
     def trigger_autoactions(self) -> None:
         """Trigger auto actions for this file copy.

--- a/alpenhorn/io/default/delete.py
+++ b/alpenhorn/io/default/delete.py
@@ -101,24 +101,13 @@ def delete_async(
     # Node name
     name = copies[0].node.name
 
-    # The number archive copies needed to delete a copy.
-    # Need at least two _other_ copies to be able to delete a file.
-    copies_required = 3 if copies[0].node.archive else 2
-
     # Process candidates for deletion
     for copy in copies:
-        shortname = copy.file.path
-
-        # Archived count
-        ncopies = copy.file.archive_count
-
-        # If at least two _other_ copies exist, we can delete the file.
-        if ncopies < copies_required:
-            log.warning(
-                f"Too few archive copies ({ncopies}) to delete {shortname} on {name}."
-            )
+        # Re-run database checks
+        if not copy.check_delete():
             continue  # Skip this one
 
+        shortname = copy.file.path
         fullpath = copy.path
         try:
             fullpath.unlink()  # Remove the actual file

--- a/examples/alpenhorn.conf
+++ b/examples/alpenhorn.conf
@@ -1,0 +1,168 @@
+---
+# This is an example alpenhorn config file.  Alpenhorn config files are YAML
+# files.
+#
+# At minimum, alpenhorn requires the config to specify the database connection
+# details, either through the "database" section, or else by providing the path
+# to an alpenhorn extension module providing a DatabaseExtension (or both).
+
+# Alpenhorn extension modules, as a list of fully-qualified references to python
+# packages or modules.  Each extension module listed here will be imported into
+# alpenhorn on start-up and must provide a function called "register_extensions"
+# which returns a list of Alpenhorn Extension instances.
+extensions:
+  - alpenhorn.generic
+  - alpenhorn_chime
+  - chimedb.core.alpenhorn
+
+# Configure the database connection.  By default you should specify the
+# connection details to your database here via a peewee "db_url" URI.  See:
+#
+#    http://docs.peewee-orm.com/en/latest/peewee/db_tools.html#module-playhouse.db_url
+#
+# If using an Alpenhorn DatabaseExtension, the contents of this section are
+# passed to that extension, which may have different requirements for the data
+# in this section.
+database:
+  url: mysql://dbuser:dbpassword@database.server.com/alpenhorn_dbname
+
+# Configure the operation of the local daemon
+daemon:
+    # The daemon host name used to determine which StorageNodes are locally
+    # available to the daemon.  If this value is not given, a daemon instance
+    # will attempt to guess the value by looking at the hostname of the machine
+    # it's running on.
+    #
+    # Regardless of whether the daemon host is explicitly or implicitly determined,
+    # it must match the name of one of the StorageHosts in the data index for the
+    # daemon to successfully start up.
+    host: alpenhost
+
+    # Initial number of worker threads
+    num_workers: 4
+
+    # Minimum time length (in seconds) between updates
+    update_interval: 60
+
+    # Minimum number of copies of a file which must exist on archive nodes
+    # before any other copy of the file can be deleted.
+    #
+    # WARNING: Setting this to a value smaller than two violates the
+    # alpenhorn daemon's data integrity rules.  To acknowledge this violation,
+    # but still run with a value less that two, you will need to add to the
+    # daemon invocation the "--disable-archive-integrity" flag.
+    archive_copy_count: 2
+
+    # Period (in seconds) at which to poll the filesystem for new files to
+    # import, when auto-import is turned on for a node.
+    auto_import_interval: 30
+
+    # Minimum number of days to wait from the last update of a file copy
+    # record before auto-verifying the file, when auto-verify is turned on
+    # for a node.
+    auto_verify_min_days: 7
+
+    # Maximum time (in seconds) to run serial I/O per update loop.  Serial
+    # I/O is only performed in cases when there are no worker threads to
+    # handle I/O tasks.
+    serial_io_timeout: 900
+
+    # These two parameters control how long a transfer job is allowed to
+    # run before being forceably killed.  The timeout (in seconds) for a
+    # pull of a file of size "size_b" bytes is:
+    #
+    #   pull_timeout_base + size_b / pull_bytes_per_second
+    #
+    # If pull_bytes_per_second is zero, the timeout is disabled (the
+    # job will rum forever if it doesn't exit; not recommended).
+    pull_timeout_base: 300
+    pull_bytes_per_second: 20000000
+
+    # Prometheus client port.  Setting this to a positive value will
+    # cause the daemon to start the prometheus client HTTP server to
+    # serve GET requests on that port (but only when not running in
+    # --exit-after-update mode).  If not set, or set to a non-positive
+    # value, then the prometheus client is not started.
+    prom_client_port: 8080
+
+    # Node update-skew threshold.  Normally, the daemon will exit with an
+    # error if it detects some other process regularly updating one of the
+    # nodes it is managing.  This is designed to catch instances where
+    # multiple copies of the daemon have been spawned for some reason.  The
+    # error will be triggered if the number of _consecutive_ main loops
+    # where such a third-party update is detected equals or exceeds this
+    # value.  Setting this to zero disables the check.
+    update_skew_threshold: 4
+
+# Daemon logging configuration.  By default, the daemon sends all log message to
+# standard error.
+logging:
+    # Set the logging level of the Python root logger
+    level: warning
+
+    # Allow overriding the level on a module by module basis
+    module_levels:
+        alpenhorn: info
+        alpenhorn.db: debug
+
+    # Alpenhorn can be configured to send log output to syslog and/or
+    # a file.  This is _in addition_ to the log sent to standard error,
+    # which is always enabled.
+
+    # Syslog logging.
+    syslog:
+        # If true, enable logging to syslog.  Note: if the "syslog" section
+        # is present in the logging config, then the default value of this
+        # is true.  As a result, this key need only be specified if none of
+        # the other syslog configuration parameters are provided in the config.
+        enable: true
+
+        # The network address to send syslog message to.
+        #
+        # May also be a Unix domain socket (like "/dev/log").  In that case,
+        # set `port`, below, to zero to indicate this.
+        #
+        # Defaults to "localhost".
+        address: localhost
+
+        # The network port to send syslog messages to.  If this is zero,
+        # then the port is ignored and `address` is taken to be a Unix domain
+        # socket.  Defaults to 514, the standard syslog port.
+        port: 514
+
+        # The syslog facility to use.  If given, should be the name of one of
+        # the syslog facilities, disregarding case ("user", "local0", ...)
+        # Defaults to "user".
+        facility: user
+
+        # Set to True to use TCP, instead of UDP, to send messages to the
+        # syslog server.  Ignored if using a Unix domain socket (i.e. `port`
+        # is zero).  Default is False.
+        use_tcp: false
+
+    # File logging.
+    file:
+        # Full path to the log file.
+        name: /path/to/alpenhorn.log
+
+        # If a third-party (like logrotate) is rotating the alpenhorn log
+        # file, set this to "true" to tell alpenhorn to watch for log-file
+        # rotation.
+        watch: false
+
+        # Alternately, alpenhorn can manage log file rotation itself.  Set
+        # "rotate" to true to enable this behaviour.  At most one of "watch"
+        # and "rotate" may be true.
+        rotate: true
+
+        # The following two settings affect alpenhorn-managed log rotation
+        # and are ignored if "rotate" is not true.
+
+        # Maximum number of rotated files to keep.  Must be at least one
+        # Rotated files append an integer to the name specified (e.g.
+        # "alpenhorn.log.1", "alpenhorn.log.2" etc.).
+        backup_count: 10
+
+        # Size, in bytes, at which log file rotation occurs.  May include a
+        # suffix: k, M, or G.
+        max_bytes: 4M

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,6 +147,35 @@ def set_config(request, logger, reset_extensions):
 
 
 @pytest.fixture
+def config_file(request, xfs, hostname, clidb_uri):
+    """Write an alpenhorn config file in the fake filesystem.
+
+    Writes a standard daemon config to the file.  If the alpenhorn_config mark
+    is used, that will be used to update the config before it's written
+    to disk.
+    """
+
+    # The config.
+    #
+    # The weird value for "url" here gets around playhouse.db_url not
+    # url-decoding the netloc of the supplied URL.  The netloc is used
+    # as the "database" value, so to get the URI in there, we need to pass
+    # it as a parameter, which WILL get urldecoded and supercede the empty
+    # netloc.
+    alpenconfig = {
+        "database": {"url": "sqlite:///?database=" + urlquote(clidb_uri) + "&uri=true"},
+        "logging": {"level": "debug"},
+        "daemon": {"host": hostname, "num_workers": 0, "update_interval": 1},
+    }
+    marker = request.node.get_closest_marker("alpenhorn_config")
+    if marker is not None:
+        alpenconfig = config.merge_dict_tree(alpenconfig, marker.args[0])
+
+    # Put it in a file
+    xfs.create_file("/etc/alpenhorn/alpenhorn.conf", contents=yaml.dump(alpenconfig))
+
+
+@pytest.fixture
 def mock_run_command(request, set_config):
     """Mock alpenhorn.daemon.proc.run_command to _not_ run a command.
 

--- a/tests/daemon/test_entry_endtoend.py
+++ b/tests/daemon/test_entry_endtoend.py
@@ -20,10 +20,8 @@ import pathlib
 import shutil
 import sys
 from unittest.mock import patch
-from urllib.parse import quote as urlquote
 
 import pytest
-import yaml
 from click.testing import CliRunner
 
 from alpenhorn.daemon.entry import entry
@@ -299,30 +297,6 @@ def mock_rsync(xfs):
             yield
 
 
-@pytest.fixture
-def e2e_config(xfs, hostname, clidb_uri):
-    """Fixture creating the config file for the end-to-end test."""
-
-    # The config.
-    #
-    # The weird value for "url" here gets around playhouse.db_url not
-    # url-decoding the netloc of the supplied URL.  The netloc is used
-    # as the "database" value, so to get the URI in there, we need to pass
-    # it as a parameter, which WILL get urldecoded and supercede the empty
-    # netloc.
-    config = {
-        "extensions": [
-            "pattern_importer",
-        ],
-        "database": {"url": "sqlite:///?database=" + urlquote(clidb_uri) + "&uri=true"},
-        "logging": {"level": "debug"},
-        "daemon": {"host": hostname, "num_workers": 0, "update_interval": 1},
-    }
-
-    # Put it in a file
-    xfs.create_file("/etc/alpenhorn/alpenhorn.conf", contents=yaml.dump(config))
-
-
 @pytest.mark.lfs_hsm_state(
     {
         "/nl2/acq1/correct.me": "restored",
@@ -331,7 +305,14 @@ def e2e_config(xfs, hostname, clidb_uri):
     }
 )
 @pytest.mark.lfs_hsm_restore_result("restore")
-def test_cli(e2e_db, e2e_config, mock_lfs, mock_rsync):
+@pytest.mark.alpenhorn_config(
+    {
+        "extensions": [
+            "pattern_importer",
+        ]
+    }
+)
+def test_cli(e2e_db, config_file, mock_lfs, mock_rsync):
     runner = CliRunner()
 
     result = runner.invoke(entry, ["--once"], catch_exceptions=False)

--- a/tests/daemon/test_entry_options.py
+++ b/tests/daemon/test_entry_options.py
@@ -1,0 +1,47 @@
+"""Test daemon options."""
+
+import pytest
+from click.testing import CliRunner
+
+from alpenhorn.daemon.entry import entry
+from alpenhorn.db import StorageHost
+
+
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
+def test_no_integrity(xfs, clidb, config_file, hostname):
+    """Test fatal error on integrity problems."""
+
+    # Need a StorageHost to run on
+    StorageHost.create(name=hostname)
+
+    runner = CliRunner()
+
+    # We use --once to avoid accidentally get stuck in a loop
+    # in case this doesn't work
+    result = runner.invoke(entry, ["--once"], catch_exceptions=False)
+
+    # To get the daemon output in the test output in case of error
+    print(result.stdout)
+
+    assert result.exit_code != 0
+
+
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
+def test_no_integrity_override(xfs, clidb, config_file, hostname):
+    """Test --disable-archive-integrity."""
+
+    # Need a StorageHost to run on
+    StorageHost.create(name=hostname)
+
+    runner = CliRunner()
+
+    # We use --once to avoid accidentally get stuck in a loop
+    # in case this doesn't work
+    result = runner.invoke(
+        entry, ["--once", "--disable-archive-integrity"], catch_exceptions=False
+    )
+
+    # To get the daemon output in the test output in case of error
+    print(result.stdout)
+
+    assert result.exit_code == 0

--- a/tests/daemon/test_update_node.py
+++ b/tests/daemon/test_update_node.py
@@ -476,7 +476,10 @@ def test_update_idle(unode, queue):
             assert ioiu.mock_calls == [call(True), call(False), call(False)]
 
 
-def test_update_delete_under_min(unode, simpleacq, archivefile, archivefilecopy):
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
+def test_update_delete_under_min(
+    unode, set_config, simpleacq, archivefile, archivefilecopy
+):
     """Test UpdateableNode.update_delete() when under min"""
 
     archivefilecopy(
@@ -549,7 +552,10 @@ def test_update_delete_under_min(unode, simpleacq, archivefile, archivefilecopy)
     mock_delete.assert_called_once_with([copyM1, copyN1, copyM2, copyN2, copyN3])
 
 
-def test_update_delete_over_min(unode, simpleacq, archivefile, archivefilecopy):
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
+def test_update_delete_over_min(
+    unode, set_config, simpleacq, archivefile, archivefilecopy
+):
     """Test UpdateableNode.update_delete() when not under min"""
 
     archivefilecopy(
@@ -577,8 +583,9 @@ def test_update_delete_over_min(unode, simpleacq, archivefile, archivefilecopy):
     mock_delete.assert_called_once_with([copyN])
 
 
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
 def test_update_delete_transfer_pending(
-    unode, simplegroup, simplefile, archivefilecopy, archivefilecopyrequest
+    unode, set_config, simplegroup, simplefile, archivefilecopy, archivefilecopyrequest
 ):
     """update_delete() should skip files that have pending transfers."""
 
@@ -595,7 +602,10 @@ def test_update_delete_transfer_pending(
     mock_delete.assert_not_called()
 
 
-def test_update_delete_bad_file(unode, simpleacq, archivefile, archivefilecopy):
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
+def test_update_delete_bad_file(
+    unode, set_config, simpleacq, archivefile, archivefilecopy
+):
     """update_delete() should attempt to delete bad files."""
 
     fileM = archivefile(name="fileM", acq=simpleacq)
@@ -611,6 +621,7 @@ def test_update_delete_bad_file(unode, simpleacq, archivefile, archivefilecopy):
     mock_delete.assert_called_once_with([copyM, copyX])
 
 
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
 def test_update_node_run(
     unode,
     queue,

--- a/tests/db/test_archive.py
+++ b/tests/db/test_archive.py
@@ -178,6 +178,143 @@ def test_copy_path(simplefile, simplenode, archivefilecopy):
     )
 
 
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
+def test_copy_check_delete_wants(set_config, dbtables, simplecopy):
+    """Test wants_file with ArchiveFileCopy.check_delete."""
+
+    simplecopy.has_file = "Y"
+    simplecopy.wants_file = "Y"
+    simplecopy.save()
+    assert not simplecopy.check_delete(discretionary=True)
+    assert not simplecopy.check_delete(discretionary=False)
+    assert not simplecopy.check_delete()
+
+    simplecopy.wants_file = "M"
+    simplecopy.save()
+    assert simplecopy.check_delete(discretionary=True)
+    assert not simplecopy.check_delete(discretionary=False)
+    # By default, discretionary deletion is on
+    assert simplecopy.check_delete()
+
+    simplecopy.wants_file = "N"
+    simplecopy.save()
+    assert simplecopy.check_delete(discretionary=True)
+    assert simplecopy.check_delete(discretionary=False)
+    assert simplecopy.check_delete()
+
+
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 0}})
+def test_copy_check_delete_has(set_config, dbtables, simplecopy):
+    """Test has_file with ArchiveFileCopy.check_delete."""
+
+    # Make the file deletable
+    simplecopy.wants_file = "N"
+
+    simplecopy.has_file = "Y"
+    simplecopy.save()
+    assert simplecopy.check_delete()
+
+    simplecopy.has_file = "M"
+    simplecopy.save()
+    assert simplecopy.check_delete()
+
+    simplecopy.has_file = "X"
+    simplecopy.save()
+    assert simplecopy.check_delete()
+
+    # This is the only one that blocks deletion
+    simplecopy.has_file = "N"
+    simplecopy.save()
+    assert not simplecopy.check_delete()
+
+
+def test_copy_check_delete_arcount(
+    dbtables, daemon_host, simplefile, simplegroup, storagenode, archivefilecopy
+):
+    """Test archive copy count in ArchiveFileCopy.check_delete."""
+
+    arc1 = storagenode(name="arc1", group=simplegroup, archive=True)
+    arc2 = storagenode(name="arc2", group=simplegroup, archive=True)
+
+    # This is the node we're deleting from
+    node = storagenode(name="node", group=simplegroup, archive=True)
+
+    # This is the copy we want to delete
+    copy = archivefilecopy(file=simplefile, node=node, has_file="Y", wants_file="N")
+
+    # This fails (no archive copies)
+    assert not copy.check_delete()
+
+    # First archive copy
+    archivefilecopy(file=simplefile, node=arc1, has_file="Y", wants_file="Y")
+    assert not copy.check_delete()
+
+    # Second archive copy
+    archivefilecopy(file=simplefile, node=arc2, has_file="Y", wants_file="Y")
+    # Now it succeeds
+    assert copy.check_delete()
+
+
+def test_copy_check_delete_from_arc(
+    dbtables, simplefile, simplegroup, storagenode, archivefilecopy
+):
+    """Test archive copy count in ArchiveFileCopy.check_delete on an archive node."""
+
+    arc1 = storagenode(name="arc1", group=simplegroup, archive=True)
+    arc2 = storagenode(name="arc2", group=simplegroup, archive=True)
+
+    # This is the node we're deleting from
+    node = storagenode(name="node", group=simplegroup, archive=True)
+
+    # This is the copy we want to delete
+    copy = archivefilecopy(file=simplefile, node=node, has_file="Y", wants_file="N")
+
+    # This fails (no archive copies)
+    assert not copy.check_delete()
+
+    # First archive copy
+    archivefilecopy(file=simplefile, node=arc1, has_file="Y", wants_file="Y")
+    assert not copy.check_delete()
+
+    # Second archive copy
+    archivefilecopy(file=simplefile, node=arc2, has_file="Y", wants_file="Y")
+    # Now it succeeds
+    assert copy.check_delete()
+
+
+@pytest.mark.alpenhorn_config({"daemon": {"archive_copy_count": 3}})
+def test_copy_check_delete_arcount_config(
+    dbtables, set_config, simplefile, simplegroup, storagenode, archivefilecopy
+):
+    """Test archive copy count in ArchiveFileCopy.check_delete with config."""
+
+    arc1 = storagenode(name="arc1", group=simplegroup, archive=True)
+    arc2 = storagenode(name="arc2", group=simplegroup, archive=True)
+    arc3 = storagenode(name="arc3", group=simplegroup, archive=True)
+
+    # This is the node we're deleting from
+    node = storagenode(name="node", group=simplegroup, archive=True)
+
+    # This is the copy we want to delete
+    copy = archivefilecopy(file=simplefile, node=node, has_file="Y", wants_file="N")
+
+    # This fails (no archive copies)
+    assert not copy.check_delete()
+
+    # First archive copy
+    archivefilecopy(file=simplefile, node=arc1, has_file="Y", wants_file="Y")
+    assert not copy.check_delete()
+
+    # Second archive copy, still doesn't work
+    archivefilecopy(file=simplefile, node=arc2, has_file="Y", wants_file="Y")
+    assert not copy.check_delete()
+
+    # Third archive copy
+    archivefilecopy(file=simplefile, node=arc3, has_file="Y", wants_file="Y")
+    # Now it succeeds
+    assert copy.check_delete()
+
+
 def test_archivefileimportrequest_model(
     simplegroup, storagenode, archivefileimportrequest
 ):

--- a/tests/io/default/test_delete.py
+++ b/tests/io/default/test_delete.py
@@ -1,25 +1,12 @@
 """Test DefaultNodeIO.delete()."""
 
 import pathlib
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from alpenhorn.db.archive import ArchiveFileCopy
 from alpenhorn.io.default import UpDownLock, delete_async, remove_filedir
-
-
-@pytest.fixture
-def mock_archive_count():
-    """Mock ArchiveFile.archive_count to return a
-    number big enough to allow deletion."""
-
-    @property
-    def _mock_archive_count(self):
-        return 6
-
-    with patch("alpenhorn.db.archive.ArchiveFile.archive_count", _mock_archive_count):
-        yield
 
 
 def test_zero_len(queue, unode):
@@ -30,94 +17,7 @@ def test_zero_len(queue, unode):
     assert queue.qsize == 0
 
 
-def test_ncopies(
-    xfs,
-    queue,
-    unode,
-    simplegroup,
-    storagenode,
-    simpleacq,
-    archivefile,
-    archivefilecopy,
-    archive=False,
-):
-    """Test not deleting from non-archival node
-    when there are not enough other copies of the file."""
-
-    # Need to make the containing directory
-    xfs.create_dir("/node/simpleacq")
-
-    unode.db.archive = archive
-    unode.db.save()
-
-    arc1 = storagenode(name="arc1", group=simplegroup, root="/arc1", archive=True)
-    arc2 = storagenode(name="arc2", group=simplegroup, root="/arc2", archive=True)
-
-    # Can't be deleted from node: only one archive copy
-    file1 = archivefile(name="file1", acq=simpleacq)
-    copy1 = archivefilecopy(file=file1, node=unode.db, has_file="Y")
-    archivefilecopy(file=file1, node=arc1, has_file="Y")
-
-    # Can't be deleted from node: only one archive copy
-    file2 = archivefile(name="file2", acq=simpleacq)
-    copy2 = archivefilecopy(file=file2, node=unode.db, has_file="Y")
-    archivefilecopy(file=file2, node=arc1, has_file="Y")
-    archivefilecopy(file=file2, node=arc2, has_file="N")
-
-    # Can be deleted from node: two archived copies
-    file3 = archivefile(name="file3", acq=simpleacq)
-    copy3 = archivefilecopy(file=file3, node=unode.db, has_file="Y")
-    archivefilecopy(file=file3, node=arc1, has_file="Y")
-    archivefilecopy(file=file3, node=arc2, has_file="Y")
-
-    unode.io.delete([copy1, copy2, copy3])
-
-    assert queue.qsize == 1
-
-    # Call the async
-    task, key = queue.get()
-    task()
-    queue.task_done(key)
-
-    # copy1 and copy2 aren't deleted, but copy3 is
-    assert list(
-        ArchiveFileCopy.select(ArchiveFileCopy.has_file)
-        .where(ArchiveFileCopy.node == unode.db)
-        .tuples()
-        .execute()
-    ) == [
-        ("Y",),
-        ("Y",),
-        ("N",),
-    ]
-
-
-def test_ncopies_archive(
-    xfs,
-    queue,
-    unode,
-    simplegroup,
-    storagenode,
-    simpleacq,
-    archivefile,
-    archivefilecopy,
-):
-    """Same as previous but on an archive node."""
-
-    test_ncopies(
-        xfs,
-        queue,
-        unode,
-        simplegroup,
-        storagenode,
-        simpleacq,
-        archivefile,
-        archivefilecopy,
-        archive=True,
-    )
-
-
-def test_delete_dirs(
+def test_delete_check(
     xfs,
     queue,
     simplegroup,
@@ -125,7 +25,59 @@ def test_delete_dirs(
     archiveacq,
     archivefile,
     archivefilecopy,
-    mock_archive_count,
+):
+    """The delete async calls the ArchiveFileCopy.check_delete."""
+    node = storagenode(name="node", group=simplegroup, root="/node")
+    acq = archiveacq(name="acq")
+    copy1 = archivefilecopy(
+        file=archivefile(name="file1", acq=acq),
+        node=node,
+        has_file="Y",
+    )
+    xfs.create_file(copy1.path, contents=copy1.file.name)
+    copy2 = archivefilecopy(
+        file=archivefile(name="file2", acq=acq),
+        node=node,
+        has_file="Y",
+    )
+    xfs.create_file(copy2.path, contents=copy2.file.name)
+
+    mock = MagicMock()
+    mock.return_value = False
+
+    with patch("alpenhorn.db.archive.ArchiveFileCopy.check_delete", mock):
+        # Call async directly with a fake UpDownLock
+        delete_async(None, UpDownLock(), [copy1, copy2])
+
+    # Nothing was deleted
+    assert ArchiveFileCopy.select().where(ArchiveFileCopy.has_file == "Y").count() == 2
+
+    # Check files
+    assert pathlib.Path(copy1.path).exists()
+    assert pathlib.Path(copy2.path).exists()
+
+    # Now do the same, but returning true
+    mock.return_value = True
+    with patch("alpenhorn.db.archive.ArchiveFileCopy.check_delete", mock):
+        delete_async(None, UpDownLock(), [copy1, copy2])
+
+    # Both were deleted
+    assert ArchiveFileCopy.select().where(ArchiveFileCopy.has_file == "Y").count() == 0
+
+    # Check files
+    assert not pathlib.Path(copy1.path).exists()
+    assert not pathlib.Path(copy2.path).exists()
+
+
+def test_delete_dirs(
+    xfs,
+    queue,
+    dbtables,
+    simplegroup,
+    storagenode,
+    archiveacq,
+    archivefile,
+    archivefilecopy,
 ):
     """Test deleting directories (and some files)."""
     node = storagenode(name="node", group=simplegroup, root="/node")
@@ -188,8 +140,12 @@ def test_delete_dirs(
     delete_copies = copies.copy()
     del delete_copies[2]
 
-    # Call async directly with a fake UpDownLock
-    delete_async(None, UpDownLock(), delete_copies)
+    with patch(
+        "alpenhorn.db.archive.ArchiveFileCopy.check_delete",
+        lambda discretionary=True: True,
+    ):
+        # Call async directly with a fake UpDownLock
+        delete_async(None, UpDownLock(), delete_copies)
 
     # Only copies[2] remains
     assert ArchiveFileCopy.select().where(ArchiveFileCopy.has_file == "Y").count() == 1


### PR DESCRIPTION
This allows changing the number of archive copies required to permit deleting a file (formerly hard-coded at two) by changing the `daemon.archive_copy_copy` config value.  Setting this this to somehting less than two means alpenhorn won't be able to guarantee data integrity, but maybe that's okay, if that's what users want.

If they _do_ want that, they'll need to use the new `--disable-archive-integrity` flag to the daemon to avoid the fatal error arising from a too-small value violating the data protection rules.

This collects all the pre-deletion DB checks into a function (`ArchiveFileCopy.check_delete`) for the same reason that I did that for pulls in #330 so that it's easy to re-run the checks inside the I/O task to handle cases where the task has been in the queue for a long time and circumstances have changed.

Also create a separate `examples/alpenhorn.conf` file for more visibility as to the possible contents of such a file.

Closes #366 