### PR TITLE
fix(node stats): Remove wants_file from stats queries in CLI

### DIFF
--- a/alpenhorn/cli/node/stats.py
+++ b/alpenhorn/cli/node/stats.py
@@ -41,7 +41,6 @@ def get_stats(nodes: list[StorageNode], extra_stats: bool) -> dict[int, dict]:
         .join(ArchiveFile, pw.JOIN.LEFT_OUTER)
         .where(
             ArchiveFileCopy.has_file == "Y",
-            ArchiveFileCopy.wants_file == "Y",
             StorageNode.id << nodes,
         )
         .group_by(StorageNode.id)
@@ -66,7 +65,6 @@ def get_stats(nodes: list[StorageNode], extra_stats: bool) -> dict[int, dict]:
             .join(ArchiveFileCopy, pw.JOIN.LEFT_OUTER)
             .where(
                 ArchiveFileCopy.has_file == "X",
-                ArchiveFileCopy.wants_file == "Y",
                 StorageNode.id << nodes,
             )
             .group_by(StorageNode.id)
@@ -83,7 +81,6 @@ def get_stats(nodes: list[StorageNode], extra_stats: bool) -> dict[int, dict]:
             .join(ArchiveFileCopy, pw.JOIN.LEFT_OUTER)
             .where(
                 ArchiveFileCopy.has_file == "M",
-                ArchiveFileCopy.wants_file == "Y",
                 StorageNode.id << nodes,
             )
             .group_by(StorageNode.id)
@@ -100,7 +97,6 @@ def get_stats(nodes: list[StorageNode], extra_stats: bool) -> dict[int, dict]:
             .join(ArchiveFileCopy, pw.JOIN.LEFT_OUTER)
             .where(
                 ArchiveFileCopy.has_file == "N",
-                ArchiveFileCopy.wants_file == "Y",
                 StorageNode.id << nodes,
             )
             .group_by(StorageNode.id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 prometheus = [
-  "prometheus_client"
+  "prometheus_client >= 0.18.0"
 ]
 dist = [
   "build",

--- a/tests/cli/node/test_stats.py
+++ b/tests/cli/node/test_stats.py
@@ -141,7 +141,7 @@ def test_extra(some_nodes, cli, assert_row_present):
 
     result = cli(0, ["node", "stats", "--extra-stats"])
 
-    assert_row_present(result.output, "Node1", 2, "3.000 GiB", "30.00", "-", "1", "-")
-    assert_row_present(result.output, "Node2", 0, "-", "-", "-", "-", "1")
+    assert_row_present(result.output, "Node1", 2, "3.000 GiB", "30.00", "-", "2", "-")
+    assert_row_present(result.output, "Node2", 0, "-", "-", "-", "-", "2")
     assert_row_present(result.output, "Node3", 0, "-", "-", "-", "-", "-")
     assert_row_present(result.output, "Node4", 1, "1.000 GiB", "5.00", "1", "-", "-")


### PR DESCRIPTION
This changes the query used in the `node stats` command to remove the `wants_file == 'Y'` constraint.  I think my idea was only files that aren't part of a pending delete should be counted (because they'll be deleted), but now I think that's the wrong way to do it: there's no reason to expect that an active daemon is running on the nodes we're querying and until the file copies are actually deleted, they take up the space they're occupying (including counting towards "max_total" calculations) so they should appear in the counts provided by the CLI.

This code is used by several commands:
* node stats
* node show
* group show

(I noticed this when trying to figure out why the CHIME grafana currently has 2500 files listed on `fir_staging` while `alpenhorn node show` listed only 200.  It's because alpenhorn on fir is clogged up with file transfers and has marked 2300 files for deletion but hasn't gotten around to deleting them yet.)

_Bonus commit for this PR: an unrelated change setting the minimum version of `prometheus_client` in pyproject._