### PR TITLE
Move force_check_filecopy out of Default I/O

### DIFF
--- a/alpenhorn/db/storage.py
+++ b/alpenhorn/db/storage.py
@@ -448,6 +448,71 @@ class StorageNode(base_model):
         if update_fields:
             self.save(only=update_fields)
 
+    def check_unregistered(self, file_: ArchiveFile, storage_used: int | None) -> None:
+        """Force a check of an unregistered file copy found on this node.
+
+        Upserts an ArchiveFileCopy record to force a check of an
+        unregistered file copy on this node.  If `file_` is _not_ unregistered
+        (i.e. ``self.filecopy_state(file_) != "N"``), this method does nothing
+        and returns False.
+
+        Parameters
+        ----------
+        file_ : ArchiveFile
+            The unregistered file
+        node : StorageNode
+            The node to run the check on
+        storage_used : int or None
+            The space used on the node by the file, if known.
+
+        Returns
+        -------
+        bool
+            True if a check of the unregisred file was scheduled.  False if the file
+            was already registered.
+        """
+        from .archive import ArchiveFileCopy
+
+        # ready == False is the safe option here: copy will be readied
+        # during the subsequent check if needed.
+        try:
+            # Try to create a new copy
+            ArchiveFileCopy.create(
+                file=file_,
+                node=self,
+                has_file="M",
+                wants_file="Y",
+                ready=False,
+                size_b=storage_used,
+            )
+            new_copy = True
+        except pw.IntegrityError:
+            new_copy = False
+
+        if not new_copy:
+            # Copy already exists, fetch it to see the current state
+            copy = ArchiveFileCopy.get(file=file_, node=self)
+
+            # If copy is not unregistered, return False early
+            if copy.has_file != "N":
+                return False
+
+            # Otherwise update
+            copy.has_file = "M"
+            copy.wants_file = "Y"
+            copy.ready = False
+            copy.size_b = storage_used
+            copy.last_udate = pw.utcnow()
+            copy.save()
+
+        # Report
+        log.info(
+            "Requesting check of previously-unregistered "
+            f"{file_.path} on node {self.name}."
+        )
+
+        return True
+
 
 class StorageTransferAction(base_model):
     """Storage transfer rules for the archive.

--- a/alpenhorn/io/default/check.py
+++ b/alpenhorn/io/default/check.py
@@ -5,63 +5,13 @@ from __future__ import annotations
 import logging
 import pathlib
 
-import peewee as pw
-
 from ...daemon.metrics import Metric
 from ...daemon.proc import timeout_call
 from ...daemon.scheduler import Task
-from ...db import (
-    ArchiveFile,
-    ArchiveFileCopy,
-    StorageNode,
-    utcnow,
-)
+from ...db import ArchiveFileCopy, utcnow
 from ..base import BaseNodeIO
 
 log = logging.getLogger(__name__)
-
-
-def force_check_filecopy(file_: ArchiveFile, node: StorageNode, node_io: BaseNodeIO):
-    """Force a check of an unregistered file.
-
-    Upserts an ArchiveFileCopy record to force a check of an
-    unregistered file copy on a node.
-
-    Parameters
-    ----------
-    file_ : ArchiveFile
-        The file to check
-    node : StorageNode
-        The node to run the check on
-    node_io : BaseNodeIO
-        The node I/O instance.  Used if we need to calculate
-        the file size.
-    """
-    log.info(f"Requesting check of {file_.acq.name}/{file_.name} on node {node.name}.")
-
-    # ready == False is the safe option here: copy will be readied
-    # during the subsequent check if needed.
-    try:
-        # Try to create a new copy
-        ArchiveFileCopy.create(
-            file=file_,
-            node=node,
-            has_file="M",
-            wants_file="Y",
-            ready=False,
-            size_b=node_io.storage_used(file_.path),
-        )
-    except pw.IntegrityError:
-        # Copy already exists, just update the existing
-        ArchiveFileCopy.update(
-            has_file="M",
-            wants_file="Y",
-            ready=False,
-            last_update=utcnow(),
-        ).where(
-            ArchiveFileCopy.file == file_,
-            ArchiveFileCopy.node == node,
-        ).execute()
 
 
 def check_async(

--- a/alpenhorn/io/default/group.py
+++ b/alpenhorn/io/default/group.py
@@ -21,7 +21,6 @@ from ...db import (
     StorageNode,
 )
 from ..base import BaseGroupIO
-from .check import force_check_filecopy
 
 log = logging.getLogger(__name__)
 
@@ -67,15 +66,10 @@ def group_search_async(
     found_missing = False
     for node in groupio.nodes:
         if node.io.exists(req.file.path):
-            # file on disk: is it known?
-            #
-            # Acreate/update the ArchiveFileCopy to force a check next pass
-            copy_state = node.db.filecopy_state(req.file)
-
-            if copy_state == "N":
-                # Update/create ArchiveFileCopy to force a check.
-                force_check_filecopy(req.file, node.db, node.io)
-                found_missing = True
+            # Request check if not already known to alpenhorn
+            found_missing = node.db.check_unregistered(
+                req.file, node.io.storage_used(req.file.path)
+            )
 
     # If we found something, warn and stop
     if found_missing:

--- a/alpenhorn/io/default/pull.py
+++ b/alpenhorn/io/default/pull.py
@@ -14,15 +14,12 @@ import shutil
 import time
 from tempfile import TemporaryDirectory
 
-import peewee as pw
-
 from ...common import config
 from ...daemon import RemoteNode, proc
 from ...daemon.metrics import Metric
 from ...daemon.scheduler import Task, threadlocal
-from ...db import ArchiveFileCopy, ArchiveFileCopyRequest
+from ...db import ArchiveFileCopyRequest
 from ..base import BaseNodeIO
-from .check import force_check_filecopy
 from .updownlock import UpDownLock
 
 __all__ = ["bbcp", "hardlink", "local_copy", "rsync"]
@@ -481,26 +478,18 @@ def pull_async(
 
     # Check for existing file, if not done already
     if not did_search:
-        # If this is a known corrupt file, there's no need to do an existence check.
-        # (because in that case we'd want to clobber an existing file anyways).
         try:
-            copy = ArchiveFileCopy.get(node=io.node, file=req.file)
-            known_corrupt = copy.has_file == "X"
-        except pw.DoesNotExist:
-            known_corrupt = False
+            if io.exists(req.file.path):
+                if io.node.check_unregistered(req.file, io.storage_used(req.file.path)):
+                    log.warning(
+                        "Skipping pull request for "
+                        f"{req.file.acq.name}/{req.file.name}: "
+                        f"file already on disk on node {io.node.name}."
+                    )
 
-        try:
-            if not known_corrupt and io.exists(req.file.path):
-                log.warning(
-                    "Skipping pull request for "
-                    f"{req.file.acq.name}/{req.file.name}: "
-                    f"file already on disk on node {io.node.name}."
-                )
-
-                force_check_filecopy(req.file, io.node, io)
-                # request not resolved.  Should be sorted out after
-                # the file check happens.
-                return
+                    # request not resolved.  Should be sorted out after
+                    # the file check happens.
+                    return
         except OSError:
             # On error, try to do the pull
             pass

--- a/tests/db/test_storage_action.py
+++ b/tests/db/test_storage_action.py
@@ -1,0 +1,75 @@
+"""test alpenhorn.storage."""
+
+import peewee as pw
+import pytest
+
+from alpenhorn.db.storage import StorageTransferAction
+
+
+def test_schema(dbproxy, simplenode, storagetransferaction):
+    # Force table creation
+    storagetransferaction(node_from=simplenode, group_to=simplenode.group)
+
+    assert set(dbproxy.get_tables()) == {
+        "storagegroup",
+        "storagenode",
+        "storagetransferaction",
+    }
+
+
+def test_edge_model(storagetransferaction, storagenode, storagegroup):
+    group1 = storagegroup(name="group1")
+    node1 = storagenode(name="node1", group=group1)
+
+    group2 = storagegroup(name="group2")
+    node2 = storagenode(name="node2", group=group2)
+
+    storagetransferaction(node_from=node1, group_to=group2)
+    storagetransferaction(
+        node_from=node2, group_to=group1, autosync=True, autoclean=True
+    )
+
+    # (node_from, group_to) is unique
+    with pytest.raises(pw.IntegrityError):
+        storagetransferaction(node_from=node1, group_to=group2)
+
+    # Check records in DB
+    assert StorageTransferAction.select().where(
+        StorageTransferAction.node_from == node1,
+        StorageTransferAction.group_to == group2,
+    ).dicts().get() == {
+        "id": 1,
+        "node_from": node1.id,
+        "group_to": group2.id,
+        "autosync": False,
+        "autoclean": False,
+    }
+    assert StorageTransferAction.select().where(
+        StorageTransferAction.node_from == node2,
+        StorageTransferAction.group_to == group1,
+    ).dicts().get() == {
+        "id": 2,
+        "node_from": node2.id,
+        "group_to": group1.id,
+        "autosync": True,
+        "autoclean": True,
+    }
+
+
+def test_edge_self_loop(storagetransferaction, storagenode, storagegroup):
+    """StorageTransferAction.self_loop is True when node_from.group == group_to"""
+
+    group1 = storagegroup(name="group1")
+    node1 = storagenode(name="node1", group=group1)
+
+    group2 = storagegroup(name="group2")
+    storagenode(name="node2", group=group2)
+
+    # Not a loop
+    storagetransferaction(node_from=node1, group_to=group2)
+
+    # Loop
+    storagetransferaction(node_from=node1, group_to=group1)
+
+    assert not StorageTransferAction.get(id=1).self_loop
+    assert StorageTransferAction.get(id=2).self_loop

--- a/tests/db/test_storage_group.py
+++ b/tests/db/test_storage_group.py
@@ -1,0 +1,103 @@
+"""test alpenhorn.storage."""
+
+import peewee as pw
+import pytest
+
+from alpenhorn.db.storage import StorageGroup
+
+
+def test_schema(dbproxy, storagegroup):
+    # Force table creation
+    storagegroup(name="group")
+
+    assert set(dbproxy.get_tables()) == {
+        "storagegroup",
+    }
+
+
+def test_group_model(storagegroup):
+    storagegroup(name="min")
+    storagegroup(name="max", io_class="IOClass", io_config="{ioconfig}", notes="Notes")
+
+    # name is unique
+    with pytest.raises(pw.IntegrityError):
+        storagegroup(name="min")
+
+    # Check records in DB
+    assert StorageGroup.select().where(StorageGroup.name == "min").dicts().get() == {
+        "id": 1,
+        "name": "min",
+        "io_class": None,
+        "io_config": None,
+        "notes": None,
+    }
+    assert StorageGroup.select().where(StorageGroup.name == "max").dicts().get() == {
+        "id": 2,
+        "name": "max",
+        "io_class": "IOClass",
+        "io_config": "{ioconfig}",
+        "notes": "Notes",
+    }
+
+
+def test_copy_state(simplenode, simpleacq, archivefile, archivefilecopy):
+    """Test group.state_on_node()."""
+    group = simplenode.group
+
+    # None is returned here with 'N', even though an ArchiveFileCopy
+    # exists with a specific node in the group.
+    filen = archivefile(name="filen", acq=simpleacq, size_b=1)
+    archivefilecopy(file=filen, node=simplenode, has_file="N")
+    assert group.state_on_node(filen) == ("N", None)
+
+    filey = archivefile(name="filey", acq=simpleacq, size_b=1)
+    archivefilecopy(file=filey, node=simplenode, has_file="Y")
+    assert group.state_on_node(filey) == ("Y", simplenode)
+
+    filex = archivefile(name="filex", acq=simpleacq, size_b=1)
+    archivefilecopy(file=filex, node=simplenode, has_file="X")
+    assert group.state_on_node(filex) == ("X", simplenode)
+
+    filem = archivefile(name="filem", acq=simpleacq, size_b=1)
+    archivefilecopy(file=filem, node=simplenode, has_file="M")
+    assert group.state_on_node(filem) == ("M", simplenode)
+
+    # Non-existent file returns 'N'
+    missing = archivefile(name="missing", acq=simpleacq, size_b=1)
+    assert group.state_on_node(missing) == ("N", None)
+
+
+def test_copy_state_multi(
+    simplegroup, storagenode, simpleacq, archivefile, archivefilecopy
+):
+    """Test group.state_on_node() with mutliple copies on the node."""
+
+    # Several nodes with different kinds of file copies
+    nodeN = storagenode(name="N", group=simplegroup)
+    nodeX = storagenode(name="X", group=simplegroup)
+    nodeM = storagenode(name="M", group=simplegroup)
+    nodeY = storagenode(name="Y", group=simplegroup)
+
+    # X wins over N
+    fileXN = archivefile(name="XN", acq=simpleacq)
+    archivefilecopy(file=fileXN, node=nodeN, has_file="N")
+    archivefilecopy(file=fileXN, node=nodeX, has_file="X")
+
+    assert simplegroup.state_on_node(fileXN) == ("X", nodeX)
+
+    # M wins over M and N
+    fileMXN = archivefile(name="MXN", acq=simpleacq)
+    archivefilecopy(file=fileMXN, node=nodeN, has_file="N")
+    archivefilecopy(file=fileMXN, node=nodeX, has_file="X")
+    archivefilecopy(file=fileMXN, node=nodeM, has_file="M")
+
+    assert simplegroup.state_on_node(fileMXN) == ("M", nodeM)
+
+    # Y wins over X, M and N
+    fileYMXN = archivefile(name="YMXN", acq=simpleacq)
+    archivefilecopy(file=fileYMXN, node=nodeN, has_file="N")
+    archivefilecopy(file=fileYMXN, node=nodeX, has_file="X")
+    archivefilecopy(file=fileYMXN, node=nodeM, has_file="M")
+    archivefilecopy(file=fileYMXN, node=nodeY, has_file="Y")
+
+    assert simplegroup.state_on_node(fileYMXN) == ("Y", nodeY)

--- a/tests/db/test_storage_node.py
+++ b/tests/db/test_storage_node.py
@@ -5,6 +5,7 @@ import pathlib
 import peewee as pw
 import pytest
 
+from alpenhorn.db.archive import ArchiveFileCopy
 from alpenhorn.db.storage import StorageNode
 
 
@@ -322,3 +323,58 @@ def test_update_avail_gb(simplenode):
     node = StorageNode.get(id=simplenode.id)
     assert node.avail_gb == avail
     assert node.avail_gb_last_checked == 0
+
+
+def test_check_unregistered_none(dbtables, simplefile, simplenode):
+    """Test StorageNode.check_unregistered with no pre-existing copy record."""
+
+    assert simplenode.check_unregistered(simplefile, storage_used=1234)
+
+    # Get the record
+    copy = ArchiveFileCopy.get(id=1)
+
+    assert copy.node == simplenode
+    assert copy.file == simplefile
+    assert copy.size_b == 1234
+    assert copy.has_file == "M"
+    assert copy.wants_file == "Y"
+    assert copy.ready is False
+
+
+def test_check_unregistered_corrupt(simplecopy):
+    """Test StorageNode.check_unregistered with a pre-existing copy record."""
+
+    # Make the copy corrupt
+    simplecopy.ready = True
+    simplecopy.has_file = "X"
+    simplecopy.save()
+
+    # Record wasn't updated
+    assert not simplecopy.node.check_unregistered(simplecopy.file, storage_used=1234)
+
+    # Get the record
+    copy = ArchiveFileCopy.get(id=1)
+
+    # Record wasn't updated
+    assert copy.has_file == "X"
+    assert copy.ready is True
+
+
+def test_check_unregistered_gone(simplecopy):
+    """Test StorageNode.check_unregistered with a pre-existing copy record."""
+
+    # Set some parameters that the call will change
+    simplecopy.ready = True
+    simplecopy.wants_file = "M"
+    simplecopy.has_file = "N"
+    simplecopy.save()
+
+    simplecopy.node.check_unregistered(simplecopy.file, storage_used=1234)
+
+    # Get the record
+    copy = ArchiveFileCopy.get(id=1)
+
+    assert copy.size_b == 1234
+    assert copy.has_file == "M"
+    assert copy.wants_file == "Y"
+    assert copy.ready is False

--- a/tests/db/test_storage_node.py
+++ b/tests/db/test_storage_node.py
@@ -5,42 +5,16 @@ import pathlib
 import peewee as pw
 import pytest
 
-from alpenhorn.db.storage import StorageGroup, StorageNode, StorageTransferAction
+from alpenhorn.db.storage import StorageNode
 
 
-def test_schema(dbproxy, simplenode, storagetransferaction):
+def test_schema(dbproxy, simplegroup, storagenode):
     # Force table creation
-    storagetransferaction(node_from=simplenode, group_to=simplenode.group)
+    storagenode(name="node", group=simplegroup)
 
     assert set(dbproxy.get_tables()) == {
         "storagegroup",
         "storagenode",
-        "storagetransferaction",
-    }
-
-
-def test_group_model(storagegroup):
-    storagegroup(name="min")
-    storagegroup(name="max", io_class="IOClass", io_config="{ioconfig}", notes="Notes")
-
-    # name is unique
-    with pytest.raises(pw.IntegrityError):
-        storagegroup(name="min")
-
-    # Check records in DB
-    assert StorageGroup.select().where(StorageGroup.name == "min").dicts().get() == {
-        "id": 1,
-        "name": "min",
-        "io_class": None,
-        "io_config": None,
-        "notes": None,
-    }
-    assert StorageGroup.select().where(StorageGroup.name == "max").dicts().get() == {
-        "id": 2,
-        "name": "max",
-        "io_class": "IOClass",
-        "io_config": "{ioconfig}",
-        "notes": "Notes",
     }
 
 
@@ -123,69 +97,6 @@ def test_local(simplenode, hostname):
 
     simplenode.host = "other-host"
     assert not simplenode.local
-
-
-def test_copy_state(simplenode, simpleacq, archivefile, archivefilecopy):
-    """Test group.state_on_node()."""
-    group = simplenode.group
-
-    # None is returned here with 'N', even though an ArchiveFileCopy
-    # exists with a specific node in the group.
-    filen = archivefile(name="filen", acq=simpleacq, size_b=1)
-    archivefilecopy(file=filen, node=simplenode, has_file="N")
-    assert group.state_on_node(filen) == ("N", None)
-
-    filey = archivefile(name="filey", acq=simpleacq, size_b=1)
-    archivefilecopy(file=filey, node=simplenode, has_file="Y")
-    assert group.state_on_node(filey) == ("Y", simplenode)
-
-    filex = archivefile(name="filex", acq=simpleacq, size_b=1)
-    archivefilecopy(file=filex, node=simplenode, has_file="X")
-    assert group.state_on_node(filex) == ("X", simplenode)
-
-    filem = archivefile(name="filem", acq=simpleacq, size_b=1)
-    archivefilecopy(file=filem, node=simplenode, has_file="M")
-    assert group.state_on_node(filem) == ("M", simplenode)
-
-    # Non-existent file returns 'N'
-    missing = archivefile(name="missing", acq=simpleacq, size_b=1)
-    assert group.state_on_node(missing) == ("N", None)
-
-
-def test_copy_state_multi(
-    simplegroup, storagenode, simpleacq, archivefile, archivefilecopy
-):
-    """Test group.state_on_node() with mutliple copies on the node."""
-
-    # Several nodes with different kinds of file copies
-    nodeN = storagenode(name="N", group=simplegroup)
-    nodeX = storagenode(name="X", group=simplegroup)
-    nodeM = storagenode(name="M", group=simplegroup)
-    nodeY = storagenode(name="Y", group=simplegroup)
-
-    # X wins over N
-    fileXN = archivefile(name="XN", acq=simpleacq)
-    archivefilecopy(file=fileXN, node=nodeN, has_file="N")
-    archivefilecopy(file=fileXN, node=nodeX, has_file="X")
-
-    assert simplegroup.state_on_node(fileXN) == ("X", nodeX)
-
-    # M wins over M and N
-    fileMXN = archivefile(name="MXN", acq=simpleacq)
-    archivefilecopy(file=fileMXN, node=nodeN, has_file="N")
-    archivefilecopy(file=fileMXN, node=nodeX, has_file="X")
-    archivefilecopy(file=fileMXN, node=nodeM, has_file="M")
-
-    assert simplegroup.state_on_node(fileMXN) == ("M", nodeM)
-
-    # Y wins over X, M and N
-    fileYMXN = archivefile(name="YMXN", acq=simpleacq)
-    archivefilecopy(file=fileYMXN, node=nodeN, has_file="N")
-    archivefilecopy(file=fileYMXN, node=nodeX, has_file="X")
-    archivefilecopy(file=fileYMXN, node=nodeM, has_file="M")
-    archivefilecopy(file=fileYMXN, node=nodeY, has_file="Y")
-
-    assert simplegroup.state_on_node(fileYMXN) == ("Y", nodeY)
 
 
 def test_archive_property(simplegroup, storagenode):
@@ -411,61 +322,3 @@ def test_update_avail_gb(simplenode):
     node = StorageNode.get(id=simplenode.id)
     assert node.avail_gb == avail
     assert node.avail_gb_last_checked == 0
-
-
-def test_edge_model(storagetransferaction, storagenode, storagegroup):
-    group1 = storagegroup(name="group1")
-    node1 = storagenode(name="node1", group=group1)
-
-    group2 = storagegroup(name="group2")
-    node2 = storagenode(name="node2", group=group2)
-
-    storagetransferaction(node_from=node1, group_to=group2)
-    storagetransferaction(
-        node_from=node2, group_to=group1, autosync=True, autoclean=True
-    )
-
-    # (node_from, group_to) is unique
-    with pytest.raises(pw.IntegrityError):
-        storagetransferaction(node_from=node1, group_to=group2)
-
-    # Check records in DB
-    assert StorageTransferAction.select().where(
-        StorageTransferAction.node_from == node1,
-        StorageTransferAction.group_to == group2,
-    ).dicts().get() == {
-        "id": 1,
-        "node_from": node1.id,
-        "group_to": group2.id,
-        "autosync": False,
-        "autoclean": False,
-    }
-    assert StorageTransferAction.select().where(
-        StorageTransferAction.node_from == node2,
-        StorageTransferAction.group_to == group1,
-    ).dicts().get() == {
-        "id": 2,
-        "node_from": node2.id,
-        "group_to": group1.id,
-        "autosync": True,
-        "autoclean": True,
-    }
-
-
-def test_edge_self_loop(storagetransferaction, storagenode, storagegroup):
-    """StorageTransferAction.self_loop is True when node_from.group == group_to"""
-
-    group1 = storagegroup(name="group1")
-    node1 = storagenode(name="node1", group=group1)
-
-    group2 = storagegroup(name="group2")
-    storagenode(name="node2", group=group2)
-
-    # Not a loop
-    storagetransferaction(node_from=node1, group_to=group2)
-
-    # Loop
-    storagetransferaction(node_from=node1, group_to=group1)
-
-    assert not StorageTransferAction.get(id=1).self_loop
-    assert StorageTransferAction.get(id=2).self_loop


### PR DESCRIPTION
Moved to `StorageNode.check_unregistered` along with some code surrounding the original calls to this function which were concerned with trying to figure out whether the unexpected filecopy was truly unregistered or not.

This is not an I/O function at all.  Probably should have been moved when I first collected everything into `alpenhorn.io.default`.

Also (in a separate commit) split up `tests/io/test_storage.py` which was getting disorganized.